### PR TITLE
Replace browserslist with supports bigint

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,14 @@
     "prettier": "@solana/prettier-config-solana",
     "browserslist": {
         "production": [
-            ">0.2%",
-            "not dead",
+            ">0.2% and supports bigint and not dead",
             "not op_mini all"
         ],
         "development": [
             "last 1 chrome version",
             "last 1 firefox version",
-            "last 1 safari version"
+            "last 1 safari version",
+            "supports bigint"
         ]
     },
     "pnpm": {


### PR DESCRIPTION
- Currently `2n ** n` is being compiled incorrectly to `Math.pow(2, n)`. This doesn't work where n is a bigint. In practice this has broken the genesis epoch page
- I don't know if we need to use different browserslist configs for dev and production?
- Testing just "supports bigint and not dead" in Vercel prod environment 