### PR TITLE
Updating the canonical reference for the Memo program

### DIFF
--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -18,8 +18,8 @@ export enum PROGRAM_NAMES {
     ACCOUNT_COMPRESSION = 'State Compression Program',
     FEATURE_PROPOSAL = 'Feature Proposal Program',
     LENDING = 'Lending Program',
+    MEMO_1 = 'Memo Program v1',
     MEMO = 'Memo Program',
-    MEMO_2 = 'Memo Program v2',
     NAME = 'Name Service Program',
     STAKE_POOL = 'Stake Pool Program',
     SWAP = 'Swap Program',
@@ -277,11 +277,11 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     },
     Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo: {
         deployments: ALL_CLUSTERS,
-        name: PROGRAM_NAMES.MEMO,
+        name: PROGRAM_NAMES.MEMO_1,
     },
     MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr: {
         deployments: ALL_CLUSTERS,
-        name: PROGRAM_NAMES.MEMO_2,
+        name: PROGRAM_NAMES.MEMO,
     },
     Port7uDYB3wk6GJAw4KT1WpTeMtSu9bTcChBHkX2LfR: {
         deployments: [Cluster.MainnetBeta],


### PR DESCRIPTION
The legacy version of the Memo program (`Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo`) is referred to as Memo v1,
whereas the latest version of the Memo program (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`) is more canonically known simply as `Memo`: https://spl.solana.com/memo

came up in the context of an upcoming wallet integration which noted that the newer version of the Memo program isn't prototypically referred to as Memo v2 but just Memo