### PR TITLE
Eliminate `coingecko-api` NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "bs58": "^4.0.1",
         "chart.js": "^4.3.0",
         "classnames": "^2.3.1",
-        "coingecko-api": "1.0.10",
         "cross-fetch": "^3.1.5",
         "eslint": "8.39.0",
         "eslint-config-next": "13.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ dependencies:
   classnames:
     specifier: ^2.3.1
     version: 2.3.1
-  coingecko-api:
-    specifier: 1.0.10
-    version: 1.0.10
   cross-fetch:
     specifier: ^3.1.5
     version: 3.1.5
@@ -3022,10 +3019,6 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
-
-  /coingecko-api@1.0.10:
-    resolution: {integrity: sha512-7YLLC85+daxAw5QlBWoHVBVpJRwoPr4HtwanCr8V/WRjoyHTa1Lb9DQAvv4MDJZHiz4no6HGnDQnddtjV35oRA==}
-    dev: false
 
   /collect-v8-coverage@1.0.1:
     resolution: {integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==}


### PR DESCRIPTION
Eliminate `coingecko-api` NPM package

# Summary

There's no reason not to just go to the JSON API directly. This NPM package hasn't been updated since 2020 anyway.

# Test Plan

1. Load homepage
2. Load Orca token page

Observe that both load same data as the control, and that they update on their own.
