### PR TITLE
fix: check UTL verifiedness of tokens before showing spoof warning banner

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -42,7 +42,7 @@ import { redirect, useSelectedLayoutSegment } from 'next/navigation';
 import React, { PropsWithChildren } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
-import { FullLegacyTokenInfo, getFullTokenInfo } from '@/app/utils/token-info';
+import { FullTokenInfo, getFullTokenInfo } from '@/app/utils/token-info';
 
 const IDENTICON_WIDTH = 64;
 
@@ -203,7 +203,7 @@ export default function AddressLayout({ children, params }: Props) {
     );
 }
 
-function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { address: string; account?: Account, tokenInfo?: FullLegacyTokenInfo, isTokenInfoLoading: boolean }) {
+function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { address: string; account?: Account, tokenInfo?: FullTokenInfo, isTokenInfoLoading: boolean }) {
     const mintInfo = useMintAccountInfo(address);
 
     const parsedData = account?.data.parsed;
@@ -230,7 +230,9 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
                 logoURI: parsedData?.nftData?.json?.image,
                 name: parsedData?.nftData?.json?.name ?? parsedData?.nftData.metadata.data.name,
             };
-            unverified = true;
+            if (!tokenInfo?.verified) {
+                unverified = true;
+            }
         } else if (tokenInfo) {
             token = tokenInfo;
         }
@@ -292,7 +294,7 @@ function DetailsSections({
     pubkey: PublicKey;
     tab?: string;
     info?: CacheEntry<Account>;
-    tokenInfo?: FullLegacyTokenInfo;
+    tokenInfo?: FullTokenInfo;
     isTokenInfoLoading: boolean;
 }) {
     const fetchAccount = useFetchAccountInfo();
@@ -320,7 +322,7 @@ function DetailsSections({
     );
 }
 
-function InfoSection({ account, tokenInfo }: { account: Account, tokenInfo?: FullLegacyTokenInfo }) {
+function InfoSection({ account, tokenInfo }: { account: Account, tokenInfo?: FullTokenInfo }) {
     const parsedData = account.data.parsed;
     const rawData = account.data.raw;
 


### PR DESCRIPTION
  fix: check UTL verifiedness of tokens before showing spoof warning banner
  
  # Summary
  
  The UTL provides a `verfied` property. Let's not show a token name/icon spoof warning banner unless that property is `false`.
  
  
  # Test Plan
  
  <img width="635" alt="image" src="https://github.com/solana-labs/explorer/assets/13243/6c194129-c67c-4116-b324-1b837128fe8c">
  
  http://localhost:3000/address/2VhjJ9WxaGC3EZFwJG9BDUs9KxKCAjQY4vgd1qxgYWVg/transfers
  
  <img width="621" alt="image" src="https://github.com/solana-labs/explorer/assets/13243/6415b372-f9dc-4e40-ba88-850b9883b04e">
  
  http://localhost:3000/address/DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263
  
  <img width="662" alt="image" src="https://github.com/solana-labs/explorer/assets/13243/60a0befd-ca8f-49dd-9b42-7ec3a283dbcb">
  
  http://localhost:3000/address/FASTAr1in6u53vykPbCuFTUZnGdiLJrXaTEQ7UAArdBm