### PR TITLE
feat: support more ATA program's instructions

### DIFF
--- a/src/components/instruction/associated-token/AssociatedTokenDetailsCard.tsx
+++ b/src/components/instruction/associated-token/AssociatedTokenDetailsCard.tsx
@@ -12,9 +12,11 @@ import { ParsedInfo } from "validators";
 import { create } from "superstruct";
 import { reportError } from "utils/sentry";
 import {
+  CreateIdempotentInfo,
   RecoverNestedInfo,
 
 } from "./types";
+import { CreateIdempotentDetailsCard } from "./CreateIdempotentDetailsCard";
 
 type DetailsProps = {
   tx: ParsedTransaction;
@@ -31,6 +33,10 @@ export function AssociatedTokenDetailsCard(props: DetailsProps) {
     switch (parsed.type) {
       case "create": {
         return <CreateDetailsCard {...props} />;
+      }
+      case "createIdempotent": {
+        const info = create(parsed.info, CreateIdempotentInfo);
+        return <CreateIdempotentDetailsCard info={info} {...props} />;
       }
       case "recoverNested": {
         const info = create(parsed.info, RecoverNestedInfo);

--- a/src/components/instruction/associated-token/AssociatedTokenDetailsCard.tsx
+++ b/src/components/instruction/associated-token/AssociatedTokenDetailsCard.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  SignatureResult,
+  ParsedInstruction,
+  ParsedTransaction,
+} from "@solana/web3.js";
+
+import { UnknownDetailsCard } from "../UnknownDetailsCard";
+import { CreateDetailsCard } from "./CreateDetailsCard";
+import { RecoverNestedDetailsCard } from "./RecoverNestedDetailsCard";
+import { ParsedInfo } from "validators";
+import { create } from "superstruct";
+import { reportError } from "utils/sentry";
+import {
+  RecoverNestedInfo,
+
+} from "./types";
+
+type DetailsProps = {
+  tx: ParsedTransaction;
+  ix: ParsedInstruction;
+  result: SignatureResult;
+  index: number;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
+};
+
+export function AssociatedTokenDetailsCard(props: DetailsProps) {
+  try {
+    const parsed = create(props.ix.parsed, ParsedInfo);
+    switch (parsed.type) {
+      case "create": {
+        return <CreateDetailsCard {...props} />;
+      }
+      case "recoverNested": {
+        const info = create(parsed.info, RecoverNestedInfo);
+        return <RecoverNestedDetailsCard info={info} {...props} />;
+      }
+      default:
+        return <UnknownDetailsCard {...props} />;
+    }
+  } catch (error) {
+    reportError(error, {
+      signature: props.tx.signatures[0],
+    });
+    return <UnknownDetailsCard {...props} />;
+  }
+}

--- a/src/components/instruction/associated-token/CreateDetailsCard.tsx
+++ b/src/components/instruction/associated-token/CreateDetailsCard.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { ParsedInstruction, PublicKey, SignatureResult } from "@solana/web3.js";
-import { InstructionCard } from "./InstructionCard";
+import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
 
-export function AssociatedTokenDetailsCard({
+export function CreateDetailsCard({
   ix,
   index,
   result,

--- a/src/components/instruction/associated-token/CreateIdempotentDetailsCard.tsx
+++ b/src/components/instruction/associated-token/CreateIdempotentDetailsCard.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {
+  SignatureResult,
+  ParsedInstruction,
+} from "@solana/web3.js";
+import { InstructionCard } from "../InstructionCard";
+import { Address } from "components/common/Address";
+import { CreateIdempotentInfo } from "./types";
+
+export function CreateIdempotentDetailsCard(props: {
+  ix: ParsedInstruction;
+  index: number;
+  result: SignatureResult;
+  info: CreateIdempotentInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
+}) {
+  const { ix, index, result, info, innerCards, childIndex } = props;
+
+  return (
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title="Associated Token Program: Create Idempotent"
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
+      <tr>
+        <td>Source</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.source} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Account</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.account} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Wallet</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.wallet} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Mint</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.mint} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>System Program</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.systemProgram} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Token Program</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.tokenProgram} alignRight link />
+        </td>
+      </tr>
+
+    </InstructionCard>
+  );
+}

--- a/src/components/instruction/associated-token/RecoverNestedDetailsCard.tsx
+++ b/src/components/instruction/associated-token/RecoverNestedDetailsCard.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import {
+  SignatureResult,
+  ParsedInstruction,
+} from "@solana/web3.js";
+import { InstructionCard } from "../InstructionCard";
+import { Address } from "components/common/Address";
+import { RecoverNestedInfo } from "./types";
+
+export function RecoverNestedDetailsCard(props: {
+  ix: ParsedInstruction;
+  index: number;
+  result: SignatureResult;
+  info: RecoverNestedInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
+}) {
+  const { ix, index, result, info, innerCards, childIndex } = props;
+
+  return (
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title="Associated Token Program: Recover Nested"
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
+      <tr>
+        <td>Destination</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.destination} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Nested Mint</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.nestedMint} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Nested Owner</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.nestedOwner} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Nested Source</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.nestedSource} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Owner Mint</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.ownerMint} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Owner</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.wallet} alignRight link />
+        </td>
+      </tr>
+
+      <tr>
+        <td>Token Program</td>
+        <td className="text-lg-end">
+          <Address pubkey={info.tokenProgram} alignRight link />
+        </td>
+      </tr>
+
+    </InstructionCard>
+  );
+}

--- a/src/components/instruction/associated-token/types.ts
+++ b/src/components/instruction/associated-token/types.ts
@@ -3,6 +3,16 @@
 import { enums, type, Infer } from "superstruct";
 import { PublicKeyFromString } from "validators/pubkey";
 
+export type CreateIdempotentInfo = Infer<typeof CreateIdempotentInfo>;
+export const CreateIdempotentInfo = type({
+  source: PublicKeyFromString,
+  account: PublicKeyFromString,
+  wallet: PublicKeyFromString,
+  mint: PublicKeyFromString,
+  systemProgram: PublicKeyFromString,
+  tokenProgram: PublicKeyFromString,
+});
+
 export type RecoverNestedInfo = Infer<typeof RecoverNestedInfo>;
 export const RecoverNestedInfo = type({
   destination: PublicKeyFromString,

--- a/src/components/instruction/associated-token/types.ts
+++ b/src/components/instruction/associated-token/types.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-redeclare */
+
+import { enums, type, Infer } from "superstruct";
+import { PublicKeyFromString } from "validators/pubkey";
+
+export type RecoverNestedInfo = Infer<typeof RecoverNestedInfo>;
+export const RecoverNestedInfo = type({
+  destination: PublicKeyFromString,
+  nestedMint: PublicKeyFromString,
+  nestedOwner: PublicKeyFromString,
+  nestedSource: PublicKeyFromString,
+  ownerMint: PublicKeyFromString,
+  tokenProgram: PublicKeyFromString,
+  wallet: PublicKeyFromString,
+});
+
+export type SystemInstructionType = Infer<typeof SystemInstructionType>;
+export const SystemInstructionType = enums([
+  "create",
+  "createIdempotent",
+  "recoverNested",
+]);

--- a/src/components/transaction/InstructionsSection.tsx
+++ b/src/components/transaction/InstructionsSection.tsx
@@ -37,7 +37,7 @@ import { Cluster, useCluster } from "providers/cluster";
 import { BpfUpgradeableLoaderDetailsCard } from "components/instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard";
 import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
 import { isWormholeInstruction } from "components/instruction/wormhole/types";
-import { AssociatedTokenDetailsCard } from "components/instruction/AssociatedTokenDetailsCard";
+import { AssociatedTokenDetailsCard } from "components/instruction/associated-token/AssociatedTokenDetailsCard";
 import { MangoDetailsCard } from "components/instruction/MangoDetails";
 import { isPythInstruction } from "components/instruction/pyth/types";
 import { PythDetailsCard } from "components/instruction/pyth/PythDetailsCard";


### PR DESCRIPTION
#### Problem

We can only show the ATA program's `Create` instruction

#### Summary of Changes

- add create idempotent
- add recover nested

There are some example txs on devnet.

Create: `2tviVeEsy2ncWFVC45HMuwA9Wtmumzof8YA3DUasdA6fWHkRApc8EfQN77J7QAyumjjytDLEyw27uJAVB77uohju`
CreateIdempotent: `4cxPepPaacejJxaWW85jNkFiQdTEPUM7UQqpy1dbH8v61bUAUiqUdeP6ubEjc6SGyRFL4yEeoKh31hJdAzPW671W`
RecoverNested: `2Hymc8AgGayksndQAJnV1FuUiy6n4XNAGxWZBFGfZJRHAUJtnnn1cnDAHE5hzFe6TnRKFmybpESpPXc8GgX9i2Xn`
