### PR TITLE
Integrate basic token-2022 support

### DIFF
--- a/app/address/[address]/attributes/page-client.tsx
+++ b/app/address/[address]/attributes/page-client.tsx
@@ -2,6 +2,7 @@
 
 import { MetaplexNFTAttributesCard } from '@components/account/MetaplexNFTAttributesCard';
 import { ParsedAccountRenderer } from '@components/account/ParsedAccountRenderer';
+import { isTokenProgramData } from '@providers/accounts';
 import React from 'react';
 
 type Props = Readonly<{
@@ -15,7 +16,7 @@ function MetaplexNFTAttributesCardRenderer({
     onNotFound,
 }: React.ComponentProps<React.ComponentProps<typeof ParsedAccountRenderer>['renderComponent']>) {
     const parsedData = account?.data?.parsed;
-    if (!parsedData || parsedData.program !== 'spl-token' || parsedData.parsed.type !== 'mint' || !parsedData.nftData) {
+    if (!parsedData || !isTokenProgramData(parsedData) || parsedData.parsed.type !== 'mint' || !parsedData.nftData) {
         return onNotFound();
     }
     return <MetaplexNFTAttributesCard nftData={parsedData.nftData} />;

--- a/app/address/[address]/metadata/page-client.tsx
+++ b/app/address/[address]/metadata/page-client.tsx
@@ -2,6 +2,7 @@
 
 import { MetaplexMetadataCard } from '@components/account/MetaplexMetadataCard';
 import { ParsedAccountRenderer } from '@components/account/ParsedAccountRenderer';
+import { isTokenProgramData } from '@providers/accounts';
 import React from 'react';
 
 type Props = Readonly<{
@@ -15,7 +16,7 @@ function MetaplexMetadataCardRenderer({
     onNotFound,
 }: React.ComponentProps<React.ComponentProps<typeof ParsedAccountRenderer>['renderComponent']>) {
     const parsedData = account?.data?.parsed;
-    if (!parsedData || parsedData.program !== 'spl-token' || parsedData.parsed.type !== 'mint' || !parsedData.nftData) {
+    if (!parsedData || !isTokenProgramData(parsedData) || parsedData.parsed.type !== 'mint' || !parsedData.nftData) {
         return onNotFound();
     }
     return <MetaplexMetadataCard nftData={parsedData.nftData} />;

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -3,6 +3,7 @@ import { Copyable } from '@components/common/Copyable';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { TableCardBody } from '@components/common/TableCardBody';
 import { Account, NFTData, TokenProgramData, useFetchAccountInfo } from '@providers/accounts';
+import { TOKEN_2022_PROGRAM_ID } from '@providers/accounts/tokens';
 import isMetaplexNFT from '@providers/accounts/utils/isMetaplexNFT';
 import { useCluster } from '@providers/cluster';
 import { PublicKey } from '@solana/web3.js';
@@ -151,7 +152,7 @@ function FungibleTokenMintAccountCard({ account, mintInfo, tokenInfo }: { accoun
             <div className="card">
                 <div className="card-header">
                     <h3 className="card-header-title mb-0 d-flex align-items-center">
-                        {tokenInfo ? 'Overview' : 'Token Mint'}
+                        {tokenInfo ? 'Overview' : account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58() ? 'Token-2022 Mint' : 'Token Mint'}
                     </h3>
                     <button className="btn btn-white btn-sm" onClick={refresh}>
                         <RefreshCw className="align-text-top me-2" size={13} />
@@ -370,7 +371,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
     return (
         <div className="card">
             <div className="card-header">
-                <h3 className="card-header-title mb-0 d-flex align-items-center">Token Account</h3>
+                <h3 className="card-header-title mb-0 d-flex align-items-center">Token{ account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58() && "-2022" } Account</h3>
                 <button className="btn btn-white btn-sm" onClick={() => refresh(account.pubkey, 'parsed')}>
                     <RefreshCw className="align-text-top me-2" size={13} />
                     Refresh

--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -14,7 +14,7 @@ import {
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
 import { isTokenProgramData } from '@providers/accounts';
 import { useAccountHistories, useFetchAccountHistory } from '@providers/accounts/history';
-import { TOKEN_PROGRAM_ID, TokenInfoWithPubkey, useAccountOwnedTokens } from '@providers/accounts/tokens';
+import { isTokenProgramId, TokenInfoWithPubkey, useAccountOwnedTokens } from '@providers/accounts/tokens';
 import { CacheEntry, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Details, useFetchTransactionDetails, useTransactionDetailsCache } from '@providers/transactions/parsed';
@@ -426,7 +426,7 @@ const TokenTransactionRow = React.memo(function TokenTransactionRow({
                         return undefined;
                     }
                 } else {
-                    if (ix.accounts.findIndex(account => account.equals(TOKEN_PROGRAM_ID)) >= 0) {
+                    if (ix.accounts.findIndex(account => isTokenProgramId(account)) >= 0) {
                         name = 'Unknown (Inner)';
                     } else {
                         return undefined;

--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -12,6 +12,7 @@ import {
     parseTokenLendingInstructionTitle,
 } from '@components/instruction/token-lending/types';
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
+import { isTokenProgramData } from '@providers/accounts';
 import { useAccountHistories, useFetchAccountHistory } from '@providers/accounts/history';
 import { TOKEN_PROGRAM_ID, TokenInfoWithPubkey, useAccountOwnedTokens } from '@providers/accounts/tokens';
 import { CacheEntry, FetchStatus } from '@providers/cache';
@@ -391,7 +392,7 @@ const TokenTransactionRow = React.memo(function TokenTransactionRow({
                 }
 
                 if ('parsed' in ix) {
-                    if (ix.program === 'spl-token') {
+                    if (isTokenProgramData(ix)) {
                         name = getTokenProgramInstructionName(ix, tx);
                     } else {
                         return undefined;
@@ -476,7 +477,7 @@ function InstructionDetails({ instructionType, tx }: { instructionType: Instruct
 
     const instructionTypes = instructionType.innerInstructions
         .map(ix => {
-            if ('parsed' in ix && ix.program === 'spl-token') {
+            if ('parsed' in ix && isTokenProgramData(ix)) {
                 return getTokenProgramInstructionName(ix, tx);
             }
             return undefined;

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -5,7 +5,7 @@ import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Signature } from '@components/common/Signature';
 import { TokenInstructionType, Transfer, TransferChecked } from '@components/instruction/token/types';
-import { useAccountHistory } from '@providers/accounts';
+import { isTokenProgramData, useAccountHistory } from '@providers/accounts';
 import { useFetchAccountHistory } from '@providers/accounts/history';
 import { FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
@@ -218,7 +218,7 @@ function getTransfer(
     cluster: Cluster,
     signature: string
 ): Transfer | TransferChecked | undefined {
-    if ('parsed' in instruction && instruction.program === 'spl-token') {
+    if ('parsed' in instruction && isTokenProgramData(instruction)) {
         try {
             const { type: rawType } = instruction.parsed;
             const type = create(rawType, TokenInstructionType);

--- a/app/components/common/InstructionDetails.tsx
+++ b/app/components/common/InstructionDetails.tsx
@@ -1,3 +1,4 @@
+import { isTokenProgramData } from '@providers/accounts';
 import { ConfirmedSignatureInfo } from '@solana/web3.js';
 import { getTokenProgramInstructionName, InstructionType } from '@utils/instruction';
 import React from 'react';
@@ -14,7 +15,7 @@ export function InstructionDetails({
 
     const instructionTypes = instructionType.innerInstructions
         .map(ix => {
-            if ('parsed' in ix && ix.program === 'spl-token') {
+            if ('parsed' in ix && isTokenProgramData(ix)) {
                 return getTokenProgramInstructionName(ix, tx);
             }
             return undefined;

--- a/app/components/instruction/token/TokenDetailsCard.tsx
+++ b/app/components/instruction/token/TokenDetailsCard.tsx
@@ -9,6 +9,7 @@ import useSWR from 'swr';
 
 import { useCluster } from '@/app/providers/cluster';
 import { Cluster } from '@/app/utils/cluster';
+import { TOKEN_IDS } from '@/app/utils/programs';
 import { getTokenInfo, getTokenInfoSwrKey } from '@/app/utils/token-info';
 
 import { InstructionCard } from '../InstructionCard';
@@ -27,7 +28,7 @@ export function TokenDetailsCard(props: DetailsProps) {
     const parsed = create(props.ix.parsed, ParsedInfo);
     const { type: rawType, info } = parsed;
     const type = create(rawType, TokenInstructionType);
-    const title = `Token Program: ${IX_TITLES[type]}`;
+    const title = `${TOKEN_IDS[props.ix.programId.toString()]}: ${IX_TITLES[type]}`;
     const created = create(info, IX_STRUCTS[type] as any);
     return <TokenInstruction title={title} info={created} {...props} />;
 }

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { pubkeyToString } from '@utils/index';
+import { assertIsTokenProgram, TokenProgram } from '@utils/programs';
 import { ParsedAddressLookupTableAccount } from '@validators/accounts/address-lookup-table';
 import { ConfigAccount } from '@validators/accounts/config';
 import { NonceAccount } from '@validators/accounts/nonce';
@@ -57,8 +58,16 @@ export type NFTData = {
     editionInfo: EditionInfo;
 };
 
+export function isTokenProgramData(data: { program: string }): data is TokenProgramData {
+    try {
+        assertIsTokenProgram(data.program);
+        return true;
+    } catch(e) {
+        return false;
+    }
+}
 export type TokenProgramData = {
-    program: 'spl-token';
+    program: TokenProgram;
     parsed: TokenAccount;
     nftData?: NFTData;
 };
@@ -374,7 +383,8 @@ async function handleParsedAccountData(
             };
         }
 
-        case 'spl-token': {
+        case 'spl-token':
+        case 'spl-token-2022': {
             const parsed = create(info, TokenAccount);
             let nftData;
 
@@ -484,7 +494,7 @@ export function useMintAccountInfo(address: string | undefined): MintAccountInfo
         try {
             const parsedData = account.data.parsed;
             if (!parsedData) return;
-            if (parsedData.program !== 'spl-token' || parsedData.parsed.type !== 'mint') {
+            if (!isTokenProgramData(parsedData) || parsedData.parsed.type !== 'mint') {
                 return;
             }
 
@@ -504,7 +514,7 @@ export function useTokenAccountInfo(address: string | undefined): TokenAccountIn
         try {
             const parsedData = account.data.parsed;
             if (!parsedData) return;
-            if (parsedData.program !== 'spl-token' || parsedData.parsed.type !== 'account') {
+            if (!isTokenProgramData(parsedData) || parsedData.parsed.type !== 'account') {
                 return;
             }
 

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -46,6 +46,10 @@ export function TokensProvider({ children }: ProviderProps) {
 }
 
 export const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+export const TOKEN_2022_PROGRAM_ID = new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+export function isTokenProgramId(programId: PublicKey) {
+    return programId.equals(TOKEN_PROGRAM_ID) || programId.equals(TOKEN_2022_PROGRAM_ID);
+}
 
 async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster: Cluster, url: string) {
     const key = pubkey.toBase58();
@@ -59,11 +63,14 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
     let status;
     let data;
     try {
-        const { value } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
+        const { value: tokenAccounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
             programId: TOKEN_PROGRAM_ID,
         });
+        const { value: token2022Accounts } = await new Connection(url, 'processed').getParsedTokenAccountsByOwner(pubkey, {
+            programId: TOKEN_2022_PROGRAM_ID,
+        });
 
-        const tokens: TokenInfoWithPubkey[] = value.slice(0, 101).map(accountInfo => {
+        const tokens: TokenInfoWithPubkey[] = tokenAccounts.concat(token2022Accounts).slice(0, 101).map(accountInfo => {
             const parsedInfo = accountInfo.account.data.parsed.info;
             const info = create(parsedInfo, TokenAccountInfo);
             return { info, pubkey: accountInfo.pubkey };

--- a/app/providers/accounts/utils/isMetaplexNFT.ts
+++ b/app/providers/accounts/utils/isMetaplexNFT.ts
@@ -1,16 +1,17 @@
 import { MintAccountInfo } from '@validators/accounts/token';
 
-import { ParsedData, TokenProgramData } from '..';
+import { isTokenProgramData, ParsedData, TokenProgramData } from '..';
 
 export default function isMetaplexNFT(
     parsedData?: ParsedData,
     mintInfo?: MintAccountInfo
 ): parsedData is TokenProgramData {
     return !!(
-        parsedData?.program === 'spl-token' &&
-        parsedData?.parsed.type === 'mint' &&
-        parsedData?.nftData &&
+        parsedData &&
+        isTokenProgramData(parsedData) &&
+        parsedData.parsed.type === 'mint' &&
+        parsedData.nftData &&
         mintInfo?.decimals === 0 &&
-        (parseInt(mintInfo.supply) === 1 || parsedData?.nftData.metadata.tokenStandard === 1)
+        (parseInt(mintInfo.supply) === 1 || parsedData.nftData.metadata.tokenStandard === 1)
     );
 }

--- a/app/utils/instruction.ts
+++ b/app/utils/instruction.ts
@@ -12,6 +12,7 @@ import {
     ParsedTransactionWithMeta,
     PartiallyDecodedInstruction,
 } from '@solana/web3.js';
+import { isTokenProgram } from '@utils/programs';
 import { intoTransactionInstruction } from '@utils/tx';
 import { ParsedInfo } from '@validators/index';
 import { create } from 'superstruct';
@@ -82,7 +83,7 @@ export function getTokenInstructionName(
     }
 
     if ('parsed' in ix) {
-        if (ix.program === 'spl-token') {
+        if (isTokenProgram(ix.program)) {
             return getTokenProgramInstructionName(ix, signatureInfo);
         } else {
             return undefined;

--- a/app/utils/instruction.ts
+++ b/app/utils/instruction.ts
@@ -5,7 +5,7 @@ import {
     parseTokenLendingInstructionTitle,
 } from '@components/instruction/token-lending/types';
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
-import { TOKEN_PROGRAM_ID } from '@providers/accounts/tokens';
+import { isTokenProgramId } from '@providers/accounts/tokens';
 import {
     ConfirmedSignatureInfo,
     ParsedInstruction,
@@ -105,7 +105,7 @@ export function getTokenInstructionName(
         }
     }
 
-    if (ix.accounts.findIndex(account => account.equals(TOKEN_PROGRAM_ID)) >= 0) {
+    if (ix.accounts.findIndex(account => isTokenProgramId(account)) >= 0) {
         name = 'Unknown (Inner)';
     } else {
         return undefined;

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -24,6 +24,7 @@ export enum PROGRAM_NAMES {
     STAKE_POOL = 'Stake Pool Program',
     SWAP = 'Swap Program',
     TOKEN = 'Token Program',
+    TOKEN_2022 = 'Token-2022 Program',
     TOKEN_METADATA = 'Token Metadata Program',
     TOKEN_VAULT = 'Token Vault Program',
 
@@ -343,6 +344,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
         deployments: ALL_CLUSTERS,
         name: PROGRAM_NAMES.TOKEN,
     },
+    TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb: {
+        deployments: ALL_CLUSTERS,
+        name: PROGRAM_NAMES.TOKEN_2022,
+    },
     Vote111111111111111111111111111111111111111: {
         deployments: ALL_CLUSTERS,
         name: PROGRAM_NAMES.VOTE,
@@ -434,3 +439,21 @@ export const SYSVAR_IDS: { [key: string]: string } = {
     SysvarS1otHistory11111111111111111111111111: 'Sysvar: Slot History',
     SysvarStakeHistory1111111111111111111111111: 'Sysvar: Stake History',
 };
+
+export const TOKEN_IDS: { [key: string]: string } = {
+  TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA: 'Token Program',
+  TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb: 'Token-2022 Program',
+} as const;
+
+export type TokenProgram = 'spl-token' | 'spl-token-2022';
+export function assertIsTokenProgram(program: string): asserts program is TokenProgram {
+    if (program !== 'spl-token' && program !== 'spl-token-2022') throw new Error("Expected token program name of `spl-token` or `spl-token-2022`");
+}
+export function isTokenProgram(program: string): program is TokenProgram {
+    try {
+        assertIsTokenProgram(program);
+        return true;
+    } catch(e) {
+        return false;
+    }
+}


### PR DESCRIPTION
#### Problem

Token-2022 has been around for awhile, but the explorer still has no knowledge of it!

#### Summary of changes

This is really just basic support, and it was done in a pretty simple manner:

* look for instances of `"spl-token"`, which is the program name returned from JSON-parsed encoding, and make sure that it also supports `"spl-token-2022"`
* look for instances of `TOKEN_PROGRAM_ID`, and make sure that it also supports `TOKEN_2022_PROGRAM_ID`

So in the end, accounts and mints are properly displayed, and the additional token-2022 accounts are fetched too.

There is no parsing of extensions included in this PR, but it can certainly be done in follow-up work.