### PR TITLE
Change null checking on json search results

### DIFF
--- a/src/providers/accounts/index.tsx
+++ b/src/providers/accounts/index.tsx
@@ -438,7 +438,10 @@ const getMetaDataJSON = async (
     if (!uri) return resolve(undefined);
 
     const processJson = (extended: any) => {
-      if (!extended || extended?.properties?.files?.length === 0) {
+      if (
+        !extended ||
+        (!extended.image && extended?.properties?.files?.length === 0)
+      ) {
         return;
       }
 


### PR DESCRIPTION
Migrating From: https://github.com/solana-labs/solana/pull/29970

Fix null checking for JSON Search results on NFT metadata to improve NFT Image display

#### Problem
Some NFT images do not render on Solana Explorer because they do not have `.properties.files` defined in their metadata. [Example](https://explorer.solana.com/address/CM67ngnFeVxRPC98cJt7LRVtt6uNMrRjN6UZBZvd8WGV) from a recent Solana Spaces airdrop (by CrossMint): 

<img width="679" alt="image" src="https://user-images.githubusercontent.com/85324096/215296695-e58c69a0-6078-4e1f-bb65-29839297916c.png">

Despite the metadata not having `.properties.files`, it does include a `.image` with a URI to the image.  Currently, the Explorer JSON processor has a null check on  `.properties.files` and NOT on `.image`, even though we process and use `.image` for [rendering the images](https://github.com/solana-labs/solana/blob/5d6f94ef4254e53d4f423dee987768591fd74768/explorer/src/components/common/NFTArt.tsx#L238). 

#### Summary of Changes
Change our null checker to check that no files metadata present AND no image is present (both must be true to return `null`). This will allow image rendering of an image if no files metadata is present and also would allow video/animation rendering if no image value is present.

![image](https://user-images.githubusercontent.com/85324096/215297076-817c42dd-b437-4dd1-ac85-d29ce58b6bcb.png)


