### PR TITLE
Refactor MintsProvider to remove web3js dependency

### DIFF
--- a/app/components/ClusterModal.tsx
+++ b/app/components/ClusterModal.tsx
@@ -3,7 +3,6 @@
 import { useCluster, useClusterModal, useUpdateCustomUrl } from '@providers/cluster';
 import { useDebounceCallback } from '@react-hook/debounce';
 import { Cluster, clusterName, CLUSTERS, clusterSlug, ClusterStatus } from '@utils/cluster';
-import { assertUnreachable } from '@utils/index';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -80,6 +79,10 @@ function CustomClusterInput({ activeSuffix, active }: InputProps) {
             )}
         </>
     );
+}
+
+function assertUnreachable(_x: never): never {
+    throw new Error('Unreachable!');
 }
 
 function ClusterToggle() {

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -16,10 +16,6 @@ export type SignatureProps = {
     signature: TransactionSignature;
 };
 
-export function assertUnreachable(_x: never): never {
-    throw new Error('Unreachable!');
-}
-
 export function normalizeTokenAmount(raw: string | number, decimals: number): number {
     let rawTokens: number;
     if (typeof raw === 'string') rawTokens = parseInt(raw);


### PR DESCRIPTION
Note: Merge after #267 (this PR builds on that)
Actual diff: https://github.com/solana-labs/explorer/compare/1f5128679ff182b4d1c75ca5d6062b8523286ff2...mcintyre94:explorer:mints-provider-refactor 

This PR refactors out the `MintsProvider` provider that was used on all pages. This provider was just a wrapper for 2 other providers:

- `TokenRegistryProvider` remains in the root layout. It didn't have any web3js dependency so is just copied as-is to a new provider
- `LargestAccountsProvider` is only used for the `address/[address]/largest` route. It's removed from the root layout and now only used on that page. Refactoring it to use experimental web3js is blocked by https://github.com/solana-labs/solana-web3.js/pull/1390 but as it's no longer on the homepage path there's no rush there 

The PR also refactors `ClusterModal` to remove its web3js dependency, by inlining a utils function that only it was using 