### PR TITLE
only show warning if token is not registered nor does it have a valid token metadata

### DIFF
--- a/src/pages/AccountDetailsPage.tsx
+++ b/src/pages/AccountDetailsPage.tsx
@@ -168,7 +168,7 @@ export function AccountDetailsPage({ address, tab }: Props) {
 
   try {
     pubkey = new PublicKey(address);
-  } catch (err) {}
+  } catch (err) { }
 
   // Fetch account on load
   React.useEffect(() => {
@@ -228,16 +228,17 @@ export function AccountHeader({
     // Fall back to legacy token list when there is stub metadata (blank uri), updatable by default by the mint authority
     if (!parsedData?.nftData?.metadata.data.uri && tokenDetails) {
       token = tokenDetails;
-    } else if (parsedData?.nftData) {
+    } else if (parsedData?.nftData && parsedData?.nftData?.metadata.data.uri) {
       token = {
         logoURI: parsedData?.nftData?.json?.image,
         name:
           parsedData?.nftData?.json?.name ??
           parsedData?.nftData.metadata.data.name,
       };
-      unverified = true;
     } else if (tokenDetails) {
       token = tokenDetails;
+    } else {
+      unverified = true;
     }
 
     return (


### PR DESCRIPTION
This is a proposed solution for Issue #229 .

If we do not find the token data in the registry list nor does it have valid token metadata then only show the warning message. 

NOTE: Another proposal would be to completely remove the "unverified" flag and treat all tokens same.