### PR TITLE
Display state of feature accounts that are pending activation, and activated

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -3,6 +3,7 @@
 import { AddressLookupTableAccountSection } from '@components/account/address-lookup-table/AddressLookupTableAccountSection';
 import { isAddressLookupTableAccount } from '@components/account/address-lookup-table/types';
 import { ConfigAccountSection } from '@components/account/ConfigAccountSection';
+import { FEATURE_PROGRAM_ID,FeatureAccountSection } from '@components/account/FeatureAccountSection';
 import { MetaplexNFTHeader } from '@components/account/MetaplexNFTHeader';
 import { isNFTokenAccount, parseNFTokenCollectionAccount } from '@components/account/nftoken/isNFTokenAccount';
 import { NFTOKEN_ADDRESS } from '@components/account/nftoken/nftoken';
@@ -336,6 +337,8 @@ function InfoSection({ account }: { account: Account }) {
         return <AddressLookupTableAccountSection account={account} lookupTableAccount={parsedData.parsed.info} />;
     } else if (rawData && isAddressLookupTableAccount(account.owner, rawData)) {
         return <AddressLookupTableAccountSection account={account} data={rawData} />;
+    } else if (account.owner.equals(FEATURE_PROGRAM_ID)) {
+        return <FeatureAccountSection account={account} />;
     } else {
         return <UnknownAccountCard account={account} />;
     }

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -3,7 +3,7 @@
 import { AddressLookupTableAccountSection } from '@components/account/address-lookup-table/AddressLookupTableAccountSection';
 import { isAddressLookupTableAccount } from '@components/account/address-lookup-table/types';
 import { ConfigAccountSection } from '@components/account/ConfigAccountSection';
-import { FEATURE_PROGRAM_ID,FeatureAccountSection } from '@components/account/FeatureAccountSection';
+import { FeatureAccountSection } from '@components/account/FeatureAccountSection';
 import { MetaplexNFTHeader } from '@components/account/MetaplexNFTHeader';
 import { isNFTokenAccount, parseNFTokenCollectionAccount } from '@components/account/nftoken/isNFTokenAccount';
 import { NFTOKEN_ADDRESS } from '@components/account/nftoken/nftoken';
@@ -35,6 +35,7 @@ import { useTokenRegistry } from '@providers/mints/token-registry';
 import { PROGRAM_ID as ACCOUNT_COMPRESSION_ID } from '@solana/spl-account-compression';
 import { PublicKey } from '@solana/web3.js';
 import { ClusterStatus } from '@utils/cluster';
+import { FEATURE_PROGRAM_ID } from '@utils/parseFeatureAccount';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import { redirect, useSelectedLayoutSegment } from 'next/navigation';
@@ -337,7 +338,7 @@ function InfoSection({ account }: { account: Account }) {
         return <AddressLookupTableAccountSection account={account} lookupTableAccount={parsedData.parsed.info} />;
     } else if (rawData && isAddressLookupTableAccount(account.owner, rawData)) {
         return <AddressLookupTableAccountSection account={account} data={rawData} />;
-    } else if (account.owner.equals(FEATURE_PROGRAM_ID)) {
+    } else if (account.owner.toBase58() === FEATURE_PROGRAM_ID) {
         return <FeatureAccountSection account={account} />;
     } else {
         return <UnknownAccountCard account={account} />;

--- a/app/components/account/FeatureAccountSection.tsx
+++ b/app/components/account/FeatureAccountSection.tsx
@@ -1,0 +1,104 @@
+import { Address } from '@components/common/Address';
+import { TableCardBody } from '@components/common/TableCardBody';
+import { Account } from '@providers/accounts';
+import * as BufferLayout from '@solana/buffer-layout';
+import { PublicKey } from "@solana/web3.js";
+
+import { UnknownAccountCard } from './UnknownAccountCard';
+
+export const FEATURE_PROGRAM_ID = new PublicKey('Feature111111111111111111111111111111111111');
+
+export type FeatureAccount = {
+    address: string;
+    activatedAt: number | null;
+};
+
+export const featureAccountLayout = BufferLayout.struct([
+    ((): BufferLayout.Union => {
+        const union = BufferLayout.union(BufferLayout.u8('isActivated'), null, "activatedAt");
+        union.addVariant(0, BufferLayout.struct([]), "none");
+        union.addVariant(1, BufferLayout.nu64(), 'some');
+        return union;
+    })()
+]);
+
+export function isFeatureAccount(account: Account): boolean {
+    return Boolean(account.owner.equals(FEATURE_PROGRAM_ID) && account.data.raw);
+}
+
+export const parseFeatureAccount = (account: Account): FeatureAccount | null => {
+    if (!isFeatureAccount(account)) {
+        return null;
+    }
+
+    try {
+        const parsed = featureAccountLayout.decode(account.data.raw!);
+
+        if (!parsed) {
+            return null;
+        }
+
+        let activatedAt: number | null = null;
+        if (parsed.activatedAt.some) {
+            activatedAt = parsed.activatedAt.some;
+        }
+
+        return {
+            activatedAt: activatedAt,
+            address: account.pubkey.toBase58(),
+        }
+    } catch (e) {
+        console.error('Problem parsing Feature Account...', e);
+        return null;
+    }
+}
+
+export function FeatureAccountSection({ account }: { account: Account }) {
+    const feature = parseFeatureAccount(account);
+    if (feature) {
+        return <FeatureCard feature={feature} />;
+    }
+
+    return <UnknownAccountCard account={account} />;
+}
+
+const FeatureCard = ({ feature }: { feature: FeatureAccount }) => {
+    let activatedAt;
+    if (feature.activatedAt) {
+        activatedAt = (
+            <tr>
+                <td>Activated At Slot</td>
+                <td className="text-lg-end">
+                    <code>{feature.activatedAt}</code>
+                </td>
+            </tr>
+        );
+    }
+    console.log(feature);
+
+    return (
+        <div className="card">
+            <div className="card-header">
+                <h3 className="card-header-title mb-0 d-flex align-items-center">Feature Activation</h3>
+            </div>
+
+            <TableCardBody>
+                <tr>
+                    <td>Address</td>
+                    <td className="text-lg-end">
+                        <Address pubkey={new PublicKey(feature.address)} alignRight raw />
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>Activated?</td>
+                    <td className="text-lg-end">
+                        <code>{feature.activatedAt === null ? "No" : "Yes"}</code>
+                    </td>
+                </tr>
+
+                {activatedAt}
+            </TableCardBody>
+        </div>
+    )
+};

--- a/app/components/account/__tests__/FeatureAccountSection-test.ts
+++ b/app/components/account/__tests__/FeatureAccountSection-test.ts
@@ -1,0 +1,33 @@
+import { FEATURE_PROGRAM_ID, parseFeatureAccount } from '@components/account/FeatureAccountSection';
+import { PublicKey } from '@solana/web3.js';
+
+describe('parseFeatureAccount', () => {
+    it('parses deployed feature', () => {
+        const buffer = new Uint8Array([
+            0x01,0x80,0xc2,0x2b,0x0a,0x00,0x00,0x00,0x00,
+        ]);
+        const feature = parseFeatureAccount({
+            data: { raw: buffer as Buffer },
+            executable: false,
+            lamports: 1,
+            owner: new PublicKey(FEATURE_PROGRAM_ID),
+            pubkey: new PublicKey('7txXZZD6Um59YoLMF7XUNimbMjsqsWhc7g2EniiTrmp1'),
+            space: buffer.length,
+        });
+        expect(feature?.activatedAt).toBe(170640000);
+    });
+    it('parses undeployed feature', () => {
+        const buffer = new Uint8Array([
+            0x00
+        ]);
+        const feature = parseFeatureAccount({
+            data: { raw: buffer as Buffer },
+            executable: false,
+            lamports: 1,
+            owner: new PublicKey(FEATURE_PROGRAM_ID),
+            pubkey: new PublicKey('7txXZZD6Um59YoLMF7XUNimbMjsqsWhc7g2EniiTrmp1'),
+            space: buffer.length,
+        });
+        expect(feature?.activatedAt).toBeNull();
+    });
+});

--- a/app/utils/__tests__/parseFeatureAccount-test.ts
+++ b/app/utils/__tests__/parseFeatureAccount-test.ts
@@ -1,11 +1,9 @@
-import { FEATURE_PROGRAM_ID, parseFeatureAccount } from '@components/account/FeatureAccountSection';
 import { PublicKey } from '@solana/web3.js';
+import { FEATURE_PROGRAM_ID, parseFeatureAccount } from '@utils/parseFeatureAccount';
 
 describe('parseFeatureAccount', () => {
-    it('parses deployed feature', () => {
-        const buffer = new Uint8Array([
-            0x01,0x80,0xc2,0x2b,0x0a,0x00,0x00,0x00,0x00,
-        ]);
+    it('parses an activated feature', () => {
+        const buffer = new Uint8Array([0x01, 0x80, 0xc2, 0x2b, 0x0a, 0x00, 0x00, 0x00, 0x00]);
         const feature = parseFeatureAccount({
             data: { raw: buffer as Buffer },
             executable: false,
@@ -16,10 +14,8 @@ describe('parseFeatureAccount', () => {
         });
         expect(feature?.activatedAt).toBe(170640000);
     });
-    it('parses undeployed feature', () => {
-        const buffer = new Uint8Array([
-            0x00
-        ]);
+    it('parses a feature that is scheduled for activation', () => {
+        const buffer = new Uint8Array([0x00]);
         const feature = parseFeatureAccount({
             data: { raw: buffer as Buffer },
             executable: false,

--- a/app/utils/parseFeatureAccount.ts
+++ b/app/utils/parseFeatureAccount.ts
@@ -1,0 +1,32 @@
+import { Account } from '@providers/accounts';
+import * as BufferLayout from '@solana/buffer-layout';
+
+export const FEATURE_PROGRAM_ID = 'Feature111111111111111111111111111111111111';
+
+type FeatureAccount = {
+    address: string;
+    activatedAt: number | null;
+};
+
+function isFeatureAccount(account: Account): boolean {
+    return account.owner.toBase58() === FEATURE_PROGRAM_ID && account.data.raw != null;
+}
+
+export const parseFeatureAccount = (account: Account): FeatureAccount => {
+    if (!isFeatureAccount(account) || account.data.raw == null) {
+        throw new Error(`Failed to parse ${account} as a feature account`);
+    }
+    const address = account.pubkey.toBase58();
+    const parsed = BufferLayout.struct([
+        ((): BufferLayout.Union => {
+            const union = BufferLayout.union(BufferLayout.u8('isActivated'), null, 'activatedAt');
+            union.addVariant(0, BufferLayout.constant(null), 'value');
+            union.addVariant(1, BufferLayout.nu64(), 'value');
+            return union;
+        })(),
+    ]).decode(account.data.raw);
+    return {
+        activatedAt: parsed.activatedAt.value,
+        address,
+    };
+};


### PR DESCRIPTION
This implements:

* When a feature has been activated at the epoch boundary for which it was scheduled, we can read out the activation slot and render it in the UI.
* When a feature has been scheduled for activation but the activation epoch boundary hasn't been reached, the slot is `none` and we can render ‘not active’ in the UI.

This does not implement:
* When a feature has not been scheduled at all. Its feature flag account doesn't exist so there's no UI we can show one way or another.

_NOTE: Originally made by @terorie as PR #253. I was not able to push to that branch, so had to open a new PR._