### PR TITLE
Move top accounts to supply page and add filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,13 +34,16 @@ function App() {
           <Route exact path="/supply">
             <TabbedPage tab="Supply">
               <SupplyCard />
-            </TabbedPage>
-          </Route>
-          <Route exact path="/accounts/top">
-            <TabbedPage tab="Accounts">
               <TopAccountsCard />
             </TabbedPage>
           </Route>
+          <Route
+            exact
+            path="/accounts/top"
+            render={({ location }) => (
+              <Redirect to={{ ...location, pathname: "/supply" }} />
+            )}
+          ></Route>
           <Route
             exact
             path={TX_ALIASES.flatMap(tx => [tx, tx + "s"]).map(

--- a/src/components/SupplyCard.tsx
+++ b/src/components/SupplyCard.tsx
@@ -39,6 +39,11 @@ export default function SupplyCard() {
           <td className="w-100">Circulating Supply (SOL)</td>
           <td>{lamportsToSolString(supply.circulating)}</td>
         </tr>
+
+        <tr>
+          <td className="w-100">Non-Circulating Supply (SOL)</td>
+          <td>{lamportsToSolString(supply.nonCirculating)}</td>
+        </tr>
       </TableCardBody>
     </div>
   );
@@ -49,7 +54,7 @@ const renderHeader = () => {
     <div className="card-header">
       <div className="row align-items-center">
         <div className="col">
-          <h4 className="card-header-title">Supply Stats</h4>
+          <h4 className="card-header-title">Overview</h4>
         </div>
       </div>
     </div>

--- a/src/components/TopAccountsCard.tsx
+++ b/src/components/TopAccountsCard.tsx
@@ -10,7 +10,7 @@ import { lamportsToSolString } from "utils";
 import { useQuery } from "utils/url";
 import { useSupply } from "providers/supply";
 
-type Filter = "circulating" | "nonCirculating" | null;
+type Filter = "circulating" | "nonCirculating" | "all" | null;
 
 export default function TopAccountsCard() {
   const supply = useSupply();
@@ -40,22 +40,23 @@ export default function TopAccountsCard() {
   let supplyCount: number;
   let accounts, header;
   switch (filter) {
-    case "circulating": {
-      accounts = richList.circulating;
-      supplyCount = supply.circulating;
-      header = "Circulating";
-      break;
-    }
     case "nonCirculating": {
       accounts = richList.nonCirculating;
       supplyCount = supply.nonCirculating;
       header = "Non-Circulating";
       break;
     }
-    default: {
+    case "all": {
       accounts = richList.total;
       supplyCount = supply.total;
       header = "Total";
+      break;
+    }
+    case "circulating":
+    default: {
+      accounts = richList.circulating;
+      supplyCount = supply.circulating;
+      header = "Circulating";
       break;
     }
   }
@@ -109,7 +110,11 @@ export default function TopAccountsCard() {
 const useQueryFilter = (): Filter => {
   const query = useQuery();
   const filter = query.get("filter");
-  if (filter === "circulating" || filter === "nonCirculating") {
+  if (
+    filter === "circulating" ||
+    filter === "nonCirculating" ||
+    filter === "all"
+  ) {
     return filter;
   } else {
     return null;
@@ -118,14 +123,15 @@ const useQueryFilter = (): Filter => {
 
 const filterTitle = (filter: Filter): string => {
   switch (filter) {
-    case "circulating": {
-      return "Circulating";
-    }
     case "nonCirculating": {
       return "Non-Circulating";
     }
-    default: {
+    case "all": {
       return "All";
+    }
+    case "circulating":
+    default: {
+      return "Circulating";
     }
   }
 };
@@ -150,7 +156,7 @@ const FilterDropdown = ({ filter, toggle, show }: DropdownProps) => {
     };
   };
 
-  const FILTERS: Filter[] = [null, "circulating", "nonCirculating"];
+  const FILTERS: Filter[] = [null, "nonCirculating", "all"];
   return (
     <div className="dropdown">
       <button


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/explorer/issues/141
Fixes: https://github.com/solana-labs/explorer/issues/146

Changes:
- Add largest accounts to supply page
- Redirect `/accounts/top` to `/supply`
- Add filter button (and url param) for showing "all", "circulating", and "non-circulating" largest accounts
- Add line for "non-circulating" supply sol count to "Supply Overview"

<img width="982" alt="Screen Shot 2020-06-02 at 5 28 28 PM" src="https://user-images.githubusercontent.com/1076145/83503966-7b8d7680-a4f6-11ea-8cd4-48f198bce4be.png">
