### PR TITLE
Add unit labels to TPS chart

### DIFF
--- a/src/components/LiveTransactionStatsCard.tsx
+++ b/src/components/LiveTransactionStatsCard.tsx
@@ -149,11 +149,11 @@ const TPS_CHART_OPTIONS = (historyMaxTps: number): ChartOptions => {
               if (max < 5000) {
                 return `${value}`;
               } else if (max < 1000000) {
-                return `${(value as number) / 1000}k`;
+                return `${(value as number) / 1000}k`; // k as in `kilo`
               } else if (max < 5000000) {
-                return `${(value as number) / 1000000}m`;
+                return `${(value as number) / 1000000}m`; // m as in `mega`
               } else {
-                return `${(value as number) / 1000000000}b`;
+                return `${(value as number) / 1000000000}g`; // g as in `giga`
               }
             },
             fontColor: "#EEE",

--- a/src/components/LiveTransactionStatsCard.tsx
+++ b/src/components/LiveTransactionStatsCard.tsx
@@ -143,6 +143,19 @@ const TPS_CHART_OPTIONS = (historyMaxTps: number): ChartOptions => {
           ticks: {
             stepSize: 100,
             fontSize: 10,
+            maxTicksLimit: 10,
+            callback: (value, index, values) => {
+              const max = Math.max(...(values as any as number[]));
+              if (max < 5000) {
+                return `${value}`;
+              } else if (max < 1000000) {
+                return `${(value as number) / 1000}k`;
+              } else if (max < 5000000) {
+                return `${(value as number) / 1000000}m`;
+              } else {
+                return `${(value as number) / 1000000000}b`;
+              }
+            },
             fontColor: "#EEE",
             beginAtZero: true,
             display: true,


### PR DESCRIPTION
Custom y-tick axes labels to prevent chart.js OOM when large number of transactions is returned.

Example behavior shown for testnet:
![image](https://user-images.githubusercontent.com/7481857/218557232-a23df533-a677-46cc-bff8-5ef72e1334f7.png)
