### PR TITLE
Only show CoinGecko information on Mainnet

### DIFF
--- a/app/utils/coingecko.tsx
+++ b/app/utils/coingecko.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import useTabVisibility from 'use-tab-visibility';
 
+import { useCluster } from '../providers/cluster';
+import { Cluster } from './cluster';
+
 const PRICE_REFRESH = 10000;
 
 export enum CoingeckoStatus {
@@ -43,6 +46,7 @@ export type CoinGeckoResult = {
 };
 
 export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
+    const { cluster } = useCluster()
     const [coinInfo, setCoinInfo] = React.useState<CoinGeckoResult>();
     const { visible: isTabVisible } = useTabVisibility();
     React.useEffect(() => {
@@ -50,6 +54,9 @@ export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
             return;
         }
         if (!isTabVisible) {
+            return;
+        }
+        if (cluster !== Cluster.MainnetBeta) {
             return;
         }
         let interval: NodeJS.Timeout | undefined;
@@ -64,14 +71,14 @@ export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
                 try {
                     const response = await fetch(
                         `https://api.coingecko.com/api/v3/coins/${coinId}?` +
-                            [
-                                'community_data=false',
-                                'developer_data=false',
-                                'localization=false',
-                                'market_data=true',
-                                'sparkline=false',
-                                'tickers=false',
-                            ].join('&')
+                        [
+                            'community_data=false',
+                            'developer_data=false',
+                            'localization=false',
+                            'market_data=true',
+                            'sparkline=false',
+                            'tickers=false',
+                        ].join('&')
                     );
                     if (stale) {
                         return;
@@ -106,7 +113,7 @@ export function useCoinGecko(coinId?: string): CoinGeckoResult | undefined {
             }
             stale = true;
         };
-    }, [coinId, isTabVisible]);
+    }, [coinId, isTabVisible, cluster]);
 
     return coinInfo;
 }


### PR DESCRIPTION
I often use a USDC-on-devnet coin in workshops, which I guess has a CoinGecko ID 
I think it's a bit weird that the CoinGecko data shows when I look at that coin on Explorer on Devnet
This PR changes `useCoinGecko` to only fetch and return data on Mainnet