### PR TITLE
Fix bad system instruction type handling

### DIFF
--- a/src/utils/tx.ts
+++ b/src/utils/tx.ts
@@ -58,9 +58,9 @@ export function decodeTransfer(
   ix: TransactionInstruction
 ): TransferParams | null {
   if (!ix.programId.equals(SystemProgram.programId)) return null;
-  if (SystemInstruction.decodeInstructionType(ix) !== "Transfer") return null;
 
   try {
+    if (SystemInstruction.decodeInstructionType(ix) !== "Transfer") return null;
     return SystemInstruction.decodeTransfer(ix);
   } catch (err) {
     console.error(ix, err);
@@ -72,9 +72,9 @@ export function decodeCreate(
   ix: TransactionInstruction
 ): CreateAccountParams | null {
   if (!ix.programId.equals(SystemProgram.programId)) return null;
-  if (SystemInstruction.decodeInstructionType(ix) !== "Create") return null;
 
   try {
+    if (SystemInstruction.decodeInstructionType(ix) !== "Create") return null;
     return SystemInstruction.decodeCreateAccount(ix);
   } catch (err) {
     console.error(ix, err);


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/explorer/issues/98

#### Problem
Decoding the type of a system instruction can throw an error if the instruction type is not known

#### Change
Move instruction type check inside try block