### PR TITLE
token-account: Show delegate and delegated amount

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -426,24 +426,24 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                     </tr>
                 )}
                 {info.delegate && (
-                    <tr>
-                        <td>Delegate</td>
-                        <td className="text-lg-end">
-                            <Address pubkey={info.delegate} alignRight link />
-                        </td>
-                    </tr>
-                )}
-                {info.delegatedAmount && (
-                    <tr>
-                        <td>Delegated amount {typeof symbol === 'string' && `(${symbol})`}</td>
-                        <td className="text-lg-end">
-                            {info.isNative ? (
-                                <>
-                                    {'\u25ce'}<span className="font-monospace">{new BigNumber(info.delegatedAmount.uiAmountString).toFormat(9)}</span>
-                                </>
-                            ) : <>{info.delegatedAmount.uiAmountString}</>}
-                        </td>
-                    </tr>
+                    <>
+                        <tr>
+                            <td>Delegate</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={info.delegate} alignRight link />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Delegated amount {typeof symbol === 'string' && `(${symbol})`}</td>
+                            <td className="text-lg-end">
+                                {info.isNative ? (
+                                    <>
+                                        {'\u25ce'}<span className="font-monospace">{new BigNumber(info.delegatedAmount ? info.delegatedAmount.uiAmountString : "0").toFormat(9)}</span>
+                                    </>
+                                ) : <>{info.delegatedAmount ? info.delegatedAmount.uiAmountString : "0"}</>}
+                            </td>
+                        </tr>
+                    </>
                 )}
             </TableCardBody>
         </div>

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -425,6 +425,26 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                         </td>
                     </tr>
                 )}
+                {info.delegate && (
+                    <tr>
+                        <td>Delegate</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={info.delegate} alignRight link />
+                        </td>
+                    </tr>
+                )}
+                {info.delegatedAmount && (
+                    <tr>
+                        <td>Delegated amount {typeof symbol === 'string' && `(${symbol})`}</td>
+                        <td className="text-lg-end">
+                            {info.isNative ? (
+                                <>
+                                    {'\u25ce'}<span className="font-monospace">{new BigNumber(info.delegatedAmount.uiAmountString).toFormat(9)}</span>
+                                </>
+                            ) : <>{info.delegatedAmount.uiAmountString}</>}
+                        </td>
+                    </tr>
+                )}
             </TableCardBody>
         </div>
     );


### PR DESCRIPTION
#### Problem

Token accounts can have delegates with delegated amounts, but the explorer doesn't show that information.

#### Solution

Also show them!

Here's a wrapped SOL version:

![image](https://github.com/solana-labs/explorer/assets/934662/df4661f0-0324-4681-84be-4f4ea0f308da)

And a normal token version:

![image](https://github.com/solana-labs/explorer/assets/934662/0bf19a6f-8f1f-4da3-9f2e-7be90406825e)
