### PR TITLE
Eliminate `PublicKey` from `isAddressLookupTableAccount`

### DIFF
--- a/app/address/[address]/entries/page-client.tsx
+++ b/app/address/[address]/entries/page-client.tsx
@@ -4,6 +4,7 @@ import { LookupTableEntriesCard } from '@components/account/address-lookup-table
 import { isAddressLookupTableAccount } from '@components/account/address-lookup-table/types';
 import { ParsedAccountRenderer } from '@components/account/ParsedAccountRenderer';
 import React from 'react';
+import { Base58EncodedAddress } from 'web3js-experimental';
 
 type Props = Readonly<{
     params: {
@@ -19,7 +20,7 @@ function AddressLookupTableEntriesRenderer({
     const rawData = account?.data.raw;
     if (parsedData && parsedData.program === 'address-lookup-table' && parsedData.parsed.type === 'lookupTable') {
         return <LookupTableEntriesCard parsedLookupTable={parsedData.parsed.info} />;
-    } else if (rawData && isAddressLookupTableAccount(account.owner, rawData)) {
+    } else if (rawData && isAddressLookupTableAccount(account.owner.toBase58() as Base58EncodedAddress, rawData)) {
         return <LookupTableEntriesCard lookupTableAccountData={rawData} />;
     } else {
         return onNotFound();

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -41,6 +41,7 @@ import Link from 'next/link';
 import { redirect, useSelectedLayoutSegment } from 'next/navigation';
 import React, { PropsWithChildren } from 'react';
 import useSWRImmutable from 'swr/immutable';
+import { Base58EncodedAddress } from 'web3js-experimental';
 
 import { FullTokenInfo, getFullTokenInfo } from '@/app/utils/token-info';
 
@@ -361,7 +362,7 @@ function InfoSection({ account, tokenInfo }: { account: Account, tokenInfo?: Ful
         parsedData.parsed.type === 'lookupTable'
     ) {
         return <AddressLookupTableAccountSection account={account} lookupTableAccount={parsedData.parsed.info} />;
-    } else if (rawData && isAddressLookupTableAccount(account.owner, rawData)) {
+    } else if (rawData && isAddressLookupTableAccount(account.owner.toBase58() as Base58EncodedAddress, rawData)) {
         return <AddressLookupTableAccountSection account={account} data={rawData} />;
     } else if (account.owner.toBase58() === FEATURE_PROGRAM_ID) {
         return <FeatureAccountSection account={account} />;
@@ -441,7 +442,7 @@ function getTabs(pubkey: PublicKey, account: Account): TabComponent[] {
     }
 
     // Add the key for address lookup tables
-    if (account.data.raw && isAddressLookupTableAccount(account.owner, account.data.raw)) {
+    if (account.data.raw && isAddressLookupTableAccount(account.owner.toBase58() as Base58EncodedAddress, account.data.raw)) {
         tabs.push(...TABS_LOOKUP['address-lookup-table']);
     }
 

--- a/app/components/account/address-lookup-table/types.ts
+++ b/app/components/account/address-lookup-table/types.ts
@@ -1,10 +1,11 @@
-import { PublicKey } from '@solana/web3.js';
+import { Base58EncodedAddress } from 'web3js-experimental';
 
-const PROGRAM_ID = 'AddressLookupTab1e1111111111111111111111111';
+const LOOKUP_TABLE_ACCOUNT_TYPE = 1;
+const PROGRAM_ID =
+    'AddressLookupTab1e1111111111111111111111111' as Base58EncodedAddress<'AddressLookupTab1e1111111111111111111111111'>;
 
-export function isAddressLookupTableAccount(accountOwner: PublicKey, accountData: Uint8Array): boolean {
-    if (accountOwner.toBase58() !== PROGRAM_ID) return false;
+export function isAddressLookupTableAccount(accountOwner: Base58EncodedAddress, accountData: Uint8Array): boolean {
+    if (accountOwner !== PROGRAM_ID) return false;
     if (!accountData || accountData.length === 0) return false;
-    const LOOKUP_TABLE_ACCOUNT_TYPE = 1;
     return accountData[0] === LOOKUP_TABLE_ACCOUNT_TYPE;
 }


### PR DESCRIPTION
We don't need an entire `PublicKey` instance just to assert on the address of the owner.

# Test Plan

1. Visit https://explorer-git-10-18-overrideavsctov577onnpm-solana-labs.vercel.app/address/DnXcJm7zT3cWYXTUaf9Mww2Q12EEwuuU5LtvQzV8ZvzQ/entries?cluster=devnet

Observe table entries are there.