### PR TITLE
Use experimental web3js for homepage data

### DIFF
--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -224,7 +224,8 @@ function AnimatedTransactionCount({ info }: { info: PerformanceInfo }) {
     const countUpRef = React.useRef({ lastUpdate: 0, period: 0, start: 0 });
     const countUp = countUpRef.current;
 
-    const { transactionCount: txCount, avgTps } = info;
+    const { transactionCount, avgTps } = info;
+    const txCount = Number(transactionCount);
 
     // Track last tx count to reset count up options
     if (txCount !== txCountRef.current) {
@@ -442,14 +443,13 @@ function PingBarChart({
             <div class="value">${val.mean} ms</div>
             <div class="label">
               <p class="mb-0">${val.confirmed} of ${val.submitted} confirmed</p>
-            ${
-                val.loss
+            ${val.loss
                     ? `<p class="mb-0">${val.loss.toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          style: 'percent',
-                      })} loss</p>`
+                        minimumFractionDigits: 2,
+                        style: 'percent',
+                    })} loss</p>`
                     : ''
-            }
+                }
             ${SERIES_INFO[series].label(seriesLength - i)}min ago
             </div>
           `;

--- a/app/components/TopAccountsCard.tsx
+++ b/app/components/TopAccountsCard.tsx
@@ -11,6 +11,8 @@ import React, { createRef, useMemo } from 'react';
 import { ChevronDown } from 'react-feather';
 import useAsyncEffect from 'use-async-effect';
 
+import { percentage } from '../utils/math';
+
 type Filter = 'circulating' | 'nonCirculating' | 'all' | null;
 
 export function TopAccountsCard() {
@@ -33,7 +35,7 @@ export function TopAccountsCard() {
         return <ErrorCard text={richList} retry={fetchRichList} />;
     }
 
-    let supplyCount: number;
+    let supplyCount: bigint;
     let accounts, header;
 
     if (richList !== Status.Idle) {
@@ -105,7 +107,7 @@ export function TopAccountsCard() {
     );
 }
 
-const renderAccountRow = (account: AccountBalancePair, index: number, supply: number) => {
+const renderAccountRow = (account: AccountBalancePair, index: number, supply: bigint) => {
     return (
         <tr key={index}>
             <td>
@@ -117,7 +119,7 @@ const renderAccountRow = (account: AccountBalancePair, index: number, supply: nu
             <td className="text-end">
                 <SolBalance lamports={account.lamports} maximumFractionDigits={0} />
             </td>
-            <td className="text-end">{`${((100 * account.lamports) / supply).toFixed(3)}%`}</td>
+            <td className="text-end">{percentage(BigInt(100 * account.lamports), supply, 4).toFixed(3) + '%'}</td>
         </tr>
     );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import {
 import { Status, useFetchSupply, useSupply } from '@providers/supply';
 import { ClusterStatus } from '@utils/cluster';
 import { abbreviatedNumber, lamportsToSol, slotsToHumanString } from '@utils/index';
+import { percentage } from '@utils/math';
 import React from 'react';
 
 export default function Page() {
@@ -80,12 +81,12 @@ function StakingComponent() {
         return <ErrorCard text={supply} retry={fetchData} />;
     }
 
-    // Multiply by 10000 while in BigInt form, so we get 2dp with no loss of accuracy, then round to 1
-    const circulatingPercentage = (Number(supply.circulating * BigInt(10000) / supply.total) / 100).toFixed(1);
+    // Calculate to 2dp for accuracy, then display as 1
+    const circulatingPercentage = percentage(supply.circulating, supply.total, 2).toFixed(1);
 
     let delinquentStakePercentage;
     if (delinquentStake && activeStake) {
-        delinquentStakePercentage = (Number(delinquentStake * BigInt(10000) / activeStake) / 100).toFixed(1);
+        delinquentStakePercentage = percentage(delinquentStake, activeStake, 2).toFixed(1);
     }
 
     return (
@@ -150,8 +151,8 @@ function StatsCardBody() {
     const hourlySlotTime = Math.round(1000 * avgSlotTime_1h);
     const averageSlotTime = Math.round(1000 * avgSlotTime_1min);
     const { slotIndex, slotsInEpoch } = epochInfo;
-    const epochProgress = ((100 * slotIndex) / slotsInEpoch).toFixed(1) + '%';
-    const epochTimeRemaining = slotsToHumanString(slotsInEpoch - slotIndex, hourlySlotTime);
+    const epochProgress = percentage(slotIndex, slotsInEpoch, 2).toFixed(1) + '%';
+    const epochTimeRemaining = slotsToHumanString(Number(slotsInEpoch - slotIndex), hourlySlotTime);
     const { blockHeight, absoluteSlot } = epochInfo;
 
     return (
@@ -159,14 +160,14 @@ function StatsCardBody() {
             <tr>
                 <td className="w-100">Slot</td>
                 <td className="text-lg-end font-monospace">
-                    <Slot slot={absoluteSlot} link />
+                    <Slot slot={Number(absoluteSlot)} link />
                 </td>
             </tr>
             {blockHeight !== undefined && (
                 <tr>
                     <td className="w-100">Block height</td>
                     <td className="text-lg-end font-monospace">
-                        <Slot slot={blockHeight} />
+                        <Slot slot={Number(blockHeight)} />
                     </td>
                 </tr>
             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,13 +59,13 @@ function StakingComponent() {
 
     const delinquentStake = React.useMemo(() => {
         if (voteAccounts) {
-            return voteAccounts.delinquent.reduce((prev, current) => prev + current.activatedStake, 0);
+            return voteAccounts.delinquent.reduce((prev, current) => prev + current.activatedStake, BigInt(0));
         }
     }, [voteAccounts]);
 
     const activeStake = React.useMemo(() => {
         if (voteAccounts && delinquentStake) {
-            return voteAccounts.current.reduce((prev, current) => prev + current.activatedStake, 0) + delinquentStake;
+            return voteAccounts.current.reduce((prev, current) => prev + current.activatedStake, BigInt(0)) + delinquentStake;
         }
     }, [voteAccounts, delinquentStake]);
 
@@ -80,11 +80,12 @@ function StakingComponent() {
         return <ErrorCard text={supply} retry={fetchData} />;
     }
 
-    const circulatingPercentage = ((supply.circulating / supply.total) * 100).toFixed(1);
+    // Multiply by 10000 while in BigInt form, so we get 2dp with no loss of accuracy, then round to 1
+    const circulatingPercentage = (Number(supply.circulating * BigInt(10000) / supply.total) / 100).toFixed(1);
 
     let delinquentStakePercentage;
     if (delinquentStake && activeStake) {
-        delinquentStakePercentage = ((delinquentStake / activeStake) * 100).toFixed(1);
+        delinquentStakePercentage = (Number(delinquentStake * BigInt(10000) / activeStake) / 100).toFixed(1);
     }
 
     return (
@@ -107,11 +108,11 @@ function StakingComponent() {
                 <div className="card">
                     <div className="card-body">
                         <h4>Active Stake</h4>
-                        {activeStake && (
+                        {activeStake ? (
                             <h1>
                                 <em>{displayLamports(activeStake)}</em> / <small>{displayLamports(supply.total)}</small>
                             </h1>
-                        )}
+                        ) : null}
                         {delinquentStakePercentage && (
                             <h5>
                                 Delinquent stake: <em>{delinquentStakePercentage}%</em>
@@ -124,7 +125,7 @@ function StakingComponent() {
     );
 }
 
-function displayLamports(value: number) {
+function displayLamports(value: number | bigint) {
     return abbreviatedNumber(lamportsToSol(value));
 }
 

--- a/app/providers/stats/solanaPerformanceInfo.tsx
+++ b/app/providers/stats/solanaPerformanceInfo.tsx
@@ -1,5 +1,3 @@
-import { PerfSample } from '@solana/web3.js';
-
 import { ClusterStatsStatus } from './solanaClusterStats';
 
 export type PerformanceInfo = {
@@ -11,7 +9,13 @@ export type PerformanceInfo = {
         medium: (number | null)[];
         long: (number | null)[];
     };
-    transactionCount: number;
+    transactionCount: bigint;
+};
+
+export type PerformanceSample = {
+    numTransactions: bigint;
+    numSlots: bigint;
+    samplePeriodSecs: number;
 };
 
 export enum PerformanceInfoActionType {
@@ -23,12 +27,12 @@ export enum PerformanceInfoActionType {
 
 export type PerformanceInfoActionSetTransactionCount = {
     type: PerformanceInfoActionType.SetTransactionCount;
-    data: number;
+    data: bigint;
 };
 
 export type PerformanceInfoActionSetPerfSamples = {
     type: PerformanceInfoActionType.SetPerfSamples;
-    data: PerfSample[];
+    data: PerformanceSample[];
 };
 
 export type PerformanceInfoActionSetError = {
@@ -56,10 +60,10 @@ export function performanceInfoReducer(state: PerformanceInfo, action: Performan
 
             const short = action.data
                 .filter(sample => {
-                    return sample.numTransactions !== 0;
+                    return sample.numTransactions !== BigInt(0);
                 })
                 .map(sample => {
-                    return sample.numTransactions / sample.samplePeriodSecs;
+                    return Number(sample.numTransactions / BigInt(sample.samplePeriodSecs));
                 });
 
             const avgTps = short[0];
@@ -78,7 +82,7 @@ export function performanceInfoReducer(state: PerformanceInfo, action: Performan
                 Math.max(...perfHistory.long)
             );
 
-            const status = state.transactionCount !== 0 ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
+            const status = state.transactionCount !== BigInt(0) ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
 
             return {
                 ...state,

--- a/app/providers/supply.tsx
+++ b/app/providers/supply.tsx
@@ -1,16 +1,23 @@
 'use client';
 
 import { useCluster } from '@providers/cluster';
-import { Connection, Supply } from '@solana/web3.js';
 import { Cluster, ClusterStatus } from '@utils/cluster';
 import { reportError } from '@utils/sentry';
 import React from 'react';
+import { createDefaultRpcTransport, createSolanaRpc } from 'web3js-experimental';
 
 export enum Status {
     Idle,
     Disconnected,
     Connecting,
 }
+
+type Lamports = bigint;
+
+type Supply = Readonly<{
+    circulating: Lamports,
+    total: Lamports,
+}>;
 
 type State = Supply | Status | string;
 
@@ -41,8 +48,14 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
     dispatch(Status.Connecting);
 
     try {
-        const connection = new Connection(url, 'finalized');
-        const supply = (await connection.getSupply({ excludeNonCirculatingAccountsList: true })).value;
+        const transport = createDefaultRpcTransport({ url });
+        const rpc = createSolanaRpc({ transport });
+
+        const supplyResponse = await rpc.getSupply({ commitment: 'finalized', excludeNonCirculatingAccountsList: true }).send();
+        const supply: Supply = {
+            circulating: supplyResponse.value.circulating,
+            total: supplyResponse.value.total,
+        };
 
         // Update state if still connecting
         dispatch(state => {

--- a/app/providers/supply.tsx
+++ b/app/providers/supply.tsx
@@ -16,6 +16,7 @@ type Lamports = bigint;
 
 type Supply = Readonly<{
     circulating: Lamports,
+    nonCirculating: Lamports,
     total: Lamports,
 }>;
 
@@ -54,6 +55,7 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
         const supplyResponse = await rpc.getSupply({ commitment: 'finalized', excludeNonCirculatingAccountsList: true }).send();
         const supply: Supply = {
             circulating: supplyResponse.value.circulating,
+            nonCirculating: supplyResponse.value.nonCirculating,
             total: supplyResponse.value.total,
         };
 

--- a/app/utils/__tests__/math-test.ts
+++ b/app/utils/__tests__/math-test.ts
@@ -1,0 +1,9 @@
+import { percentage } from '@utils/math';
+
+describe('percentage', () => {
+  it('returns a number with the right decimals', () => {
+    expect(percentage(BigInt(1), BigInt(3), 0)).toEqual(33)
+    expect(percentage(BigInt(1), BigInt(3), 1)).toEqual(33.3)
+    expect(percentage(BigInt(1), BigInt(3), 2)).toEqual(33.33)
+  });
+});

--- a/app/utils/math.ts
+++ b/app/utils/math.ts
@@ -1,0 +1,10 @@
+/**
+ * Calculate a percentage using bigints, as numerator/denominator * 100
+ * @returns the percentage, with the requested number of decimal places
+ */
+export function percentage(numerator: bigint, denominator: bigint, decimals: number): number {
+    // since bigint is integer, we need to multiply first to get decimals
+    // see https://stackoverflow.com/a/63095380/1375972
+    const pow = 10 ** decimals;
+    return Number(numerator * BigInt(100 * pow) / denominator) / pow;
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
         "tweetnacl": "^1.0.3",
         "typescript": "5.0.4",
         "use-async-effect": "^2.2.7",
-        "use-tab-visibility": "^1.0.9"
+        "use-tab-visibility": "^1.0.9",
+        "web3js-experimental": "npm:@solana/web3.js@2.0.0-experimental.b79b56f"
     },
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   cross-fetch: ^3.1.5
   node-fetch: ^2.6.9
   uuid: ^9.0.0
-
-packageExtensionsChecksum: 7806f6f9382d8ed8e85237fc76baca0f
 
 dependencies:
   '@blockworks-foundation/mango-client':
@@ -21,7 +15,7 @@ dependencies:
     version: 3.6.7
   '@bonfida/spl-name-service':
     specifier: 0.1.30
-    version: 0.1.30(@solana/buffer-layout@3.0.0)(@solana/spl-token@0.1.8)(@solana/web3.js@1.66.0)(bn.js@5.2.1)(borsh@0.7.0)
+    version: 0.1.30(@solana/buffer-layout@3.0.0)(@solana/spl-token@0.1.8)(@solana/web3.js@2.0.0-experimental.b79b56f)(bn.js@5.2.1)(borsh@0.7.0)
   '@cloudflare/stream-react':
     specifier: ^1.2.0
     version: 1.2.0(react@18.2.0)
@@ -33,7 +27,7 @@ dependencies:
     version: 1.1.0
   '@metaplex/js':
     specifier: ^4.12.0
-    version: 4.12.0(@metaplex-foundation/mpl-auction@0.0.2)(@metaplex-foundation/mpl-core@0.0.2)(@metaplex-foundation/mpl-metaplex@0.0.5)(@metaplex-foundation/mpl-token-metadata@1.1.0)(@metaplex-foundation/mpl-token-vault@0.0.2)(@solana/spl-token@0.1.8)(@solana/web3.js@1.66.0)
+    version: 4.12.0(@metaplex-foundation/mpl-auction@0.0.2)(@metaplex-foundation/mpl-core@0.0.2)(@metaplex-foundation/mpl-metaplex@0.0.5)(@metaplex-foundation/mpl-token-metadata@1.1.0)(@metaplex-foundation/mpl-token-vault@0.0.2)(@solana/spl-token@0.1.8)(@solana/web3.js@2.0.0-experimental.b79b56f)
   '@project-serum/anchor':
     specifier: ^0.23.0
     version: 0.23.0
@@ -57,7 +51,7 @@ dependencies:
     version: 3.0.0
   '@solana/spl-account-compression':
     specifier: ^0.1.8
-    version: 0.1.8(@solana/web3.js@1.66.0)
+    version: 0.1.8(@solana/web3.js@2.0.0-experimental.b79b56f)
   '@solana/spl-token':
     specifier: ^0.1.8
     version: 0.1.8
@@ -562,7 +556,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@bonfida/spl-name-service@0.1.30(@solana/buffer-layout@3.0.0)(@solana/spl-token@0.1.8)(@solana/web3.js@1.66.0)(bn.js@5.2.1)(borsh@0.7.0):
+  /@bonfida/spl-name-service@0.1.30(@solana/buffer-layout@3.0.0)(@solana/spl-token@0.1.8)(@solana/web3.js@2.0.0-experimental.b79b56f)(bn.js@5.2.1)(borsh@0.7.0):
     resolution: {integrity: sha512-0aSpymeNDq7rDSDEJgB6/qKyy3yUkHLQk7Jxwtmibfva3s1johEfFdl2kUDDPWi/ubgbxYjPxJRGrlGQNEmmQw==}
     peerDependencies:
       '@solana/buffer-layout': ^4.0.0
@@ -573,14 +567,12 @@ packages:
     dependencies:
       '@solana/buffer-layout': 3.0.0
       '@solana/spl-token': 0.1.8
-      '@solana/web3.js': 1.66.0
+      '@solana/web3.js': 2.0.0-experimental.b79b56f
       bn.js: 5.2.1
       borsh: 0.7.0
       ethers: 5.7.2
-      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
       - bufferutil
-      - encoding
       - utf-8-validate
     dev: false
 
@@ -1414,7 +1406,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@metaplex/js@4.12.0(@metaplex-foundation/mpl-auction@0.0.2)(@metaplex-foundation/mpl-core@0.0.2)(@metaplex-foundation/mpl-metaplex@0.0.5)(@metaplex-foundation/mpl-token-metadata@1.1.0)(@metaplex-foundation/mpl-token-vault@0.0.2)(@solana/spl-token@0.1.8)(@solana/web3.js@1.66.0):
+  /@metaplex/js@4.12.0(@metaplex-foundation/mpl-auction@0.0.2)(@metaplex-foundation/mpl-core@0.0.2)(@metaplex-foundation/mpl-metaplex@0.0.5)(@metaplex-foundation/mpl-token-metadata@1.1.0)(@metaplex-foundation/mpl-token-vault@0.0.2)(@solana/spl-token@0.1.8)(@solana/web3.js@2.0.0-experimental.b79b56f):
     resolution: {integrity: sha512-rIUTMXo5gIXFIZt08AEHyqH4oVoLL2dMYiNePQluw9pydesRym4jDayJ5POxEmKmyc6KGqVKw/YWUIivmUY5zg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
@@ -1432,7 +1424,7 @@ packages:
       '@metaplex-foundation/mpl-token-metadata': 1.1.0
       '@metaplex-foundation/mpl-token-vault': 0.0.2
       '@solana/spl-token': 0.1.8
-      '@solana/web3.js': 1.66.0
+      '@solana/web3.js': 2.0.0-experimental.b79b56f
       '@types/bs58': 4.0.1
       axios: 0.25.0
       bn.js: 5.2.1
@@ -1441,12 +1433,8 @@ packages:
       buffer: 6.0.3
       crypto-hash: 1.3.0
       form-data: 4.0.0
-      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
-      - bufferutil
       - debug
-      - encoding
-      - utf-8-validate
     dev: false
 
   /@next/env@13.4.0:
@@ -2020,7 +2008,7 @@ packages:
     resolution: {integrity: sha512-CadExK4nr2COekDkHpeByOosY0hfJSUOb1gogX6N/4dHbShOEnRLVXUXQeSw6ochMtLkfxamuZU1I3p1rS/ObQ==}
     dev: false
 
-  /@solana/spl-account-compression@0.1.8(@solana/web3.js@1.66.0):
+  /@solana/spl-account-compression@0.1.8(@solana/web3.js@2.0.0-experimental.b79b56f):
     resolution: {integrity: sha512-vsvsx358pVFPtyNd8zIZy0lezR0NuvOykQ29Zq+8oto+kHfTXMGXXQ1tKHUYke6XkINIWLFVg/jDi+1D9RYaqQ==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -2028,12 +2016,11 @@ packages:
     dependencies:
       '@metaplex-foundation/beet': 0.7.1
       '@metaplex-foundation/beet-solana': 0.4.0
-      '@solana/web3.js': 1.66.0
+      '@solana/web3.js': 2.0.0-experimental.b79b56f
       bn.js: 5.2.1
       borsh: 0.7.0
       js-sha3: 0.8.0
       typescript-collections: 1.3.3
-      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
       - bufferutil
       - encoding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   cross-fetch: ^3.1.5
   node-fetch: ^2.6.9
   uuid: ^9.0.0
+
+packageExtensionsChecksum: 7806f6f9382d8ed8e85237fc76baca0f
 
 dependencies:
   '@blockworks-foundation/mango-client':
@@ -148,6 +154,9 @@ dependencies:
   use-tab-visibility:
     specifier: ^1.0.9
     version: 1.0.9(react@18.2.0)
+  web3js-experimental:
+    specifier: npm:@solana/web3.js@2.0.0-experimental.b79b56f
+    version: /@solana/web3.js@2.0.0-experimental.b79b56f
 
 devDependencies:
   '@solana/eslint-config-solana':
@@ -568,8 +577,10 @@ packages:
       bn.js: 5.2.1
       borsh: 0.7.0
       ethers: 5.7.2
+      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
       - bufferutil
+      - encoding
       - utf-8-validate
     dev: false
 
@@ -1430,8 +1441,12 @@ packages:
       buffer: 6.0.3
       crypto-hash: 1.3.0
       form-data: 4.0.0
+      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
+      - bufferutil
       - debug
+      - encoding
+      - utf-8-validate
     dev: false
 
   /@next/env@13.4.0:
@@ -1980,6 +1995,12 @@ packages:
       typescript: 5.0.4
     dev: true
 
+  /@solana/keys@2.0.0-experimental.b79b56f:
+    resolution: {integrity: sha512-CQO4bbMkKX4DF6lMyw/8D6gSVD3Md60vKuK6cfxcE2h2vl0Je/MvHHjpTa6CAibRiAfrVAPeqqVcZviQUng58g==}
+    dependencies:
+      bs58: 5.0.0
+    dev: false
+
   /@solana/prettier-config-solana@0.0.2(prettier@2.8.8):
     resolution: {integrity: sha512-F/e2UIJwb30Y8QjR9nr/OrJiCc8yjMkiP9Ctk4VYg+8jODNP31dx6s9mn4sbMFVYA0Km5EPZLN2xsZacBy0y/A==}
     peerDependencies:
@@ -1987,6 +2008,17 @@ packages:
     dependencies:
       prettier: 2.8.8
     dev: true
+
+  /@solana/rpc-core@2.0.0-experimental.b79b56f:
+    resolution: {integrity: sha512-nZ/PFIpbmq3Y/+/QR3kMI99WCkMEiPdiZusnE+pb3BLgDcZ5SZpPf/yGytv6/MqvqwgT8oxwS/G6Z3XogeUzng==}
+    dependencies:
+      '@solana/keys': 2.0.0-experimental.b79b56f
+      bs58: 5.0.0
+    dev: false
+
+  /@solana/rpc-transport@2.0.0-experimental.b79b56f:
+    resolution: {integrity: sha512-CadExK4nr2COekDkHpeByOosY0hfJSUOb1gogX6N/4dHbShOEnRLVXUXQeSw6ochMtLkfxamuZU1I3p1rS/ObQ==}
+    dev: false
 
   /@solana/spl-account-compression@0.1.8(@solana/web3.js@1.66.0):
     resolution: {integrity: sha512-vsvsx358pVFPtyNd8zIZy0lezR0NuvOykQ29Zq+8oto+kHfTXMGXXQ1tKHUYke6XkINIWLFVg/jDi+1D9RYaqQ==}
@@ -2001,6 +2033,7 @@ packages:
       borsh: 0.7.0
       js-sha3: 0.8.0
       typescript-collections: 1.3.3
+      web3js-1: /@solana/web3.js@1.66.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2056,6 +2089,15 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: false
+
+  /@solana/web3.js@2.0.0-experimental.b79b56f:
+    resolution: {integrity: sha512-f6wbWSSGGsBlwQ23jmBAG4ZOEzXcbXKpIceC+y2iTYnCKf+dLGco27RPPx6AjRNe8cgB5dxeY+rHiEWRWJPoxA==}
+    dependencies:
+      '@solana/keys': 2.0.0-experimental.b79b56f
+      '@solana/rpc-core': 2.0.0-experimental.b79b56f
+      '@solana/rpc-transport': 2.0.0-experimental.b79b56f
+      fast-stable-stringify: 1.0.0
     dev: false
 
   /@swc/helpers@0.5.1:


### PR DESCRIPTION
This PR is a first effort to start proving out the experimental web3js on Explorer. All data displayed on the homepage is fetched using functions of the experimental web3js.

Notes:

- Annoyingly this doesn't eliminate the old web3js dependency from the homepage. There's a big tree of providers with various web3.js (and other) dependencies in [the app layout](https://github.com/solana-labs/explorer/blob/master/app/layout.tsx).

- The main difference for the functions covered here is using bigint in the new web3js. I've tried to keep processing of bigint as bigint, for example calculating percentages of bigints is done without converting them to numbers. I've mostly left display components as number, for example `<Slot>` is used in many places and is left unchanged, and `<CountUp>` is a 3rd party dependency which expects numbers.

- I've added the experimental web3js using an alias `web3js-experimental`. pnpm has an issue where peerDependencies (some libs have web3js as a peer dependency) don't work correctly, [see issue + workaround used here](https://github.com/pnpm/pnpm/issues/6588#issuecomment-1563850988)

- We mostly used the exported return types from web3js as our data structures. The experimental web3js doesn't export return types, so I've created minimal types that just contain the fields that we need and then passed these around as needed 