### PR TITLE
chore: update to pnpm 8.6.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install package manager
         uses: pnpm/action-setup@v2
         with:
-          version: 8.2.0
+          version: 8.6.6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   cross-fetch: ^3.1.5


### PR DESCRIPTION
In particular, start using lockfiles v6.1.