### PR TITLE
Feat/page title token name

### DIFF
--- a/app/address/[address]/anchor-account/page.tsx
+++ b/app/address/[address]/anchor-account/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import AnchorAccountPageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Contents of the Anchor Account at address ${address} on Solana`,
-        title: `Anchor Account Data | ${address} | Solana`,
+        description: `Contents of the Anchor Account at address ${props.params.address} on Solana`,
+        title: `Anchor Account Data | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/anchor-account/page.tsx
+++ b/app/address/[address]/anchor-account/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import AnchorAccountPageClient from './page-client';

--- a/app/address/[address]/anchor-program/page.tsx
+++ b/app/address/[address]/anchor-program/page.tsx
@@ -1,6 +1,6 @@
 import { AnchorProgramCard } from '@components/account/AnchorProgramCard';
 import { LoadingCard } from '@components/common/LoadingCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 import { Suspense } from 'react';
 

--- a/app/address/[address]/anchor-program/page.tsx
+++ b/app/address/[address]/anchor-program/page.tsx
@@ -1,5 +1,6 @@
 import { AnchorProgramCard } from '@components/account/AnchorProgramCard';
 import { LoadingCard } from '@components/common/LoadingCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 import { Suspense } from 'react';
 
@@ -9,10 +10,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `The Interface Definition Language (IDL) file for the Anchor program at address ${address} on Solana`,
-        title: `Anchor Program IDL | ${address} | Solana`,
+        description: `The Interface Definition Language (IDL) file for the Anchor program at address ${props.params.address} on Solana`,
+        title: `Anchor Program IDL | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/attributes/page.tsx
+++ b/app/address/[address]/attributes/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import NFTAttributesPageClient from './page-client';

--- a/app/address/[address]/attributes/page.tsx
+++ b/app/address/[address]/attributes/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import NFTAttributesPageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Attributes of the Metaplex NFT with address ${address} on Solana`,
-        title: `Metaplex NFT Attributes | ${address} | Solana`,
+        description: `Attributes of the Metaplex NFT with address ${props.params.address} on Solana`,
+        title: `Metaplex NFT Attributes | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/concurrent-merkle-tree/page.tsx
+++ b/app/address/[address]/concurrent-merkle-tree/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import ConcurrentMerkleTreePageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Contents of the SPL Concurrent Merkle Tree at address ${address} on Solana`,
-        title: `Concurrent Merkle Tree | ${address} | Solana`,
+        description: `Contents of the SPL Concurrent Merkle Tree at address ${props.params.address} on Solana`,
+        title: `Concurrent Merkle Tree | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/concurrent-merkle-tree/page.tsx
+++ b/app/address/[address]/concurrent-merkle-tree/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import ConcurrentMerkleTreePageClient from './page-client';

--- a/app/address/[address]/domains/page.tsx
+++ b/app/address/[address]/domains/page.tsx
@@ -1,4 +1,5 @@
 import { DomainsCard } from '@components/account/DomainsCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,12 +8,13 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Domain names owned by the address ${address} on Solana`,
-        title: `Domains | ${address} | Solana`,
+        description: `Domain names owned by the address ${props.params.address} on Solana`,
+        title: `Domains | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
+
 
 export default function OwnedDomainsPage({ params: { address } }: Props) {
     return <DomainsCard address={address} />;

--- a/app/address/[address]/domains/page.tsx
+++ b/app/address/[address]/domains/page.tsx
@@ -1,5 +1,5 @@
 import { DomainsCard } from '@components/account/DomainsCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -14,7 +14,6 @@ export async function generateMetadata(props: AddressPageMetadataProps): Promise
         title: `Domains | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
-
 
 export default function OwnedDomainsPage({ params: { address } }: Props) {
     return <DomainsCard address={address} />;

--- a/app/address/[address]/entries/page.tsx
+++ b/app/address/[address]/entries/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import AddressLookupTableEntriesPageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Entries of the address lookup table at ${address} on Solana`,
-        title: `Address Lookup Table Entries | ${address} | Solana`,
+        description: `Entries of the address lookup table at ${props.params.address} on Solana`,
+        title: `Address Lookup Table Entries | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/entries/page.tsx
+++ b/app/address/[address]/entries/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import AddressLookupTableEntriesPageClient from './page-client';

--- a/app/address/[address]/instructions/page.tsx
+++ b/app/address/[address]/instructions/page.tsx
@@ -1,4 +1,5 @@
 import { TokenInstructionsCard } from '@components/account/history/TokenInstructionsCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `A list of transactions that include an instruction involving the token with address ${address} on Solana`,
-        title: `Token Instructions | ${address} | Solana`,
+        description: `A list of transactions that include an instruction involving the token with address ${props.params.address} on Solana`,
+        title: `Token Instructions | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/instructions/page.tsx
+++ b/app/address/[address]/instructions/page.tsx
@@ -1,5 +1,5 @@
 import { TokenInstructionsCard } from '@components/account/history/TokenInstructionsCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/largest/page.tsx
+++ b/app/address/[address]/largest/page.tsx
@@ -1,4 +1,5 @@
 import { TokenLargestAccountsCard } from '@components/account/TokenLargestAccountsCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Largest holders of the token with address ${address} on Solana`,
-        title: `Token Distribution | ${address} | Solana`,
+        description: `Largest holders of the token with address ${props.params.address} on Solana`,
+        title: `Token Distribution | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/largest/page.tsx
+++ b/app/address/[address]/largest/page.tsx
@@ -1,5 +1,5 @@
 import { TokenLargestAccountsCard } from '@components/account/TokenLargestAccountsCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/metadata/page.tsx
+++ b/app/address/[address]/metadata/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import MetaplexNFTMetadataPageClient from './page-client';

--- a/app/address/[address]/metadata/page.tsx
+++ b/app/address/[address]/metadata/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import MetaplexNFTMetadataPageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Metadata for the Metaplex NFT with address ${address} on Solana`,
-        title: `Metaplex NFT Metadata | ${address} | Solana`,
+        description: `Metadata for the Metaplex NFT with address ${props.params.address} on Solana`,
+        title: `Metaplex NFT Metadata | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/nftoken-collection-nfts/page.tsx
+++ b/app/address/[address]/nftoken-collection-nfts/page.tsx
@@ -1,4 +1,5 @@
 import { NFTokenCollectionNFTGrid } from '@components/account/nftoken/NFTokenCollectionNFTGrid';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `NFToken NFTs belonging to the collection ${address} on Solana`,
-        title: `NFToken Collection NFTs | ${address} | Solana`,
+        description: `NFToken NFTs belonging to the collection ${props.params.address} on Solana`,
+        title: `NFToken Collection NFTs | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/nftoken-collection-nfts/page.tsx
+++ b/app/address/[address]/nftoken-collection-nfts/page.tsx
@@ -1,5 +1,5 @@
 import { NFTokenCollectionNFTGrid } from '@components/account/nftoken/NFTokenCollectionNFTGrid';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/page.tsx
+++ b/app/address/[address]/page.tsx
@@ -1,5 +1,6 @@
-import { TransactionHistoryCard } from '@components/account/history/TransactionHistoryCard';
-import { Metadata } from 'next/types';
+import {TransactionHistoryCard} from '@components/account/history/TransactionHistoryCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import {Metadata} from 'next/types';
 
 type Props = Readonly<{
     params: {
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `History of all transactions involving the address ${address} on Solana`,
-        title: `Transaction History | ${address} | Solana`,
+        description: `History of all transactions involving the address ${props.params.address} on Solana`,
+        title: `Transaction History | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/page.tsx
+++ b/app/address/[address]/page.tsx
@@ -1,6 +1,6 @@
-import {TransactionHistoryCard} from '@components/account/history/TransactionHistoryCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
-import {Metadata} from 'next/types';
+import { TransactionHistoryCard } from '@components/account/history/TransactionHistoryCard';
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
+import { Metadata } from 'next/types';
 
 type Props = Readonly<{
     params: {

--- a/app/address/[address]/rewards/page.tsx
+++ b/app/address/[address]/rewards/page.tsx
@@ -1,4 +1,5 @@
 import { RewardsCard } from '@components/account/RewardsCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Rewards due to the address ${address} by epoch on Solana`,
-        title: `Address Rewards | ${address} | Solana`,
+        description: `Rewards due to the address ${props.params.address} by epoch on Solana`,
+        title: `Address Rewards | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/rewards/page.tsx
+++ b/app/address/[address]/rewards/page.tsx
@@ -1,5 +1,5 @@
 import { RewardsCard } from '@components/account/RewardsCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/security/page.tsx
+++ b/app/address/[address]/security/page.tsx
@@ -1,11 +1,12 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import SecurityPageClient from './page-client';
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Contents of the security.txt for the program with address ${address} on Solana`,
-        title: `Security | ${address} | Solana`,
+        description: `Contents of the security.txt for the program with address ${props.params.address} on Solana`,
+        title: `Security | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/security/page.tsx
+++ b/app/address/[address]/security/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import SecurityPageClient from './page-client';

--- a/app/address/[address]/tokens/page.tsx
+++ b/app/address/[address]/tokens/page.tsx
@@ -1,6 +1,6 @@
 import { OwnedTokensCard } from '@components/account/OwnedTokensCard';
 import { TokenHistoryCard } from '@components/account/TokenHistoryCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/tokens/page.tsx
+++ b/app/address/[address]/tokens/page.tsx
@@ -1,5 +1,6 @@
 import { OwnedTokensCard } from '@components/account/OwnedTokensCard';
 import { TokenHistoryCard } from '@components/account/TokenHistoryCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `All tokens owned by the address ${address} on Solana`,
-        title: `Tokens | ${address} | Solana`,
+        description: `All tokens owned by the address ${props.params.address} on Solana`,
+        title: `Tokens | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/transfers/page.tsx
+++ b/app/address/[address]/transfers/page.tsx
@@ -1,5 +1,5 @@
 import { TokenTransfersCard } from '@components/account/history/TokenTransfersCard';
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{

--- a/app/address/[address]/transfers/page.tsx
+++ b/app/address/[address]/transfers/page.tsx
@@ -1,4 +1,5 @@
 import { TokenTransfersCard } from '@components/account/history/TokenTransfersCard';
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 type Props = Readonly<{
@@ -7,10 +8,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `History of all token transfers involving the address ${address} on Solana`,
-        title: `Transfers | ${address} | Solana`,
+        description: `History of all token transfers involving the address ${props.params.address} on Solana`,
+        title: `Transfers | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/vote-history/page.tsx
+++ b/app/address/[address]/vote-history/page.tsx
@@ -1,3 +1,4 @@
+import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
 import { Metadata } from 'next/types';
 
 import VoteHistoryPageClient from './page-client';
@@ -8,10 +9,10 @@ type Props = Readonly<{
     };
 }>;
 
-export async function generateMetadata({ params: { address } }: Props): Promise<Metadata> {
+export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
-        description: `Vote history of the address ${address} by slot on Solana`,
-        title: `Vote History | ${address} | Solana`,
+        description: `Vote history of the address ${props.params.address} by slot on Solana`,
+        title: `Vote History | ${await getReadableTitleFromAddress(props)} | Solana`,
     };
 }
 

--- a/app/address/[address]/vote-history/page.tsx
+++ b/app/address/[address]/vote-history/page.tsx
@@ -1,4 +1,4 @@
-import getReadableTitleFromAddress, {AddressPageMetadataProps} from "@utils/get-readable-title-from-address";
+import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
 import VoteHistoryPageClient from './page-client';

--- a/app/providers/mints/token-registry.tsx
+++ b/app/providers/mints/token-registry.tsx
@@ -14,7 +14,7 @@ export function TokenRegistryProvider({ children }: ProviderProps) {
     const { cluster } = useCluster();
 
     React.useEffect(() => {
-        getTokenList(cluster, Strategy.Solana).then((tokens: TokenInfoMap) => setTokenRegistry(tokens))
+        getTokenList(cluster, Strategy.Solana).then((tokens: TokenInfoMap) => setTokenRegistry(tokens));
     }, [cluster]);
 
     return <TokenRegistryContext.Provider value={tokenRegistry}>{children}</TokenRegistryContext.Provider>;

--- a/app/providers/mints/token-registry.tsx
+++ b/app/providers/mints/token-registry.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useCluster } from '@providers/cluster';
-import { Strategy, TokenInfo, TokenInfoMap, TokenListContainer, TokenListProvider } from '@solana/spl-token-registry';
-import { Cluster, clusterSlug } from '@utils/cluster';
+import { Strategy, TokenInfoMap } from '@solana/spl-token-registry';
+import getTokenList from '@utils/get-token-list';
 import React from 'react';
 
 const TokenRegistryContext = React.createContext<TokenInfoMap>(new Map());
@@ -14,17 +14,7 @@ export function TokenRegistryProvider({ children }: ProviderProps) {
     const { cluster } = useCluster();
 
     React.useEffect(() => {
-        new TokenListProvider().resolve(Strategy.Solana).then((tokens: TokenListContainer) => {
-            const tokenList =
-                cluster === Cluster.Custom ? [] : tokens.filterByClusterSlug(clusterSlug(cluster)).getList();
-
-            setTokenRegistry(
-                tokenList.reduce((map: TokenInfoMap, item: TokenInfo) => {
-                    map.set(item.address, item);
-                    return map;
-                }, new Map())
-            );
-        });
+        getTokenList(cluster, Strategy.Solana).then((tokens: TokenInfoMap) => setTokenRegistry(tokens))
     }, [cluster]);
 
     return <TokenRegistryContext.Provider value={tokenRegistry}>{children}</TokenRegistryContext.Provider>;

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -1,4 +1,4 @@
-import { Strategy, TokenInfo } from '@solana/spl-token-registry';
+import { Strategy } from '@solana/spl-token-registry';
 import { Cluster } from '@utils/cluster';
 import getTokenList from '@utils/get-token-list';
 
@@ -34,14 +34,12 @@ export default async function getReadableTitleFromAddress(props: AddressPageMeta
 
     try {
         const tokenList = await getTokenList(cluster, Strategy.Solana);
-        if (typeof tokenList.get(address)?.name === 'undefined') {
+        const tokenName = tokenList.get(address)?.name;
+        if (tokenName == null) {
             return address;
         }
-
-        const tokenName = (tokenList.get(address) as TokenInfo).name;
-        const tokenAddressBlob = address.slice(0, 2) + '\u2026' + address.slice(-2);
-
-        return `Token | ${tokenName} (${tokenAddressBlob})`;
+        const tokenDisplayAddress = address.slice(0, 2) + '\u2026' + address.slice(-2);
+        return `Token | ${tokenName} (${tokenDisplayAddress})`;
     } catch {
         return address;
     }

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -26,9 +26,14 @@ export default async function getReadableTitleFromAddress(props: AddressPageMeta
     try {
         const tokenList = await getTokenList(parsedCluster, Strategy.Solana);
         if (typeof tokenList.get(address)?.name === 'undefined') {
+            console.log(tokenList.get(address))
             return address;
         }
-        return `Token | ${(tokenList.get(address) as TokenInfo).name}`;
+
+        const tokenName = (tokenList.get(address) as TokenInfo).name;
+        const tokenAddressBlob = address.slice(0, 2) + '...' + address.slice(-2);
+
+        return `Token | ${tokenName} (${tokenAddressBlob})`;
     } catch {
         return address;
     }

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -1,0 +1,30 @@
+import {Strategy, TokenInfo, TokenInfoMap} from "@solana/spl-token-registry";
+import {Cluster} from "@utils/cluster";
+import getTokenList from "@utils/get-token-list";
+
+
+export type AddressPageMetadataProps = Readonly<{
+    params: {
+        address: string;
+    };
+    searchParams: {
+        cluster: string;
+    };
+}>;
+
+export default async function getReadableTitleFromAddress(props: AddressPageMetadataProps): Promise<string> {
+    const { params: { address }, searchParams: { cluster } } = props
+
+    // Get cluster from URL querystring (e.g. `?cluster=devnet`). If nothing is found, default to mainnet-beta.
+    let parsedCluster = Cluster.MainnetBeta
+    if (cluster === 'devnet') parsedCluster = Cluster.Devnet
+    else if (cluster === 'testnet') parsedCluster = Cluster.Testnet
+    else if (cluster === 'custom') parsedCluster = Cluster.Custom
+
+    return await getTokenList(parsedCluster, Strategy.Solana)
+        .then((tokens: TokenInfoMap) => {
+            if (typeof tokens.get(address)?.name === 'undefined') throw new Error('invalid token address')
+            return `Token | ${(tokens.get(address) as TokenInfo).name}`
+        })
+        .catch(() => address) // fallback to address if token not found
+}

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -26,7 +26,7 @@ export default async function getReadableTitleFromAddress(props: AddressPageMeta
     try {
         const tokenList = await getTokenList(parsedCluster, Strategy.Solana);
         if (typeof tokenList.get(address)?.name === 'undefined') {
-            console.log(tokenList.get(address))
+            console.log(tokenList.get(address));
             return address;
         }
 

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -30,7 +30,7 @@ export default async function getReadableTitleFromAddress(props: AddressPageMeta
         }
 
         const tokenName = (tokenList.get(address) as TokenInfo).name;
-        const tokenAddressBlob = address.slice(0, 2) + '...' + address.slice(-2);
+        const tokenAddressBlob = address.slice(0, 2) + '\u2026' + address.slice(-2);
 
         return `Token | ${tokenName} (${tokenAddressBlob})`;
     } catch {

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -1,7 +1,6 @@
-import {Strategy, TokenInfo, TokenInfoMap} from "@solana/spl-token-registry";
-import {Cluster} from "@utils/cluster";
-import getTokenList from "@utils/get-token-list";
-
+import { Strategy, TokenInfo } from '@solana/spl-token-registry';
+import { Cluster } from '@utils/cluster';
+import getTokenList from '@utils/get-token-list';
 
 export type AddressPageMetadataProps = Readonly<{
     params: {
@@ -13,18 +12,24 @@ export type AddressPageMetadataProps = Readonly<{
 }>;
 
 export default async function getReadableTitleFromAddress(props: AddressPageMetadataProps): Promise<string> {
-    const { params: { address }, searchParams: { cluster } } = props
+    const {
+        params: { address },
+        searchParams: { cluster },
+    } = props;
 
     // Get cluster from URL querystring (e.g. `?cluster=devnet`). If nothing is found, default to mainnet-beta.
-    let parsedCluster = Cluster.MainnetBeta
-    if (cluster === 'devnet') parsedCluster = Cluster.Devnet
-    else if (cluster === 'testnet') parsedCluster = Cluster.Testnet
-    else if (cluster === 'custom') parsedCluster = Cluster.Custom
+    let parsedCluster = Cluster.MainnetBeta;
+    if (cluster === 'devnet') parsedCluster = Cluster.Devnet;
+    else if (cluster === 'testnet') parsedCluster = Cluster.Testnet;
+    else if (cluster === 'custom') parsedCluster = Cluster.Custom;
 
-    return await getTokenList(parsedCluster, Strategy.Solana)
-        .then((tokens: TokenInfoMap) => {
-            if (typeof tokens.get(address)?.name === 'undefined') throw new Error('invalid token address')
-            return `Token | ${(tokens.get(address) as TokenInfo).name}`
-        })
-        .catch(() => address) // fallback to address if token not found
+    try {
+        const tokenList = await getTokenList(parsedCluster, Strategy.Solana);
+        if (typeof tokenList.get(address)?.name === 'undefined') {
+            return address;
+        }
+        return `Token | ${(tokenList.get(address) as TokenInfo).name}`;
+    } catch {
+        return address;
+    }
 }

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -14,17 +14,26 @@ export type AddressPageMetadataProps = Readonly<{
 export default async function getReadableTitleFromAddress(props: AddressPageMetadataProps): Promise<string> {
     const {
         params: { address },
-        searchParams: { cluster },
+        searchParams: { cluster: clusterParam },
     } = props;
 
-    // Get cluster from URL querystring (e.g. `?cluster=devnet`). If nothing is found, default to mainnet-beta.
-    let parsedCluster = Cluster.MainnetBeta;
-    if (cluster === 'devnet') parsedCluster = Cluster.Devnet;
-    else if (cluster === 'testnet') parsedCluster = Cluster.Testnet;
-    else if (cluster === 'custom') parsedCluster = Cluster.Custom;
+    let cluster: Cluster;
+    switch (clusterParam) {
+        case 'custom':
+            cluster = Cluster.Custom;
+            break;
+        case 'devnet':
+            cluster = Cluster.Devnet;
+            break;
+        case 'testnet':
+            cluster = Cluster.Testnet;
+            break;
+        default:
+            cluster = Cluster.MainnetBeta;
+    }
 
     try {
-        const tokenList = await getTokenList(parsedCluster, Strategy.Solana);
+        const tokenList = await getTokenList(cluster, Strategy.Solana);
         if (typeof tokenList.get(address)?.name === 'undefined') {
             return address;
         }

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -26,7 +26,6 @@ export default async function getReadableTitleFromAddress(props: AddressPageMeta
     try {
         const tokenList = await getTokenList(parsedCluster, Strategy.Solana);
         if (typeof tokenList.get(address)?.name === 'undefined') {
-            console.log(tokenList.get(address));
             return address;
         }
 

--- a/app/utils/get-token-list.ts
+++ b/app/utils/get-token-list.ts
@@ -7,6 +7,6 @@ export default async function getTokenList(cluster: Cluster, strategy: Strategy)
         return tokenList.reduce((map: TokenInfoMap, item: TokenInfo) => {
             map.set(item.address, item);
             return map;
-        }, new Map())
+        }, new Map());
     });
 }

--- a/app/utils/get-token-list.ts
+++ b/app/utils/get-token-list.ts
@@ -1,0 +1,12 @@
+import { Strategy, TokenInfo, TokenInfoMap, TokenListContainer, TokenListProvider } from '@solana/spl-token-registry';
+import { Cluster, clusterSlug } from '@utils/cluster';
+
+export default async function getTokenList(cluster: Cluster, strategy: Strategy): Promise<TokenInfoMap> {
+    return new TokenListProvider().resolve(strategy).then((tokens: TokenListContainer) => {
+        const tokenList = cluster === Cluster.Custom ? [] : tokens.filterByClusterSlug(clusterSlug(cluster)).getList();
+        return tokenList.reduce((map: TokenInfoMap, item: TokenInfo) => {
+            map.set(item.address, item);
+            return map;
+        }, new Map())
+    });
+}

--- a/app/utils/tx.ts
+++ b/app/utils/tx.ts
@@ -448,7 +448,7 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     },
 };
 
-export type LoaderName = (typeof LOADER_IDS)[keyof typeof LOADER_IDS];
+export type LoaderName = typeof LOADER_IDS[keyof typeof LOADER_IDS];
 export const LOADER_IDS = {
     BPFLoaderUpgradeab1e11111111111111111111111: 'BPF Upgradeable Loader',
     MoveLdr111111111111111111111111111111111111: 'Move Loader',

--- a/app/utils/tx.ts
+++ b/app/utils/tx.ts
@@ -448,7 +448,7 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     },
 };
 
-export type LoaderName = typeof LOADER_IDS[keyof typeof LOADER_IDS];
+export type LoaderName = (typeof LOADER_IDS)[keyof typeof LOADER_IDS];
 export const LOADER_IDS = {
     BPFLoaderUpgradeab1e11111111111111111111111: 'BPF Upgradeable Loader',
     MoveLdr111111111111111111111111111111111111: 'Move Loader',


### PR DESCRIPTION
For the title metadata generation, Next.js doesn't allow using client-side hooks on server-side components (see [this issue](https://github.com/vercel/next.js/issues/46372)). Thus, we can't use `useTokenRegistry` as it's marked with 'use client' for frontend. 

When users visit each address page with the token name title, both the client-side and server-side rendering fetches the token list. These identical fetches are optimized by Next.js via [automatic fetch request deduping](https://nextjs.org/docs/app/building-your-application/data-fetching#automatic-fetch-request-deduping).

> It's very important not to create two URLs with the same page title. Consider the case where two tokens have identical names; how would you prevent their URLs from rendering the same title?
1. We could append a small slice of address to the token name, e.g. USD Coin (EPjFW), but this wouldn't prevent same token names with the same "small slice" (using vanity address). 
2. Another method could be just highlighting the official tokens, e.g. USD Coin (official), and leaving the other non-official tokens as-is, but this requires an active management of "official" tokens.

Fixes #243.