### PR TITLE
Rename blockhash label to reduce ambiguity

### DIFF
--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -36,13 +36,14 @@ function Popover({
 function InfoTooltip({ bottom, right, text, children }: Props) {
   const [state, setState] = useState<State>("hide");
 
+  const justify = right ? "end" : "start";
   return (
     <div
       className="popover-container w-100"
       onMouseOver={() => setState("show")}
       onMouseOut={() => setState("hide")}
     >
-      <div className="d-flex align-items-center justify-content-end">
+      <div className={`d-flex align-items-center justify-content-${justify}`}>
         {children}
         <span className="fe fe-help-circle ml-2"></span>
       </div>

--- a/src/components/TransactionDetails.tsx
+++ b/src/components/TransactionDetails.tsx
@@ -197,7 +197,7 @@ function StatusCard({ signature }: Props) {
               {isNonce ? (
                 "Nonce"
               ) : (
-                <InfoTooltip text="Transactions use a previously confirmed blockhash as a nonce prevent double spends">
+                <InfoTooltip text="Transactions use a previously confirmed blockhash as a nonce to prevent double spends">
                   Recent Blockhash
                 </InfoTooltip>
               )}

--- a/src/components/TransactionDetails.tsx
+++ b/src/components/TransactionDetails.tsx
@@ -11,7 +11,8 @@ import { useCluster, useClusterModal } from "providers/cluster";
 import {
   TransactionSignature,
   SystemProgram,
-  StakeProgram
+  StakeProgram,
+  SystemInstruction
 } from "@solana/web3.js";
 import ClusterStatusButton from "components/ClusterStatusButton";
 import { lamportsToSolString } from "utils";
@@ -138,6 +139,12 @@ function StatusCard({ signature }: Props) {
 
   const fee = details?.transaction?.meta?.fee;
   const blockhash = details?.transaction?.transaction.recentBlockhash;
+  const ix = details?.transaction?.transaction.instructions[0];
+  const isNonce =
+    ix &&
+    SystemProgram.programId.equals(ix.programId) &&
+    SystemInstruction.decodeInstructionType(ix) === "AdvanceNonceAccount";
+
   return (
     <div className="card">
       <div className="card-header align-items-center">
@@ -187,9 +194,13 @@ function StatusCard({ signature }: Props) {
         {blockhash && (
           <tr>
             <td>
-              <InfoTooltip text="Transactions use a previously confirmed blockhash as a nonce prevent double spends">
-                Nonce
-              </InfoTooltip>
+              {isNonce ? (
+                "Nonce"
+              ) : (
+                <InfoTooltip text="Transactions use a previously confirmed blockhash as a nonce prevent double spends">
+                  Recent Blockhash
+                </InfoTooltip>
+              )}
             </td>
             <td className="text-right">
               <code>{blockhash}</code>

--- a/src/components/TransactionDetails.tsx
+++ b/src/components/TransactionDetails.tsx
@@ -166,7 +166,7 @@ function StatusCard({ signature }: Props) {
               <InfoTooltip
                 bottom
                 right
-                text="Timestamps older than 5 epochs are not available at this time"
+                text="Timestamps are available for confirmed blocks within the past 5 epochs"
               >
                 Unavailable
               </InfoTooltip>
@@ -186,7 +186,11 @@ function StatusCard({ signature }: Props) {
 
         {blockhash && (
           <tr>
-            <td>Blockhash</td>
+            <td>
+              <InfoTooltip text="Transactions use a previously confirmed blockhash as a nonce prevent double spends">
+                Nonce
+              </InfoTooltip>
+            </td>
             <td className="text-right">
               <code>{blockhash}</code>
             </td>


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/explorer/issues/143

Changes:
- Rename "Blockhash" label to "Nonce" when viewing a nonced transaction
- Use "Recent blockhash" for all other transactions
- Add info tooltip to add some context

> Transactions use a previously confirmed blockhash as a nonce prevent double spends

<img width="734" alt="Screenshot 2020-06-03 16 47 10" src="https://user-images.githubusercontent.com/1076145/83616171-1733eb00-a5ba-11ea-8414-0087e326aefe.png">
<img width="715" alt="Screenshot 2020-06-03 16 47 23" src="https://user-images.githubusercontent.com/1076145/83616181-19964500-a5ba-11ea-9aba-d6f9fd00eaf9.png">
