### PR TITLE
Move providers only used by one page into page layouts

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -21,6 +21,7 @@ import { Identicon } from '@components/common/Identicon';
 import { LoadingCard } from '@components/common/LoadingCard';
 import {
     Account,
+    AccountsProvider,
     TokenProgramData,
     useAccountInfo,
     useFetchAccountInfo,
@@ -39,7 +40,7 @@ import { FEATURE_PROGRAM_ID } from '@utils/parseFeatureAccount';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import { redirect, useSelectedLayoutSegment } from 'next/navigation';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
 const IDENTICON_WIDTH = 64;
 
@@ -145,8 +146,9 @@ const TABS_LOOKUP: { [id: string]: Tab[] } = {
 
 const TOKEN_TABS_HIDDEN = ['spl-token:mint', 'config', 'vote', 'sysvar', 'config'];
 
-type Props = { children: React.ReactNode; params: { address: string } };
-export default function AddressLayout({ children, params: { address } }: Props) {
+type Props = PropsWithChildren<{ params: { address: string } }>;
+
+function AddressLayoutInner({ children, params: { address } }: Props) {
     const fetchAccount = useFetchAccountInfo();
     const { status } = useCluster();
     const info = useAccountInfo(address);
@@ -180,6 +182,14 @@ export default function AddressLayout({ children, params: { address } }: Props) 
                 </DetailsSections>
             )}
         </div>
+    );
+}
+
+export default function AddressLayout({ children, params }: Props) {
+    return (
+        <AccountsProvider>
+            <AddressLayoutInner params={params}>{children}</AddressLayoutInner>
+        </AccountsProvider>
     );
 }
 

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -6,22 +6,18 @@ import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Slot } from '@components/common/Slot';
 import { TableCardBody } from '@components/common/TableCardBody';
-import { FetchStatus, useBlock, useFetchBlock } from '@providers/block';
+import { BlockProvider, FetchStatus, useBlock, useFetchBlock } from '@providers/block';
 import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { displayTimestamp, displayTimestampUtc } from '@utils/date';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import { notFound, useSelectedLayoutSegment } from 'next/navigation';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export default function BlockLayout({
-    children,
-    params: { slot },
-}: {
-    children: React.ReactNode;
-    params: { slot: string };
-}) {
+type Props = PropsWithChildren<{ params: { slot: string } }>;
+
+function BlockLayoutInner({ children, params: { slot } }: Props) {
     const slotNumber = Number(slot);
     if (isNaN(slotNumber) || slotNumber >= Number.MAX_SAFE_INTEGER || slotNumber % 1 !== 0) {
         notFound();
@@ -176,6 +172,14 @@ export default function BlockLayout({
             {content}
         </div>
     );
+}
+
+export default function BlockLayout({ children, params }: Props) {
+    return (
+        <BlockProvider>
+            <BlockLayoutInner params={params}>{children}</BlockLayoutInner>
+        </BlockProvider>
+    )
 }
 
 const TABS: Tab[] = [

--- a/app/epoch/[epoch]/layout.tsx
+++ b/app/epoch/[epoch]/layout.tsx
@@ -1,0 +1,10 @@
+import { EpochProvider } from '@providers/epoch';
+import { PropsWithChildren } from 'react';
+
+export default function EpochLayout({ children }: PropsWithChildren<Record<string, never>>) {
+  return (
+    <EpochProvider>
+      {children}
+    </EpochProvider>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,16 +5,9 @@ import { ClusterStatusBanner } from '@components/ClusterStatusButton';
 import { MessageBanner } from '@components/MessageBanner';
 import { Navbar } from '@components/Navbar';
 import { SearchBar } from '@components/SearchBar';
-import { AccountsProvider } from '@providers/accounts';
-import { BlockProvider } from '@providers/block';
 import { ClusterProvider } from '@providers/cluster';
-import { EpochProvider } from '@providers/epoch';
 import { MintsProvider } from '@providers/mints';
-import { RichListProvider } from '@providers/richList';
 import { ScrollAnchorProvider } from '@providers/scroll-anchor';
-import { StatsProvider } from '@providers/stats';
-import { SupplyProvider } from '@providers/supply';
-import { TransactionsProvider } from '@providers/transactions';
 import { Rubik } from 'next/font/google';
 import { Metadata } from 'next/types';
 
@@ -48,30 +41,16 @@ export default function RootLayout({
             <body>
                 <ScrollAnchorProvider>
                     <ClusterProvider>
-                        <StatsProvider>
-                            <SupplyProvider>
-                                <RichListProvider>
-                                    <AccountsProvider>
-                                        <BlockProvider>
-                                            <EpochProvider>
-                                                <MintsProvider>
-                                                    <TransactionsProvider>
-                                                        <ClusterModal />
-                                                        <div className="main-content pb-4">
-                                                            <Navbar />
-                                                            <MessageBanner />
-                                                            <ClusterStatusBanner />
-                                                            <SearchBar />
-                                                            {children}
-                                                        </div>
-                                                    </TransactionsProvider>
-                                                </MintsProvider>
-                                            </EpochProvider>
-                                        </BlockProvider>
-                                    </AccountsProvider>
-                                </RichListProvider>
-                            </SupplyProvider>
-                        </StatsProvider>
+                        <MintsProvider>
+                            <ClusterModal />
+                            <div className="main-content pb-4">
+                                <Navbar />
+                                <MessageBanner />
+                                <ClusterStatusBanner />
+                                <SearchBar />
+                                {children}
+                            </div>
+                        </MintsProvider>
                     </ClusterProvider>
                 </ScrollAnchorProvider>
                 {analytics}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,13 +10,14 @@ import { LiveTransactionStatsCard } from '@components/LiveTransactionStatsCard';
 import { StatsNotReady } from '@components/StatsNotReady';
 import { useVoteAccounts } from '@providers/accounts/vote-accounts';
 import { useCluster } from '@providers/cluster';
+import { StatsProvider } from '@providers/stats';
 import {
     ClusterStatsStatus,
     useDashboardInfo,
     usePerformanceInfo,
     useStatsProvider,
 } from '@providers/stats/solanaClusterStats';
-import { Status, useFetchSupply, useSupply } from '@providers/supply';
+import { Status, SupplyProvider, useFetchSupply, useSupply } from '@providers/supply';
 import { ClusterStatus } from '@utils/cluster';
 import { abbreviatedNumber, lamportsToSol, slotsToHumanString } from '@utils/index';
 import { percentage } from '@utils/math';
@@ -24,20 +25,24 @@ import React from 'react';
 
 export default function Page() {
     return (
-        <div className="container mt-4">
-            <StakingComponent />
-            <div className="card">
-                <div className="card-header">
-                    <div className="row align-items-center">
-                        <div className="col">
-                            <h4 className="card-header-title">Live Cluster Stats</h4>
+        <StatsProvider>
+            <SupplyProvider>
+                <div className="container mt-4">
+                    <StakingComponent />
+                    <div className="card">
+                        <div className="card-header">
+                            <div className="row align-items-center">
+                                <div className="col">
+                                    <h4 className="card-header-title">Live Cluster Stats</h4>
+                                </div>
+                            </div>
                         </div>
+                        <StatsCardBody />
                     </div>
+                    <LiveTransactionStatsCard />
                 </div>
-                <StatsCardBody />
-            </div>
-            <LiveTransactionStatsCard />
-        </div>
+            </SupplyProvider>
+        </StatsProvider>
     );
 }
 

--- a/app/supply/layout.tsx
+++ b/app/supply/layout.tsx
@@ -1,0 +1,13 @@
+import { RichListProvider } from '@providers/richList';
+import { SupplyProvider } from '@providers/supply';
+import { PropsWithChildren } from 'react';
+
+export default function SupplyLayout({ children }: PropsWithChildren<Record<string, never>>) {
+  return (
+    <SupplyProvider>
+      <RichListProvider>
+        {children}
+      </RichListProvider>
+    </SupplyProvider>
+  );
+}

--- a/app/tx/layout.tsx
+++ b/app/tx/layout.tsx
@@ -1,0 +1,10 @@
+import { TransactionsProvider } from '@providers/transactions';
+import { PropsWithChildren } from 'react';
+
+export default function TxLayout({ children }: PropsWithChildren<Record<string, never>>) {
+  return (
+    <TransactionsProvider>
+      {children}
+    </TransactionsProvider>
+  );
+}


### PR DESCRIPTION
This PR refactors the root layout to remove most providers, and moves those providers into page-specific layouts. Most providers were only providing functionality used by a single page. This should reduce the amount of code/dependencies on all pages, and also make it easier to refactor pages + providers. I suspect that many of these providers should just be flat data fetching functions and not wrapping pages at all, but this small PR gets us most of the benefit without any major refactoring.

Moved providers:

- `StatsProvider` moves to home page
- `SupplyProvider` moves to home page + supply page
- `RichListProvider` moves to supply page
- `AccountsProvider` moves to address page
- `BlockProvider` moves to block page
- `EpochProvider` moves to epoch page
- `TransactionsProvider` moves to transaction page

Remaining providers in root layout:

- `ScrollAnchorProvider` is used in multiple pages + has no major dependencies
- `ClusterProvider` is used everywhere + makes sense to have shared with ~everything
- `MintsProvider` is used in a few places including the shared search bar