### PR TITLE
Don't poll for data when the tab is in the background

### DIFF
--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -29,6 +29,7 @@ import bs58 from 'bs58';
 import Link from 'next/link';
 import React, { Suspense, useEffect, useState } from 'react';
 import { RefreshCw, Settings } from 'react-feather';
+import useTabVisibility from 'use-tab-visibility';
 
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
@@ -61,10 +62,12 @@ export default function TransactionDetailsPageClient({ params: { signature: raw 
 
     const status = useTransactionStatus(signature);
     const [zeroConfirmationRetries, setZeroConfirmationRetries] = useState(0);
+    const { visible: isTabVisible } = useTabVisibility();
 
     let autoRefresh = AutoRefresh.Inactive;
-
-    if (zeroConfirmationRetries >= ZERO_CONFIRMATION_BAILOUT) {
+    if (!isTabVisible) {
+        autoRefresh = AutoRefresh.Inactive;
+    } else if (zeroConfirmationRetries >= ZERO_CONFIRMATION_BAILOUT) {
         autoRefresh = AutoRefresh.BailedOut;
     } else if (status?.data?.info && status.data.info.confirmations !== 'max') {
         autoRefresh = AutoRefresh.Active;

--- a/app/utils/coingecko.tsx
+++ b/app/utils/coingecko.tsx
@@ -2,6 +2,7 @@
 // @ts-ignore
 import * as CoinGecko from 'coingecko-api';
 import React from 'react';
+import useTabVisibility from 'use-tab-visibility';
 
 const PRICE_REFRESH = 10000;
 
@@ -48,35 +49,41 @@ export type CoinGeckoResult = {
 
 export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
     const [coinInfo, setCoinInfo] = React.useState<CoinGeckoResult>();
+    const { visible: isTabVisible } = useTabVisibility();
     React.useEffect(() => {
+        if (!isTabVisible) {
+            return;
+        }
         let interval: NodeJS.Timeout | undefined;
+        let stale = false;
         if (coinId) {
-            const getCoinInfo = (refresh = false) => {
+            const getCoinInfo = async (refresh = false) => {
                 if (!refresh) {
                     setCoinInfo({
                         status: CoingeckoStatus.Loading,
                     });
                 }
-                CoinGeckoClient.coins
-                    .fetch(coinId)
-                    .then((info: CoinInfoResult) => {
-                        setCoinInfo({
-                            coinInfo: {
-                                last_updated: new Date(info.data.last_updated),
-                                market_cap: info.data.market_data.market_cap.usd,
-                                market_cap_rank: info.data.market_data.market_cap_rank,
-                                price: info.data.market_data.current_price.usd,
-                                price_change_percentage_24h: info.data.market_data.price_change_percentage_24h,
-                                volume_24: info.data.market_data.total_volume.usd,
-                            },
-                            status: CoingeckoStatus.Success,
-                        });
-                    })
-                    .catch((_error: any) => {
-                        setCoinInfo({
-                            status: CoingeckoStatus.FetchFailed,
-                        });
+                try {
+                    const info: CoinInfoResult = await CoinGeckoClient.coins.fetch(coinId);
+                    if (stale) {
+                        return;
+                    }
+                    setCoinInfo({
+                        coinInfo: {
+                            last_updated: new Date(info.data.last_updated),
+                            market_cap: info.data.market_data.market_cap.usd,
+                            market_cap_rank: info.data.market_data.market_cap_rank,
+                            price: info.data.market_data.current_price.usd,
+                            price_change_percentage_24h: info.data.market_data.price_change_percentage_24h,
+                            volume_24: info.data.market_data.total_volume.usd,
+                        },
+                        status: CoingeckoStatus.Success,
                     });
+                } catch {
+                    setCoinInfo({
+                        status: CoingeckoStatus.FetchFailed,
+                    });
+                }
             };
 
             getCoinInfo();
@@ -88,8 +95,9 @@ export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
             if (interval) {
                 clearInterval(interval);
             }
+            stale = true;
         };
-    }, [setCoinInfo, coinId]);
+    }, [coinId, isTabVisible]);
 
     return coinInfo;
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
         "swr": "^1.3.0",
         "tweetnacl": "^1.0.3",
         "typescript": "5.0.4",
-        "use-async-effect": "^2.2.7"
+        "use-async-effect": "^2.2.7",
+        "use-tab-visibility": "^1.0.9"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ dependencies:
   use-async-effect:
     specifier: ^2.2.7
     version: 2.2.7(react@18.2.0)
+  use-tab-visibility:
+    specifier: ^1.0.9
+    version: 1.0.9(react@18.2.0)
 
 devDependencies:
   '@solana/eslint-config-solana':
@@ -6621,6 +6624,14 @@ packages:
       '@types/react': 18.2.0
       react: 18.2.0
       use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.0)(react@18.2.0)
+    dev: false
+
+  /use-tab-visibility@1.0.9(react@18.2.0):
+    resolution: {integrity: sha512-zAbkQl36+fXpTErE8/xhDfPQMA79Bzb45VLhrfiewlL7AhwxEnfFbwI6MUMK9XT2ZCN8kiAQo/cbqpB0hQxYaA==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /utf-8-validate@5.0.10:


### PR DESCRIPTION
Don't poll for data when the tab is in the background
# Summary
This should relieve pressure on the RPCs quite a bit

# Test Plan

1. Load localhost:3000
2. Open network pane and watch RPC polling requests
3. Switch to a different tab
4. Return to Explorer

Observe that no network requests were made while you were in the background, but the polling resumes when you return

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/solana-labs/explorer/pull/245).
* #246
* __->__ #245