### PR TITLE
Add missing TransactionsProvider to address/tokens page

### DIFF
--- a/app/address/[address]/tokens/page.tsx
+++ b/app/address/[address]/tokens/page.tsx
@@ -3,6 +3,8 @@ import { TokenHistoryCard } from '@components/account/TokenHistoryCard';
 import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
 import { Metadata } from 'next/types';
 
+import { TransactionsProvider } from '@/app/providers/transactions';
+
 type Props = Readonly<{
     params: {
         address: string;
@@ -18,9 +20,9 @@ export async function generateMetadata(props: AddressPageMetadataProps): Promise
 
 export default function OwnedTokensPage({ params: { address } }: Props) {
     return (
-        <>
+        <TransactionsProvider>
             <OwnedTokensCard address={address} />
             <TokenHistoryCard address={address} />
-        </>
+        </TransactionsProvider>
     );
 }

--- a/app/providers/transactions/index.tsx
+++ b/app/providers/transactions/index.tsx
@@ -123,14 +123,6 @@ export async function fetchTransactionStatus(
     });
 }
 
-export function useTransactions() {
-    const context = React.useContext(StateContext);
-    if (!context) {
-        throw new Error(`useTransactions must be used within a TransactionsProvider`);
-    }
-    return context;
-}
-
 export function useTransactionStatus(
     signature: TransactionSignature | undefined
 ): Cache.CacheEntry<TransactionStatus> | undefined {


### PR DESCRIPTION
This is required for the TokenHistoryCard

Fixes #274 