### PR TITLE
Remove clusterUrl param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,6 +1263,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@react-hook/debounce": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-2.0.5.tgz",
+      "integrity": "sha512-WrwQ1e4vx5lxxxEpGPPliMcs6oUJ8cyEb/GL8OEUPhBW4WL8YRSDW5oPnsOqIPqhHDyQMHgMipXWgj7QVmRMKA=="
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@react-hook/debounce": "^2.0.5",
     "@solana/web3.js": "^0.56.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/src/components/TransactionDetails.tsx
+++ b/src/components/TransactionDetails.tsx
@@ -3,10 +3,9 @@ import {
   useFetchTransactionStatus,
   useTransactionStatus,
   useTransactionDetails,
-  useDetailsDispatch,
   FetchStatus
 } from "../providers/transactions";
-import { fetchDetails } from "providers/transactions/details";
+import { useFetchTransactionDetails } from "providers/transactions/details";
 import { useCluster, useClusterModal } from "providers/cluster";
 import {
   TransactionSignature,
@@ -206,12 +205,11 @@ function StatusCard({ signature }: Props) {
 
 function AccountsCard({ signature }: Props) {
   const details = useTransactionDetails(signature);
-  const dispatch = useDetailsDispatch();
-  const { url } = useCluster();
 
   const fetchStatus = useFetchTransactionStatus();
+  const fetchDetails = useFetchTransactionDetails();
   const refreshStatus = () => fetchStatus(signature);
-  const refreshDetails = () => fetchDetails(dispatch, signature, url);
+  const refreshDetails = () => fetchDetails(signature);
   const transaction = details?.transaction?.transaction;
   const message = React.useMemo(() => {
     return transaction?.compileMessage();
@@ -308,9 +306,8 @@ function AccountsCard({ signature }: Props) {
 function InstructionsSection({ signature }: Props) {
   const status = useTransactionStatus(signature);
   const details = useTransactionDetails(signature);
-  const dispatch = useDetailsDispatch();
-  const { url } = useCluster();
-  const refreshDetails = () => fetchDetails(dispatch, signature, url);
+  const fetchDetails = useFetchTransactionDetails();
+  const refreshDetails = () => fetchDetails(signature);
 
   if (!status || !status.info || !details || !details.transaction) return null;
 

--- a/src/providers/transactions/details.tsx
+++ b/src/providers/transactions/details.tsx
@@ -128,7 +128,7 @@ export function DetailsProvider({ children }: DetailsProviderProps) {
   );
 }
 
-export async function fetchDetails(
+async function fetchDetails(
   dispatch: Dispatch,
   signature: TransactionSignature,
   url: string
@@ -150,4 +150,18 @@ export async function fetchDetails(
     fetchStatus = FetchStatus.FetchFailed;
   }
   dispatch({ type: ActionType.Update, fetchStatus, signature, transaction });
+}
+
+export function useFetchTransactionDetails() {
+  const dispatch = React.useContext(DispatchContext);
+  if (!dispatch) {
+    throw new Error(
+      `useFetchTransactionDetails must be used within a TransactionsProvider`
+    );
+  }
+
+  const { url } = useCluster();
+  return (signature: TransactionSignature) => {
+    url && fetchDetails(dispatch, signature, url);
+  };
 }

--- a/src/providers/transactions/index.tsx
+++ b/src/providers/transactions/index.tsx
@@ -12,8 +12,7 @@ import { useQuery } from "../../utils/url";
 import { useCluster, Cluster, ClusterStatus } from "../cluster";
 import {
   DetailsProvider,
-  StateContext as DetailsStateContext,
-  DispatchContext as DetailsDispatchContext
+  StateContext as DetailsStateContext
 } from "./details";
 import base58 from "bs58";
 import { useFetchAccountInfo } from "../accounts";
@@ -306,16 +305,6 @@ export function useTransactionDetails(signature: TransactionSignature) {
   }
 
   return context[signature];
-}
-
-export function useDetailsDispatch() {
-  const context = React.useContext(DetailsDispatchContext);
-  if (!context) {
-    throw new Error(
-      `useDetailsDispatch must be used within a TransactionsProvider`
-    );
-  }
-  return context;
 }
 
 export function useFetchTransactionStatus() {


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/explorer/issues/151

#### Changes
- Add `cluster=custom` option
    (explorer uses this param as source of truth for selected cluster state)
- Strip `cluster=custom` from url if custom url hasn't been specified by user yet 
    (This means https://explorer.solana.com?cluster=custom will redirect to https://explorer.solana.com)
- Debounce custom cluster connection attempts while typing

We can add back the param for dev mode when needed