### PR TITLE
Account history feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1269,9 +1269,9 @@
       "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
     },
     "@solana/web3.js": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.51.0.tgz",
-      "integrity": "sha512-mt2JF9QcpL/K2/LSHgj/yqSQXxvCNkLknfvmDClLeI2VbtYMypGcw4tU4C2GrdTzKRUdzM8ncaGONxLJKgFsTQ==",
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.52.1.tgz",
+      "integrity": "sha512-xv8PknS9sjnMxPXaCZEb8Yk+S0O3lScw91NJyYjnIPYxYnxJ96H7BUCDh1zOj5op4nT8u/n4wRYG+YWT/XRwiA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@solana/web3.js": "^0.51.0",
+    "@solana/web3.js": "^0.52.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/components/AccountsCard.tsx
+++ b/src/components/AccountsCard.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import {
   useAccounts,
   Account,
-  Status,
+  FetchStatus,
   useFetchAccountInfo
 } from "../providers/accounts";
 import { assertUnreachable } from "../utils";
@@ -109,17 +109,15 @@ const renderAccountRow = (account: Account) => {
   let statusText;
   let statusClass;
   switch (account.status) {
-    case Status.CheckFailed:
-    case Status.HistoryFailed:
+    case FetchStatus.FetchFailed:
       statusClass = "dark";
       statusText = "Cluster Error";
       break;
-    case Status.Checking:
-    case Status.FetchingHistory:
+    case FetchStatus.Fetching:
       statusClass = "info";
       statusText = "Fetching";
       break;
-    case Status.Success:
+    case FetchStatus.Fetched:
       if (account.details?.executable) {
         statusClass = "dark";
         statusText = "Executable";

--- a/src/components/common/ErrorCard.tsx
+++ b/src/components/common/ErrorCard.tsx
@@ -2,11 +2,14 @@ import React from "react";
 
 export default function ErrorCard({
   retry,
+  retryText,
   text
 }: {
   retry?: () => void;
+  retryText?: string;
   text: string;
 }) {
+  const buttonText = retryText || "Try Again";
   return (
     <div className="card">
       <div className="card-body text-center">
@@ -17,12 +20,12 @@ export default function ErrorCard({
               className="btn btn-white ml-3 d-none d-md-inline"
               onClick={retry}
             >
-              Try Again
+              {buttonText}
             </span>
             <div className="d-block d-md-none mt-4">
               <hr></hr>
               <span className="btn btn-white" onClick={retry}>
-                Try Again
+                {buttonText}
               </span>
             </div>
           </>

--- a/src/providers/accounts/history.tsx
+++ b/src/providers/accounts/history.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { PublicKey } from "@solana/web3.js";
+import { useAccounts, FetchStatus } from "./index";
+import { useCluster } from "../cluster";
+import {
+  HistoryManager,
+  HistoricalTransaction,
+  SlotRange
+} from "./historyManager";
+
+interface AccountHistory {
+  status: FetchStatus;
+  fetched?: HistoricalTransaction[];
+  fetchedRange?: SlotRange;
+}
+
+type State = { [address: string]: AccountHistory };
+
+export enum ActionType {
+  Update,
+  Add,
+  Remove
+}
+
+interface Update {
+  type: ActionType.Update;
+  pubkey: PublicKey;
+  status: FetchStatus;
+  fetched?: HistoricalTransaction[];
+  fetchedRange?: SlotRange;
+}
+
+interface Add {
+  type: ActionType.Add;
+  addresses: string[];
+}
+
+interface Remove {
+  type: ActionType.Remove;
+  addresses: string[];
+}
+
+type Action = Update | Add | Remove;
+type Dispatch = (action: Action) => void;
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case ActionType.Add: {
+      if (action.addresses.length === 0) return state;
+      const details = { ...state };
+      action.addresses.forEach(address => {
+        if (!details[address]) {
+          details[address] = {
+            status: FetchStatus.Fetching
+          };
+        }
+      });
+      return details;
+    }
+
+    case ActionType.Remove: {
+      if (action.addresses.length === 0) return state;
+      const details = { ...state };
+      action.addresses.forEach(address => {
+        delete details[address];
+      });
+      return details;
+    }
+
+    case ActionType.Update: {
+      const address = action.pubkey.toBase58();
+      if (state[address]) {
+        const fetched = action.fetched
+          ? action.fetched
+          : state[address].fetched;
+        const fetchedRange = action.fetchedRange
+          ? action.fetchedRange
+          : state[address].fetchedRange;
+        return {
+          ...state,
+          [address]: {
+            status: action.status,
+            fetched,
+            fetchedRange
+          }
+        };
+      }
+      break;
+    }
+  }
+  return state;
+}
+
+const ManagerContext = React.createContext<HistoryManager | undefined>(
+  undefined
+);
+const StateContext = React.createContext<State | undefined>(undefined);
+const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+
+type HistoryProviderProps = { children: React.ReactNode };
+export function HistoryProvider({ children }: HistoryProviderProps) {
+  const [state, dispatch] = React.useReducer(reducer, {});
+  const { accounts } = useAccounts();
+  const { url } = useCluster();
+
+  const manager = React.useRef(new HistoryManager(url));
+  React.useEffect(() => {
+    manager.current = new HistoryManager(url);
+  }, [url]);
+
+  // Fetch history for new accounts
+  React.useEffect(() => {
+    const removeAddresses = new Set<string>();
+    const fetchAddresses = new Set<string>();
+    accounts.forEach(({ pubkey, lamports }) => {
+      const address = pubkey.toBase58();
+      if (lamports !== undefined && !state[address])
+        fetchAddresses.add(address);
+      else if (lamports === undefined && state[address])
+        removeAddresses.add(address);
+    });
+
+    const removeList: string[] = [];
+    removeAddresses.forEach(address => {
+      manager.current.removeAccountHistory(address);
+      removeList.push(address);
+    });
+    dispatch({ type: ActionType.Remove, addresses: removeList });
+
+    const fetchList: string[] = [];
+    fetchAddresses.forEach(s => fetchList.push(s));
+    dispatch({ type: ActionType.Add, addresses: fetchList });
+    fetchAddresses.forEach(address => {
+      fetchAccountHistory(
+        dispatch,
+        new PublicKey(address),
+        manager.current,
+        true
+      );
+    });
+  }, [accounts]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <ManagerContext.Provider value={manager.current}>
+      <StateContext.Provider value={state}>
+        <DispatchContext.Provider value={dispatch}>
+          {children}
+        </DispatchContext.Provider>
+      </StateContext.Provider>
+    </ManagerContext.Provider>
+  );
+}
+
+async function fetchAccountHistory(
+  dispatch: Dispatch,
+  pubkey: PublicKey,
+  manager: HistoryManager,
+  refresh?: boolean
+) {
+  dispatch({
+    type: ActionType.Update,
+    status: FetchStatus.Fetching,
+    pubkey
+  });
+
+  let status;
+  let fetched;
+  let fetchedRange;
+  try {
+    await manager.fetchAccountHistory(pubkey, refresh || false);
+    fetched = manager.accountHistory.get(pubkey.toBase58()) || undefined;
+    fetchedRange = manager.accountRanges.get(pubkey.toBase58()) || undefined;
+    status = FetchStatus.Fetched;
+  } catch (error) {
+    console.error("Failed to fetch account history", error);
+    status = FetchStatus.FetchFailed;
+  }
+  dispatch({ type: ActionType.Update, status, fetched, fetchedRange, pubkey });
+}
+
+export function useAccountHistory(address: string) {
+  const context = React.useContext(StateContext);
+
+  if (!context) {
+    throw new Error(`useAccountHistory must be used within a AccountsProvider`);
+  }
+
+  return context[address];
+}
+
+export function useFetchAccountHistory() {
+  const manager = React.useContext(ManagerContext);
+  const dispatch = React.useContext(DispatchContext);
+  if (!manager || !dispatch) {
+    throw new Error(
+      `useFetchAccountHistory must be used within a AccountsProvider`
+    );
+  }
+
+  return (pubkey: PublicKey, refresh?: boolean) => {
+    fetchAccountHistory(dispatch, pubkey, manager, refresh);
+  };
+}

--- a/src/providers/accounts/historyManager.ts
+++ b/src/providers/accounts/historyManager.ts
@@ -1,0 +1,155 @@
+import {
+  TransactionSignature,
+  Connection,
+  PublicKey,
+  SignatureStatus
+} from "@solana/web3.js";
+
+const MAX_STATUS_BATCH_SIZE = 256;
+
+export interface SlotRange {
+  min: number;
+  max: number;
+}
+
+export type HistoricalTransaction = {
+  signature: TransactionSignature;
+  status: SignatureStatus;
+};
+
+// Manage the transaction history for accounts for a cluster
+export class HistoryManager {
+  accountRanges: Map<string, SlotRange> = new Map();
+  accountHistory: Map<string, HistoricalTransaction[]> = new Map();
+  accountLock: Map<string, boolean> = new Map();
+  _fullRange: SlotRange | undefined;
+  connection: Connection;
+
+  constructor(url: string) {
+    this.connection = new Connection(url);
+  }
+
+  async fullRange(refresh: boolean): Promise<SlotRange> {
+    if (refresh || !this._fullRange) {
+      const max = (await this.connection.getEpochInfo("max")).absoluteSlot;
+      this._fullRange = { min: 0, max };
+    }
+    return this._fullRange;
+  }
+
+  removeAccountHistory(address: string) {
+    this.accountLock.delete(address);
+    this.accountRanges.delete(address);
+    this.accountHistory.delete(address);
+  }
+
+  async fetchAccountHistory(pubkey: PublicKey, refresh: boolean) {
+    const address = pubkey.toBase58();
+
+    if (this.accountLock.get(address) === true) return;
+    this.accountLock.set(address, true);
+
+    try {
+      let slotLookBack = 100;
+      const fullRange = await this.fullRange(refresh);
+      const currentRange = this.accountRanges.get(address);
+
+      // Determine query range based on already queried range
+      let range;
+      if (currentRange) {
+        if (refresh) {
+          const min = currentRange.max + 1;
+          const max = Math.min(min + slotLookBack - 1, fullRange.max);
+          if (max < min) return;
+          range = { min, max };
+        } else {
+          const max = currentRange.min - 1;
+          const min = Math.max(max - slotLookBack + 1, fullRange.min);
+          if (max < min) return;
+          range = { min, max };
+        }
+      } else {
+        const max = fullRange.max;
+        const min = Math.max(fullRange.min, max - slotLookBack + 1);
+        range = { min, max };
+      }
+
+      // Gradually fetch more history if nothing found
+      let signatures: string[] = [];
+      let nextRange = { ...range };
+      for (var i = 0; i < 5; i++) {
+        signatures = (
+          await this.connection.getConfirmedSignaturesForAddress(
+            pubkey,
+            nextRange.min,
+            nextRange.max
+          )
+        ).reverse();
+        if (refresh) break;
+        if (signatures.length > 0) break;
+        if (range.min <= fullRange.min) break;
+
+        switch (slotLookBack) {
+          case 100:
+            slotLookBack = 1000;
+            break;
+          case 1000:
+            slotLookBack = 10000;
+            break;
+        }
+
+        range.min = Math.max(nextRange.min - slotLookBack, fullRange.min);
+        nextRange = {
+          min: range.min,
+          max: nextRange.min - 1
+        };
+      }
+
+      // Fetch the statuses for all confirmed signatures
+      const transactions: HistoricalTransaction[] = [];
+      while (signatures.length > 0) {
+        const batch = signatures.splice(0, MAX_STATUS_BATCH_SIZE);
+        const statuses = (
+          await this.connection.getSignatureStatuses(batch, {
+            searchTransactionHistory: true
+          })
+        ).value;
+        statuses.forEach((status, index) => {
+          if (status !== null) {
+            transactions.push({
+              signature: batch[index],
+              status
+            });
+          }
+        });
+      }
+
+      // Check if account lock is still active
+      if (this.accountLock.get(address) !== true) return;
+
+      // Update fetched slot range
+      if (currentRange) {
+        currentRange.max = Math.max(range.max, currentRange.max);
+        currentRange.min = Math.min(range.min, currentRange.min);
+      } else {
+        this.accountRanges.set(address, range);
+      }
+
+      // Exit early if no new confirmed transactions were found
+      const currentTransactions = this.accountHistory.get(address) || [];
+      if (currentTransactions.length > 0 && transactions.length === 0) return;
+
+      // Append / prepend newly fetched statuses
+      let newTransactions;
+      if (refresh) {
+        newTransactions = transactions.concat(currentTransactions);
+      } else {
+        newTransactions = currentTransactions.concat(transactions);
+      }
+
+      this.accountHistory.set(address, newTransactions);
+    } finally {
+      this.accountLock.set(address, false);
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/explorer/issues/80
Fixes: https://github.com/solana-labs/explorer/issues/29

#### Problem
Naive account history implementation fetches too much history and fails

#### Changes
- Slowly ramp up history slot queries
- Batch status queries
- Add refresh history button
- Add load more history button