### PR TITLE
token-2022: Show all extensions

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -1017,7 +1017,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
             const extension = create(tokenExtension.state, TransferHookAccount);
             return (
                 <tr>
-                    <td>Transfer Hook Account</td>
+                    <td>Transfer Hook Status</td>
                     <td className="text-lg-end">{!extension.transferring && 'not '}transferring</td>
                 </tr>
             );

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -13,7 +13,7 @@ import { displayTimestampWithoutDate } from '@utils/date';
 import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
-import { MintCloseAuthority, TokenExtension } from '@validators/accounts/token-extension';
+import { MintCloseAuthority, TokenExtension, TransferFeeAmount } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
 import { ExternalLink, RefreshCw } from 'react-feather';
@@ -549,7 +549,19 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 return <></>;
             }
         }
-        case 'transferFeeAmount':
+        case 'transferFeeAmount': {
+            const extension = create(tokenExtension.state, TransferFeeAmount);
+            return (
+                <tr>
+                    <td>Withheld Amount</td>
+                    <td className="text-lg-end">
+                        {normalizeTokenAmount(extension.withheldAmount, mintInfo.decimals).toLocaleString('en-US', {
+                            maximumFractionDigits: 20,
+                        })}
+                    </td>
+                </tr>
+            );
+        }
         case 'transferFeeConfig':
         case 'confidentialTransferMint':
         case 'confidentialTransferAccount':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -13,7 +13,12 @@ import { displayTimestampWithoutDate } from '@utils/date';
 import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
-import { MintCloseAuthority, TokenExtension, TransferFeeAmount } from '@validators/accounts/token-extension';
+import {
+    MintCloseAuthority,
+    TokenExtension,
+    TransferFeeConfig,
+    TransferFeeAmount,
+} from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
 import { ExternalLink, RefreshCw } from 'react-feather';
@@ -562,7 +567,78 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </tr>
             );
         }
-        case 'transferFeeConfig':
+        case 'transferFeeConfig': {
+            const extension = create(tokenExtension.state, TransferFeeConfig);
+            return (
+                <>
+                    <tr>
+                        <h4>Transfer Fee Config</h4>
+                    </tr>
+                    {extension.transferFeeConfigAuthority && (
+                        <tr>
+                            <td>Transfer Fee Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.transferFeeConfigAuthority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Older Fee Epoch</td>
+                        <td className="text-lg-end">{extension.olderTransferFee.epoch}</td>
+                    </tr>
+                    <tr>
+                        <td>Older Maximum Fee</td>
+                        <td className="text-lg-end">
+                            {normalizeTokenAmount(
+                                extension.olderTransferFee.maximumFee,
+                                mintInfo.decimals
+                            ).toLocaleString('en-US', {
+                                maximumFractionDigits: 20,
+                            })}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Older Fee Basis Points</td>
+                        <td className="text-lg-end">{extension.olderTransferFee.transferFeeBasisPoints}</td>
+                    </tr>
+                    <tr>
+                        <td>Newer Fee Epoch</td>
+                        <td className="text-lg-end">{extension.newerTransferFee.epoch}</td>
+                    </tr>
+                    <tr>
+                        <td>Newer Maximum Fee</td>
+                        <td className="text-lg-end">
+                            {normalizeTokenAmount(
+                                extension.newerTransferFee.maximumFee,
+                                mintInfo.decimals
+                            ).toLocaleString('en-US', {
+                                maximumFractionDigits: 20,
+                            })}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Newer Fee Basis Points</td>
+                        <td className="text-lg-end">{extension.newerTransferFee.transferFeeBasisPoints}</td>
+                    </tr>
+                    {extension.withdrawWithheldAuthority && (
+                        <tr>
+                            <td>Withdraw Withheld Fees Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.withdrawWithheldAuthority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Withheld Amount</td>
+                        <td className="text-lg-end">
+                            {normalizeTokenAmount(extension.withheldAmount, mintInfo.decimals).toLocaleString('en-US', {
+                                maximumFractionDigits: 20,
+                            })}
+                        </td>
+                    </tr>
+                </>
+            );
+        }
         case 'confidentialTransferMint':
         case 'confidentialTransferAccount':
         case 'defaultAccountState':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -13,6 +13,7 @@ import { displayTimestampWithoutDate } from '@utils/date';
 import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
+import { TokenExtension } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
 import { ExternalLink, RefreshCw } from 'react-feather';
@@ -255,6 +256,7 @@ function FungibleTokenMintAccountCard({
                             </td>
                         </tr>
                     )}
+                    {mintInfo.extensions?.map(extension => TokenExtensionRows(mintInfo, extension))}
                 </TableCardBody>
             </div>
         </>
@@ -528,4 +530,40 @@ function MultisigAccountCard({ account, info }: { account: Account; info: Multis
             </TableCardBody>
         </div>
     );
+}
+
+function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExtension) {
+    switch (tokenExtension.extension) {
+        case 'mintCloseAuthority':
+        case 'transferFeeAmount':
+        case 'transferFeeConfig':
+        case 'confidentialTransferMint':
+        case 'confidentialTransferAccount':
+        case 'defaultAccountState':
+        case 'immutableOwner':
+        case 'memoTransfer':
+        case 'nonTransferable':
+        case 'interestBearingConfig':
+        case 'cpiGuard':
+        case 'permanentDelegate':
+        case 'nonTransferableAccount':
+        case 'confidentialTransferFeeConfig':
+        case 'confidentialTransferFeeAmount':
+        case 'transferHook':
+        case 'transferHookAccount':
+        case 'metadataPointer':
+        case 'tokenMetadata':
+        case 'groupPointer':
+        case 'groupMemberPointer':
+        case 'tokenGroup':
+        case 'tokenGroupMember':
+        case 'unparseableExtension':
+        default:
+            return (
+                <tr>
+                    <td>Extension</td>
+                    <td className="text-lg-end">Unparseable</td>
+                </tr>
+            );
+    }
 }

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -24,6 +24,7 @@ import {
     MintCloseAuthority,
     PermanentDelegate,
     TokenExtension,
+    TokenMetadata,
     TransferFeeConfig,
     TransferFeeAmount,
     TransferHook,
@@ -803,7 +804,7 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 <>
                     {extension.metadataAddress && (
                         <tr>
-                            <td>Token Metadata Address</td>
+                            <td>Metadata Address</td>
                             <td className="text-lg-end">
                                 <Address pubkey={extension.metadataAddress} alignRight link />
                             </td>
@@ -866,7 +867,53 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'tokenMetadata':
+        case 'tokenMetadata': {
+            const extension = create(tokenExtension.state, TokenMetadata);
+            return (
+                <>
+                    <tr>
+                        <h4>Metadata</h4>
+                    </tr>
+                    <tr>
+                        <td>Mint address</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.mint} alignRight link />
+                        </td>
+                    </tr>
+                    {extension.updateAuthority && (
+                        <tr>
+                            <td>Update Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.updateAuthority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Name</td>
+                        <td className="text-lg-end">{extension.name}</td>
+                    </tr>
+                    <tr>
+                        <td>Symbol</td>
+                        <td className="text-lg-end">{extension.symbol}</td>
+                    </tr>
+                    <tr>
+                        <td>URI</td>
+                        <td className="text-lg-end">
+                            <a rel="noopener noreferrer" target="_blank" href={extension.uri}>
+                                {extension.uri}
+                                <ExternalLink className="align-text-top ms-2" size={13} />
+                            </a>
+                        </td>
+                    </tr>
+                    {extension.additionalMetadata?.map(keyValuePair => (
+                        <tr key="{keyValuePair[0]}">
+                            <td>{keyValuePair[0]}</td>
+                            <td className="text-lg-end">{keyValuePair[1]}</td>
+                        </tr>
+                    ))}
+                </>
+            );
+        }
         case 'tokenGroup':
         case 'tokenGroupMember':
         case 'cpiGuard':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -14,6 +14,7 @@ import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
 import {
+    ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     MintCloseAuthority,
     TokenExtension,
@@ -668,7 +669,38 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'confidentialTransferFeeConfig':
+        case 'confidentialTransferFeeConfig': {
+            const extension = create(tokenExtension.state, ConfidentialTransferFeeConfig);
+            return (
+                <>
+                    <tr>
+                        <h4>Confidential Transfer Fee</h4>
+                    </tr>
+                    {extension.authority && (
+                        <tr>
+                            <td>Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.withdrawWithheldAuthorityElgamalPubkey && (
+                        <tr>
+                            <td>Auditor Elgamal Pubkey</td>
+                            <td className="text-lg-end">{extension.withdrawWithheldAuthorityElgamalPubkey}</td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Harvest to Mint</td>
+                        <td className="text-lg-end">{extension.harvestToMintEnabled ? 'enabled' : 'disabled'}</td>
+                    </tr>
+                    <tr>
+                        <td>Withheld Amount</td>
+                        <td className="text-lg-end">{extension.withheldAmount}</td>
+                    </tr>
+                </>
+            );
+        }
         case 'defaultAccountState':
         case 'nonTransferable':
         case 'interestBearingConfig':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -711,7 +711,14 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </tr>
             );
         }
-        case 'nonTransferable':
+        case 'nonTransferable': {
+            return (
+                <tr>
+                    <td>Non-Transferable</td>
+                    <td className="text-lg-end">enabled</td>
+                </tr>
+            );
+        }
         case 'interestBearingConfig':
         case 'permanentDelegate':
         case 'transferHook':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -9,7 +9,7 @@ import { useCluster } from '@providers/cluster';
 import { PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { CoingeckoStatus, useCoinGecko } from '@utils/coingecko';
-import { displayTimestampWithoutDate } from '@utils/date';
+import { displayTimestamp, displayTimestampWithoutDate } from '@utils/date';
 import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
@@ -757,11 +757,11 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                     </tr>
                     <tr>
                         <td>Last Update Timestamp</td>
-                        <td className="text-lg-end">{extension.lastUpdateTimestamp}</td>
+                        <td className="text-lg-end">{displayTimestamp(extension.lastUpdateTimestamp * 1000)}</td>
                     </tr>
                     <tr>
                         <td>Initialization Timestamp</td>
-                        <td className="text-lg-end">{extension.initializationTimestamp}</td>
+                        <td className="text-lg-end">{displayTimestamp(extension.initializationTimestamp * 1000)}</td>
                     </tr>
                 </>
             );

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -911,12 +911,19 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                             </a>
                         </td>
                     </tr>
-                    {extension.additionalMetadata?.map(keyValuePair => (
-                        <tr key="{keyValuePair[0]}">
-                            <td>{keyValuePair[0]}</td>
-                            <td className="text-lg-end">{keyValuePair[1]}</td>
-                        </tr>
-                    ))}
+                    {extension.additionalMetadata?.length > 0 && (
+                        <>
+                            <tr>
+                                <h5>Additional Metadata</h5>
+                            </tr>
+                            {extension.additionalMetadata?.map(keyValuePair => (
+                                <tr key="{keyValuePair[0]}">
+                                    <td>{keyValuePair[0]}</td>
+                                    <td className="text-lg-end">{keyValuePair[1]}</td>
+                                </tr>
+                            ))}
+                        </>
+                    )}
                 </>
             );
         }

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -17,6 +17,7 @@ import {
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     DefaultAccountState,
+    InterestBearingConfig,
     MintCloseAuthority,
     TokenExtension,
     TransferFeeConfig,
@@ -719,7 +720,40 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </tr>
             );
         }
-        case 'interestBearingConfig':
+        case 'interestBearingConfig': {
+            const extension = create(tokenExtension.state, InterestBearingConfig);
+            return (
+                <>
+                    <tr>
+                        <h4>Interest-Bearing</h4>
+                    </tr>
+                    {extension.rateAuthority && (
+                        <tr>
+                            <td>Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.rateAuthority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Current Rate Basis Points</td>
+                        <td className="text-lg-end">{extension.currentRate}</td>
+                    </tr>
+                    <tr>
+                        <td>Pre-Current Average Rate</td>
+                        <td className="text-lg-end">{extension.preUpdateAverageRate}</td>
+                    </tr>
+                    <tr>
+                        <td>Last Update Timestamp</td>
+                        <td className="text-lg-end">{extension.lastUpdateTimestamp}</td>
+                    </tr>
+                    <tr>
+                        <td>Initialization Timestamp</td>
+                        <td className="text-lg-end">{extension.initializationTimestamp}</td>
+                    </tr>
+                </>
+            );
+        }
         case 'permanentDelegate':
         case 'transferHook':
         case 'metadataPointer':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -14,6 +14,7 @@ import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
 import {
+    ConfidentialTransferMint,
     MintCloseAuthority,
     TokenExtension,
     TransferFeeConfig,
@@ -639,7 +640,34 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'confidentialTransferMint':
+        case 'confidentialTransferMint': {
+            const extension = create(tokenExtension.state, ConfidentialTransferMint);
+            return (
+                <>
+                    <tr>
+                        <h4>Confidential Transfer</h4>
+                    </tr>
+                    {extension.authority && (
+                        <tr>
+                            <td>Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.auditorElgamalPubkey && (
+                        <tr>
+                            <td>Auditor Elgamal Pubkey</td>
+                            <td className="text-lg-end">{extension.auditorElgamalPubkey}</td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>New Account Approval Policy</td>
+                        <td className="text-lg-end">{extension.autoApproveNewAccounts ? 'auto' : 'manual'}</td>
+                    </tr>
+                </>
+            );
+        }
         case 'confidentialTransferAccount':
         case 'defaultAccountState':
         case 'immutableOwner':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -13,7 +13,7 @@ import { displayTimestampWithoutDate } from '@utils/date';
 import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
-import { TokenExtension } from '@validators/accounts/token-extension';
+import { MintCloseAuthority, TokenExtension } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
 import { ExternalLink, RefreshCw } from 'react-feather';
@@ -534,7 +534,21 @@ function MultisigAccountCard({ account, info }: { account: Account; info: Multis
 
 function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExtension) {
     switch (tokenExtension.extension) {
-        case 'mintCloseAuthority':
+        case 'mintCloseAuthority': {
+            const extension = create(tokenExtension.state, MintCloseAuthority);
+            if (extension.closeAuthority) {
+                return (
+                    <tr>
+                        <td>Close Authority</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.closeAuthority} alignRight link />
+                        </td>
+                    </tr>
+                );
+            } else {
+                return <></>;
+            }
+        }
         case 'transferFeeAmount':
         case 'transferFeeConfig':
         case 'confidentialTransferMint':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -16,6 +16,7 @@ import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } 
 import {
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
+    CpiGuard,
     DefaultAccountState,
     GroupMemberPointer,
     GroupPointer,
@@ -600,12 +601,12 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                     <tr>
                         <td>Older Maximum Fee</td>
                         <td className="text-lg-end">
-                            {normalizeTokenAmount(
-                                extension.olderTransferFee.maximumFee,
-                                decimals
-                            ).toLocaleString('en-US', {
-                                maximumFractionDigits: 20,
-                            })}
+                            {normalizeTokenAmount(extension.olderTransferFee.maximumFee, decimals).toLocaleString(
+                                'en-US',
+                                {
+                                    maximumFractionDigits: 20,
+                                }
+                            )}
                         </td>
                     </tr>
                     <tr>
@@ -619,12 +620,12 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                     <tr>
                         <td>Newer Maximum Fee</td>
                         <td className="text-lg-end">
-                            {normalizeTokenAmount(
-                                extension.newerTransferFee.maximumFee,
-                                decimals
-                            ).toLocaleString('en-US', {
-                                maximumFractionDigits: 20,
-                            })}
+                            {normalizeTokenAmount(extension.newerTransferFee.maximumFee, decimals).toLocaleString(
+                                'en-US',
+                                {
+                                    maximumFractionDigits: 20,
+                                }
+                            )}
                         </td>
                     </tr>
                     <tr>
@@ -915,7 +916,15 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </>
             );
         }
-        case 'cpiGuard':
+        case 'cpiGuard': {
+            const extension = create(tokenExtension.state, CpiGuard);
+            return (
+                <tr>
+                    <td>CPI Guard</td>
+                    <td className="text-lg-end">{extension.lockCpi ? 'enabled' : 'disabled'}</td>
+                </tr>
+            );
+        }
         case 'confidentialTransferAccount':
         case 'immutableOwner':
         case 'memoTransfer':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -23,6 +23,7 @@ import {
     TokenExtension,
     TransferFeeConfig,
     TransferFeeAmount,
+    TransferHook,
 } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
@@ -770,7 +771,29 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 return <></>;
             }
         }
-        case 'transferHook':
+        case 'transferHook': {
+            const extension = create(tokenExtension.state, TransferHook);
+            return (
+                <>
+                    {extension.programId && (
+                        <tr>
+                            <td>Transfer Hook Program Id</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.programId} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.authority && (
+                        <tr>
+                            <td>Transfer Hook Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                </>
+            );
+        }
         case 'metadataPointer':
         case 'tokenMetadata':
         case 'groupPointer':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -16,6 +16,7 @@ import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } 
 import {
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
+    DefaultAccountState,
     MintCloseAuthority,
     TokenExtension,
     TransferFeeConfig,
@@ -701,7 +702,15 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'defaultAccountState':
+        case 'defaultAccountState': {
+            const extension = create(tokenExtension.state, DefaultAccountState);
+            return (
+                <tr>
+                    <td>DefaultAccountState</td>
+                    <td className="text-lg-end">{extension.accountState}</td>
+                </tr>
+            );
+        }
         case 'nonTransferable':
         case 'interestBearingConfig':
         case 'permanentDelegate':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -15,6 +15,7 @@ import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
 import {
     ConfidentialTransferAccount,
+    ConfidentialTransferFeeAmount,
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     CpiGuard,
@@ -1022,7 +1023,15 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'confidentialTransferFeeAmount':
+        case 'confidentialTransferFeeAmount': {
+            const extension = create(tokenExtension.state, ConfidentialTransferFeeAmount);
+            return (
+                <tr>
+                    <td>Confidential Withheld Amount</td>
+                    <td className="text-lg-end">{extension.withheldAmount}</td>
+                </tr>
+            );
+        }
         case 'tokenGroup':
         case 'tokenGroupMember':
         case 'unparseableExtension':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -601,10 +601,11 @@ function cmpExtension(a: TokenExtension, b: TokenExtension) {
 
 function TokenExtensionRows(
     tokenExtension: TokenExtension,
-    epoch: bigint,
+    maybeEpoch: bigint | undefined,
     decimals: number,
     symbol: string | undefined
 ) {
+    const epoch = maybeEpoch || 0n; // fallback to 0 if not provided
     switch (tokenExtension.extension) {
         case 'mintCloseAuthority': {
             const extension = create(tokenExtension.state, MintCloseAuthority);

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -122,6 +122,8 @@ function FungibleTokenMintAccountCard({
     const assetContractAddress = getEthAddress(tokenInfo?.extensions?.assetContract);
 
     const coinInfo = useCoinGecko(tokenInfo?.extensions?.coingeckoId);
+    const mintExtensions = mintInfo.extensions?.slice();
+    mintExtensions?.sort(cmpExtension);
 
     let tokenPriceInfo;
     let tokenPriceDecimals = 2;
@@ -278,7 +280,7 @@ function FungibleTokenMintAccountCard({
                             </td>
                         </tr>
                     )}
-                    {mintInfo.extensions?.map(extension =>
+                    {mintExtensions?.map(extension =>
                         TokenExtensionRows(extension, epoch, mintInfo.decimals, tokenInfo?.symbol)
                     )}
                 </TableCardBody>
@@ -400,6 +402,8 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
     const swrKey = useMemo(() => getTokenInfoSwrKey(info.mint.toString(), cluster, url), [cluster, url]);
     const { data: tokenInfo } = useSWR(swrKey, fetchTokenInfo);
     const [symbol, setSymbol] = useState<string | undefined>(undefined);
+    const accountExtensions = info.extensions?.slice();
+    accountExtensions?.sort(cmpExtension);
 
     const balance = info.isNative ? (
         <>
@@ -505,7 +509,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                         </tr>
                     </>
                 )}
-                {info.extensions?.map(extension =>
+                {accountExtensions?.map(extension =>
                     TokenExtensionRows(extension, epoch, info.tokenAmount.decimals, symbol)
                 )}
             </TableCardBody>
@@ -558,6 +562,39 @@ function MultisigAccountCard({ account, info }: { account: Account; info: Multis
             </TableCardBody>
         </div>
     );
+}
+
+function cmpExtension(a: TokenExtension, b: TokenExtension) {
+    // be sure that extensions with a header row always come later
+    const sortedExtensionTypes = [
+        'transferFeeAmount',
+        'mintCloseAuthority',
+        'defaultAccountState',
+        'immutableOwner',
+        'memoTransfer',
+        'nonTransferable',
+        'nonTransferableAccount',
+        'cpiGuard',
+        'permanentDelegate',
+        'transferHook',
+        'transferHookAccount',
+        'metadataPointer',
+        'groupPointer',
+        'groupMemberPointer',
+        // everything below this comment includes a header row
+        'confidentialTransferAccount',
+        'confidentialTransferFeeConfig',
+        'confidentialTransferFeeAmount',
+        'confidentialTransferMint',
+        'interestBearingConfig',
+        'transferFeeConfig',
+        'tokenGroup',
+        'tokenGroupMember',
+        'tokenMetadata',
+        // always keep this last
+        'unparseableExtension',
+    ];
+    return sortedExtensionTypes.indexOf(a.extension) - sortedExtensionTypes.indexOf(b.extension);
 }
 
 function TokenExtensionRows(

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -19,6 +19,7 @@ import {
     DefaultAccountState,
     InterestBearingConfig,
     MintCloseAuthority,
+    PermanentDelegate,
     TokenExtension,
     TransferFeeConfig,
     TransferFeeAmount,
@@ -754,7 +755,21 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'permanentDelegate':
+        case 'permanentDelegate': {
+            const extension = create(tokenExtension.state, PermanentDelegate);
+            if (extension.delegate) {
+                return (
+                    <tr>
+                        <td>Permanent Delegate</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.delegate} alignRight link />
+                        </td>
+                    </tr>
+                );
+            } else {
+                return <></>;
+            }
+        }
         case 'transferHook':
         case 'metadataPointer':
         case 'tokenMetadata':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -17,16 +17,16 @@ import {
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     DefaultAccountState,
-    GroupPointer,
     GroupMemberPointer,
+    GroupPointer,
     InterestBearingConfig,
     MetadataPointer,
     MintCloseAuthority,
     PermanentDelegate,
     TokenExtension,
     TokenMetadata,
-    TransferFeeConfig,
     TransferFeeAmount,
+    TransferFeeConfig,
     TransferHook,
 } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
@@ -271,7 +271,7 @@ function FungibleTokenMintAccountCard({
                             </td>
                         </tr>
                     )}
-                    {mintInfo.extensions?.map(extension => TokenExtensionRows(mintInfo, extension))}
+                    {mintInfo.extensions?.map(extension => TokenExtensionRows(mintInfo.decimals, extension))}
                 </TableCardBody>
             </div>
         </>
@@ -495,6 +495,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                         </tr>
                     </>
                 )}
+                {info.extensions?.map(extension => TokenExtensionRows(info.tokenAmount.decimals, extension))}
             </TableCardBody>
         </div>
     );
@@ -547,7 +548,7 @@ function MultisigAccountCard({ account, info }: { account: Account; info: Multis
     );
 }
 
-function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExtension) {
+function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
     switch (tokenExtension.extension) {
         case 'mintCloseAuthority': {
             const extension = create(tokenExtension.state, MintCloseAuthority);
@@ -570,7 +571,7 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 <tr>
                     <td>Withheld Amount</td>
                     <td className="text-lg-end">
-                        {normalizeTokenAmount(extension.withheldAmount, mintInfo.decimals).toLocaleString('en-US', {
+                        {normalizeTokenAmount(extension.withheldAmount, decimals).toLocaleString('en-US', {
                             maximumFractionDigits: 20,
                         })}
                     </td>
@@ -601,7 +602,7 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                         <td className="text-lg-end">
                             {normalizeTokenAmount(
                                 extension.olderTransferFee.maximumFee,
-                                mintInfo.decimals
+                                decimals
                             ).toLocaleString('en-US', {
                                 maximumFractionDigits: 20,
                             })}
@@ -620,7 +621,7 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                         <td className="text-lg-end">
                             {normalizeTokenAmount(
                                 extension.newerTransferFee.maximumFee,
-                                mintInfo.decimals
+                                decimals
                             ).toLocaleString('en-US', {
                                 maximumFractionDigits: 20,
                             })}
@@ -641,7 +642,7 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                     <tr>
                         <td>Withheld Amount</td>
                         <td className="text-lg-end">
-                            {normalizeTokenAmount(extension.withheldAmount, mintInfo.decimals).toLocaleString('en-US', {
+                            {normalizeTokenAmount(extension.withheldAmount, decimals).toLocaleString('en-US', {
                                 maximumFractionDigits: 20,
                             })}
                         </td>
@@ -914,8 +915,6 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'tokenGroup':
-        case 'tokenGroupMember':
         case 'cpiGuard':
         case 'confidentialTransferAccount':
         case 'immutableOwner':
@@ -923,6 +922,8 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
         case 'transferHookAccount':
         case 'nonTransferableAccount':
         case 'confidentialTransferFeeAmount':
+        case 'tokenGroup':
+        case 'tokenGroupMember':
         case 'unparseableExtension':
         default:
             return (

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -17,7 +17,10 @@ import {
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     DefaultAccountState,
+    GroupPointer,
+    GroupMemberPointer,
     InterestBearingConfig,
+    MetadataPointer,
     MintCloseAuthority,
     PermanentDelegate,
     TokenExtension,
@@ -794,10 +797,76 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'metadataPointer':
+        case 'metadataPointer': {
+            const extension = create(tokenExtension.state, MetadataPointer);
+            return (
+                <>
+                    {extension.metadataAddress && (
+                        <tr>
+                            <td>Token Metadata Address</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.metadataAddress} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.authority && (
+                        <tr>
+                            <td>Metadata Pointer Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                </>
+            );
+        }
+        case 'groupPointer': {
+            const extension = create(tokenExtension.state, GroupPointer);
+            return (
+                <>
+                    {extension.groupAddress && (
+                        <tr>
+                            <td>Token Group Address</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.groupAddress} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.authority && (
+                        <tr>
+                            <td>Group Pointer Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                </>
+            );
+        }
+        case 'groupMemberPointer': {
+            const extension = create(tokenExtension.state, GroupMemberPointer);
+            return (
+                <>
+                    {extension.memberAddress && (
+                        <tr>
+                            <td>Token Group Member Address</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.memberAddress} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    {extension.authority && (
+                        <tr>
+                            <td>Member Pointer Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.authority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                </>
+            );
+        }
         case 'tokenMetadata':
-        case 'groupPointer':
-        case 'groupMemberPointer':
         case 'tokenGroup':
         case 'tokenGroupMember':
         case 'cpiGuard':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -31,6 +31,7 @@ import {
     TransferFeeAmount,
     TransferFeeConfig,
     TransferHook,
+    TransferHookAccount,
 } from '@validators/accounts/token-extension';
 import { BigNumber } from 'bignumber.js';
 import { useEffect, useMemo, useState } from 'react';
@@ -936,7 +937,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                     </tr>
                     <tr>
                         <td>Status</td>
-                        <td className="text-lg-end">{!extension.approved ?? 'not '}approved</td>
+                        <td className="text-lg-end">{!extension.approved && 'not '}approved</td>
                     </tr>
                     <tr>
                         <td>Elgamal Pubkey</td>
@@ -1004,7 +1005,15 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'transferHookAccount':
+        case 'transferHookAccount': {
+            const extension = create(tokenExtension.state, TransferHookAccount);
+            return (
+                <tr>
+                    <td>Transfer Hook Account</td>
+                    <td className="text-lg-end">{!extension.transferring && 'not '}transferring</td>
+                </tr>
+            );
+        }
         case 'nonTransferableAccount':
         case 'confidentialTransferFeeAmount':
         case 'tokenGroup':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -14,6 +14,7 @@ import { abbreviatedNumber, normalizeTokenAmount } from '@utils/index';
 import { addressLabel } from '@utils/tx';
 import { MintAccountInfo, MultisigAccountInfo, TokenAccount, TokenAccountInfo } from '@validators/accounts/token';
 import {
+    ConfidentialTransferAccount,
     ConfidentialTransferFeeConfig,
     ConfidentialTransferMint,
     CpiGuard,
@@ -925,7 +926,66 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'confidentialTransferAccount':
+        case 'confidentialTransferAccount': {
+            const extension = create(tokenExtension.state, ConfidentialTransferAccount);
+            return (
+                <>
+                    <tr>
+                        <h4>Confidential Transfer</h4>
+                    </tr>
+                    <tr>
+                        <td>Status</td>
+                        <td className="text-lg-end">{!extension.approved ?? 'not '}approved</td>
+                    </tr>
+                    <tr>
+                        <td>Elgamal Pubkey</td>
+                        <td className="text-lg-end">{extension.elgamalPubkey}</td>
+                    </tr>
+                    <tr>
+                        <td>Confidential Credits</td>
+                        <td className="text-lg-end">{extension.allowConfidentialCredits ? 'enabled' : 'disabled'}</td>
+                    </tr>
+                    <tr>
+                        <td>Non-confidential Credits</td>
+                        <td className="text-lg-end">
+                            {extension.allowNonConfidentialCredits ? 'enabled' : 'disabled'}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Available Balance</td>
+                        <td className="text-lg-end">{extension.availableBalance}</td>
+                    </tr>
+                    <tr>
+                        <td>Decryptable Available Balance</td>
+                        <td className="text-lg-end">{extension.decryptableAvailableBalance}</td>
+                    </tr>
+                    <tr>
+                        <td>Pending Balance, Low Bits</td>
+                        <td className="text-lg-end">{extension.pendingBalanceLo}</td>
+                    </tr>
+                    <tr>
+                        <td>Pending Balance, High Bits</td>
+                        <td className="text-lg-end">{extension.pendingBalanceHi}</td>
+                    </tr>
+                    <tr>
+                        <td>Pending Balance Credit Counter</td>
+                        <td className="text-lg-end">{extension.pendingBalanceCreditCounter}</td>
+                    </tr>
+                    <tr>
+                        <td>Expected Pending Balance Credit Counter</td>
+                        <td className="text-lg-end">{extension.expectedPendingBalanceCreditCounter}</td>
+                    </tr>
+                    <tr>
+                        <td>Actual Pending Balance Credit Counter</td>
+                        <td className="text-lg-end">{extension.actualPendingBalanceCreditCounter}</td>
+                    </tr>
+                    <tr>
+                        <td>Maximum Pending Balance Credit Counter</td>
+                        <td className="text-lg-end">{extension.maximumPendingBalanceCreditCounter}</td>
+                    </tr>
+                </>
+            );
+        }
         case 'immutableOwner':
         case 'memoTransfer':
         case 'transferHookAccount':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -36,7 +36,15 @@ const getEthAddress = (link?: string) => {
     return address;
 };
 
-export function TokenAccountSection({ account, tokenAccount, tokenInfo }: { account: Account; tokenAccount: TokenAccount, tokenInfo?: FullLegacyTokenInfo }) {
+export function TokenAccountSection({
+    account,
+    tokenAccount,
+    tokenInfo,
+}: {
+    account: Account;
+    tokenAccount: TokenAccount;
+    tokenInfo?: FullLegacyTokenInfo;
+}) {
     const { cluster } = useCluster();
 
     try {
@@ -75,7 +83,15 @@ export function TokenAccountSection({ account, tokenAccount, tokenInfo }: { acco
     return <UnknownAccountCard account={account} />;
 }
 
-function FungibleTokenMintAccountCard({ account, mintInfo, tokenInfo }: { account: Account; mintInfo: MintAccountInfo, tokenInfo?: FullLegacyTokenInfo }) {
+function FungibleTokenMintAccountCard({
+    account,
+    mintInfo,
+    tokenInfo,
+}: {
+    account: Account;
+    mintInfo: MintAccountInfo;
+    tokenInfo?: FullLegacyTokenInfo;
+}) {
     const fetchInfo = useFetchAccountInfo();
     const refresh = () => fetchInfo(account.pubkey, 'parsed');
 
@@ -152,7 +168,11 @@ function FungibleTokenMintAccountCard({ account, mintInfo, tokenInfo }: { accoun
             <div className="card">
                 <div className="card-header">
                     <h3 className="card-header-title mb-0 d-flex align-items-center">
-                        {tokenInfo ? 'Overview' : account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58() ? 'Token-2022 Mint' : 'Token Mint'}
+                        {tokenInfo
+                            ? 'Overview'
+                            : account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58()
+                            ? 'Token-2022 Mint'
+                            : 'Token Mint'}
                     </h3>
                     <button className="btn btn-white btn-sm" onClick={refresh}>
                         <RefreshCw className="align-text-top me-2" size={13} />
@@ -356,22 +376,27 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
 
     const balance = info.isNative ? (
         <>
-            {'\u25ce'}<span className="font-monospace">{new BigNumber(info.tokenAmount.uiAmountString).toFormat(9)}</span>
+            {'\u25ce'}
+            <span className="font-monospace">{new BigNumber(info.tokenAmount.uiAmountString).toFormat(9)}</span>
         </>
-    ) : <>{info.tokenAmount.uiAmountString}</>;
+    ) : (
+        <>{info.tokenAmount.uiAmountString}</>
+    );
 
     useEffect(() => {
         if (info.isNative) {
             setSymbol('SOL');
         } else {
-            setSymbol(tokenInfo?.symbol)
+            setSymbol(tokenInfo?.symbol);
         }
-    }, [tokenInfo])
+    }, [tokenInfo]);
 
     return (
         <div className="card">
             <div className="card-header">
-                <h3 className="card-header-title mb-0 d-flex align-items-center">Token{ account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58() && "-2022" } Account</h3>
+                <h3 className="card-header-title mb-0 d-flex align-items-center">
+                    Token{account.owner.toBase58() === TOKEN_2022_PROGRAM_ID.toBase58() && '-2022'} Account
+                </h3>
                 <button className="btn btn-white btn-sm" onClick={() => refresh(account.pubkey, 'parsed')}>
                     <RefreshCw className="align-text-top me-2" size={13} />
                     Refresh
@@ -439,9 +464,16 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                             <td className="text-lg-end">
                                 {info.isNative ? (
                                     <>
-                                        {'\u25ce'}<span className="font-monospace">{new BigNumber(info.delegatedAmount ? info.delegatedAmount.uiAmountString : "0").toFormat(9)}</span>
+                                        {'\u25ce'}
+                                        <span className="font-monospace">
+                                            {new BigNumber(
+                                                info.delegatedAmount ? info.delegatedAmount.uiAmountString : '0'
+                                            ).toFormat(9)}
+                                        </span>
                                     </>
-                                ) : <>{info.delegatedAmount ? info.delegatedAmount.uiAmountString : "0"}</>}
+                                ) : (
+                                    <>{info.delegatedAmount ? info.delegatedAmount.uiAmountString : '0'}</>
+                                )}
                             </td>
                         </tr>
                     </>

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -1032,14 +1032,28 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'tokenGroup':
-        case 'tokenGroupMember':
+        case 'tokenGroup': {
+            return (
+                <tr>
+                    <td>Group</td>
+                    <td className="text-lg-end">unparseable</td>
+                </tr>
+            );
+        }
+        case 'tokenGroupMember': {
+            return (
+                <tr>
+                    <td>Group Member</td>
+                    <td className="text-lg-end">unparseable</td>
+                </tr>
+            );
+        }
         case 'unparseableExtension':
         default:
             return (
                 <tr>
-                    <td>Extension</td>
-                    <td className="text-lg-end">Unparseable</td>
+                    <td>Unknown Extension</td>
+                    <td className="text-lg-end">unparseable</td>
                 </tr>
             );
     }

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -276,7 +276,9 @@ function FungibleTokenMintAccountCard({
                             </td>
                         </tr>
                     )}
-                    {mintInfo.extensions?.map(extension => TokenExtensionRows(mintInfo.decimals, extension))}
+                    {mintInfo.extensions?.map(extension =>
+                        TokenExtensionRows(extension, mintInfo.decimals, tokenInfo?.symbol)
+                    )}
                 </TableCardBody>
             </div>
         </>
@@ -500,7 +502,7 @@ function TokenAccountCard({ account, info }: { account: Account; info: TokenAcco
                         </tr>
                     </>
                 )}
-                {info.extensions?.map(extension => TokenExtensionRows(info.tokenAmount.decimals, extension))}
+                {info.extensions?.map(extension => TokenExtensionRows(extension, info.tokenAmount.decimals, symbol))}
             </TableCardBody>
         </div>
     );
@@ -553,7 +555,7 @@ function MultisigAccountCard({ account, info }: { account: Account; info: Multis
     );
 }
 
-function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
+function TokenExtensionRows(tokenExtension: TokenExtension, decimals: number, symbol: string | undefined) {
     switch (tokenExtension.extension) {
         case 'mintCloseAuthority': {
             const extension = create(tokenExtension.state, MintCloseAuthority);
@@ -574,7 +576,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
             const extension = create(tokenExtension.state, TransferFeeAmount);
             return (
                 <tr>
-                    <td>Withheld Amount</td>
+                    <td>Withheld Amount {typeof symbol === 'string' && `(${symbol})`}</td>
                     <td className="text-lg-end">
                         {normalizeTokenAmount(extension.withheldAmount, decimals).toLocaleString('en-US', {
                             maximumFractionDigits: 20,
@@ -603,7 +605,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         <td className="text-lg-end">{extension.olderTransferFee.epoch}</td>
                     </tr>
                     <tr>
-                        <td>Older Maximum Fee</td>
+                        <td>Older Maximum Fee {typeof symbol === 'string' && `(${symbol})`}</td>
                         <td className="text-lg-end">
                             {normalizeTokenAmount(extension.olderTransferFee.maximumFee, decimals).toLocaleString(
                                 'en-US',
@@ -622,7 +624,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         <td className="text-lg-end">{extension.newerTransferFee.epoch}</td>
                     </tr>
                     <tr>
-                        <td>Newer Maximum Fee</td>
+                        <td>Newer Maximum Fee {typeof symbol === 'string' && `(${symbol})`}</td>
                         <td className="text-lg-end">
                             {normalizeTokenAmount(extension.newerTransferFee.maximumFee, decimals).toLocaleString(
                                 'en-US',
@@ -645,7 +647,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         </tr>
                     )}
                     <tr>
-                        <td>Withheld Amount</td>
+                        <td>Withheld Amount {typeof symbol === 'string' && `(${symbol})`}</td>
                         <td className="text-lg-end">
                             {normalizeTokenAmount(extension.withheldAmount, decimals).toLocaleString('en-US', {
                                 maximumFractionDigits: 20,
@@ -709,7 +711,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         <td className="text-lg-end">{extension.harvestToMintEnabled ? 'enabled' : 'disabled'}</td>
                     </tr>
                     <tr>
-                        <td>Withheld Amount</td>
+                        <td>Encrypted Withheld Amount {typeof symbol === 'string' && `(${symbol})`}</td>
                         <td className="text-lg-end">{extension.withheldAmount}</td>
                     </tr>
                 </>
@@ -1034,7 +1036,7 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
             const extension = create(tokenExtension.state, ConfidentialTransferFeeAmount);
             return (
                 <tr>
-                    <td>Confidential Withheld Amount</td>
+                    <td>Encrypted Withheld Amount {typeof symbol === 'string' && `(${symbol})`}</td>
                     <td className="text-lg-end">{extension.withheldAmount}</td>
                 </tr>
             );

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -614,8 +614,8 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         </td>
                     </tr>
                     <tr>
-                        <td>Older Fee Basis Points</td>
-                        <td className="text-lg-end">{extension.olderTransferFee.transferFeeBasisPoints}</td>
+                        <td>Older Fee Rate</td>
+                        <td className="text-lg-end">{`${extension.olderTransferFee.transferFeeBasisPoints / 100}%`}</td>
                     </tr>
                     <tr>
                         <td>Newer Fee Epoch</td>
@@ -633,8 +633,8 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         </td>
                     </tr>
                     <tr>
-                        <td>Newer Fee Basis Points</td>
-                        <td className="text-lg-end">{extension.newerTransferFee.transferFeeBasisPoints}</td>
+                        <td>Newer Fee Rate</td>
+                        <td className="text-lg-end">{`${extension.newerTransferFee.transferFeeBasisPoints / 100}%`}</td>
                     </tr>
                     {extension.withdrawWithheldAuthority && (
                         <tr>
@@ -748,12 +748,12 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                         </tr>
                     )}
                     <tr>
-                        <td>Current Rate Basis Points</td>
-                        <td className="text-lg-end">{extension.currentRate}</td>
+                        <td>Current Rate</td>
+                        <td className="text-lg-end">{`${extension.currentRate / 100}%`}</td>
                     </tr>
                     <tr>
                         <td>Pre-Current Average Rate</td>
-                        <td className="text-lg-end">{extension.preUpdateAverageRate}</td>
+                        <td className="text-lg-end">{`${extension.preUpdateAverageRate / 100}%`}</td>
                     </tr>
                     <tr>
                         <td>Last Update Timestamp</td>

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -668,25 +668,25 @@ function TokenExtensionRows(mintInfo: MintAccountInfo, tokenExtension: TokenExte
                 </>
             );
         }
-        case 'confidentialTransferAccount':
+        case 'confidentialTransferFeeConfig':
         case 'defaultAccountState':
-        case 'immutableOwner':
-        case 'memoTransfer':
         case 'nonTransferable':
         case 'interestBearingConfig':
-        case 'cpiGuard':
         case 'permanentDelegate':
-        case 'nonTransferableAccount':
-        case 'confidentialTransferFeeConfig':
-        case 'confidentialTransferFeeAmount':
         case 'transferHook':
-        case 'transferHookAccount':
         case 'metadataPointer':
         case 'tokenMetadata':
         case 'groupPointer':
         case 'groupMemberPointer':
         case 'tokenGroup':
         case 'tokenGroupMember':
+        case 'cpiGuard':
+        case 'confidentialTransferAccount':
+        case 'immutableOwner':
+        case 'memoTransfer':
+        case 'transferHookAccount':
+        case 'nonTransferableAccount':
+        case 'confidentialTransferFeeAmount':
         case 'unparseableExtension':
         default:
             return (

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -22,6 +22,7 @@ import {
     GroupMemberPointer,
     GroupPointer,
     InterestBearingConfig,
+    MemoTransfer,
     MetadataPointer,
     MintCloseAuthority,
     PermanentDelegate,
@@ -994,7 +995,15 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'memoTransfer':
+        case 'memoTransfer': {
+            const extension = create(tokenExtension.state, MemoTransfer);
+            return (
+                <tr>
+                    <td>Require Memo on Incoming Transfers</td>
+                    <td className="text-lg-end">{extension.requireIncomingTransferMemos ? 'enabled' : 'disabled'}</td>
+                </tr>
+            );
+        }
         case 'transferHookAccount':
         case 'nonTransferableAccount':
         case 'confidentialTransferFeeAmount':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -1014,7 +1014,14 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </tr>
             );
         }
-        case 'nonTransferableAccount':
+        case 'nonTransferableAccount': {
+            return (
+                <tr>
+                    <td>Non-Transferable</td>
+                    <td className="text-lg-end">enabled</td>
+                </tr>
+            );
+        }
         case 'confidentialTransferFeeAmount':
         case 'tokenGroup':
         case 'tokenGroupMember':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -986,7 +986,14 @@ function TokenExtensionRows(decimals: number, tokenExtension: TokenExtension) {
                 </>
             );
         }
-        case 'immutableOwner':
+        case 'immutableOwner': {
+            return (
+                <tr>
+                    <td>Immutable Owner</td>
+                    <td className="text-lg-end">enabled</td>
+                </tr>
+            );
+        }
         case 'memoTransfer':
         case 'transferHookAccount':
         case 'nonTransferableAccount':

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -28,6 +28,8 @@ import {
     MintCloseAuthority,
     PermanentDelegate,
     TokenExtension,
+    TokenGroup,
+    TokenGroupMember,
     TokenMetadata,
     TransferFeeAmount,
     TransferFeeConfig,
@@ -865,7 +867,7 @@ function TokenExtensionRows(
                 <>
                     {extension.metadataAddress && (
                         <tr>
-                            <td>Metadata Address</td>
+                            <td>Metadata</td>
                             <td className="text-lg-end">
                                 <Address pubkey={extension.metadataAddress} alignRight link />
                             </td>
@@ -888,7 +890,7 @@ function TokenExtensionRows(
                 <>
                     {extension.groupAddress && (
                         <tr>
-                            <td>Token Group Address</td>
+                            <td>Token Group</td>
                             <td className="text-lg-end">
                                 <Address pubkey={extension.groupAddress} alignRight link />
                             </td>
@@ -911,7 +913,7 @@ function TokenExtensionRows(
                 <>
                     {extension.memberAddress && (
                         <tr>
-                            <td>Token Group Member Address</td>
+                            <td>Token Group Member</td>
                             <td className="text-lg-end">
                                 <Address pubkey={extension.memberAddress} alignRight link />
                             </td>
@@ -936,7 +938,7 @@ function TokenExtensionRows(
                         <h4>Metadata</h4>
                     </tr>
                     <tr>
-                        <td>Mint address</td>
+                        <td>Mint</td>
                         <td className="text-lg-end">
                             <Address pubkey={extension.mint} alignRight link />
                         </td>
@@ -1095,19 +1097,61 @@ function TokenExtensionRows(
             );
         }
         case 'tokenGroup': {
+            const extension = create(tokenExtension.state, TokenGroup);
             return (
-                <tr>
-                    <td>Group</td>
-                    <td className="text-lg-end">unparseable</td>
-                </tr>
+                <>
+                    <tr>
+                        <h4>Group</h4>
+                    </tr>
+                    <tr>
+                        <td>Mint</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.mint} alignRight link />
+                        </td>
+                    </tr>
+                    {extension.updateAuthority && (
+                        <tr>
+                            <td>Update Authority</td>
+                            <td className="text-lg-end">
+                                <Address pubkey={extension.updateAuthority} alignRight link />
+                            </td>
+                        </tr>
+                    )}
+                    <tr>
+                        <td>Current Size</td>
+                        <td className="text-lg-end">{extension.size}</td>
+                    </tr>
+                    <tr>
+                        <td>Max Size</td>
+                        <td className="text-lg-end">{extension.maxSize}</td>
+                    </tr>
+                </>
             );
         }
         case 'tokenGroupMember': {
+            const extension = create(tokenExtension.state, TokenGroupMember);
             return (
-                <tr>
-                    <td>Group Member</td>
-                    <td className="text-lg-end">unparseable</td>
-                </tr>
+                <>
+                    <tr>
+                        <h4>Group Member</h4>
+                    </tr>
+                    <tr>
+                        <td>Mint</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.mint} alignRight link />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Group</td>
+                        <td className="text-lg-end">
+                            <Address pubkey={extension.group} alignRight link />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Member Number</td>
+                        <td className="text-lg-end">{extension.memberNumber}</td>
+                    </tr>
+                </>
             );
         }
         case 'unparseableExtension':

--- a/app/validators/accounts/token-extension.ts
+++ b/app/validators/accounts/token-extension.ts
@@ -91,7 +91,7 @@ export const ConfidentialTransferMint = type({
 export const ConfidentialTransferFeeConfig = type({
     authority: nullable(PublicKeyFromString),
     harvestToMintEnabled: boolean(),
-    withdrawWithheldAuthorityElgamalPubkey: nullable(PublicKeyFromString),
+    withdrawWithheldAuthorityElgamalPubkey: nullable(string()),
     withheldAmount: string(),
 });
 

--- a/app/validators/accounts/token-extension.ts
+++ b/app/validators/accounts/token-extension.ts
@@ -1,5 +1,5 @@
 import { PublicKeyFromString } from '@validators/pubkey';
-import { any, array, boolean, enums, Infer, number, optional, string, type } from 'superstruct';
+import { any, array, boolean, enums, Infer, nullable, number, string, type } from 'superstruct';
 
 export type TokenExtensionType = Infer<typeof ExtensionType>;
 const ExtensionType = enums([
@@ -44,8 +44,8 @@ const TransferFee = type({
 export const TransferFeeConfig = type({
     newerTransferFee: TransferFee,
     olderTransferFee: TransferFee,
-    transferFeeConfigAuthority: optional(PublicKeyFromString),
-    withdrawWithheldAuthority: optional(PublicKeyFromString),
+    transferFeeConfigAuthority: nullable(PublicKeyFromString),
+    withdrawWithheldAuthority: nullable(PublicKeyFromString),
     withheldAmount: number(),
 });
 
@@ -54,7 +54,7 @@ export const TransferFeeAmount = type({
 });
 
 export const MintCloseAuthority = type({
-    closeAuthority: optional(PublicKeyFromString),
+    closeAuthority: nullable(PublicKeyFromString),
 });
 
 const AccountState = enums(['initialized', 'frozen']);
@@ -71,7 +71,7 @@ export const CpiGuard = type({
 });
 
 export const PermanentDelegate = type({
-    delegate: optional(PublicKeyFromString),
+    delegate: nullable(PublicKeyFromString),
 });
 
 export const InterestBearingConfig = type({
@@ -79,19 +79,19 @@ export const InterestBearingConfig = type({
     initializationTimestamp: number(),
     lastUpdateTimestamp: number(),
     preUpdateAverageRate: number(),
-    rateAuthority: optional(PublicKeyFromString),
+    rateAuthority: nullable(PublicKeyFromString),
 });
 
 export const ConfidentialTransferMint = type({
-    auditorElgamalPubkey: optional(PublicKeyFromString),
-    authority: optional(PublicKeyFromString),
+    auditorElgamalPubkey: nullable(string()),
+    authority: nullable(PublicKeyFromString),
     autoApproveNewAccounts: boolean(),
 });
 
 export const ConfidentialTransferFeeConfig = type({
-    authority: optional(PublicKeyFromString),
+    authority: nullable(PublicKeyFromString),
     harvestToMintEnabled: boolean(),
-    withdrawWithheldAuthorityElgamalPubkey: optional(PublicKeyFromString),
+    withdrawWithheldAuthorityElgamalPubkey: nullable(PublicKeyFromString),
     withheldAmount: string(),
 });
 
@@ -115,8 +115,8 @@ export const ConfidentialTransferFeeAmount = type({
 });
 
 export const MetadataPointer = type({
-    authority: optional(PublicKeyFromString),
-    metadataAddress: optional(PublicKeyFromString),
+    authority: nullable(PublicKeyFromString),
+    metadataAddress: nullable(PublicKeyFromString),
 });
 
 export const TokenMetadata = type({
@@ -124,13 +124,13 @@ export const TokenMetadata = type({
     mint: PublicKeyFromString,
     name: string(),
     symbol: string(),
-    updateAuthority: optional(PublicKeyFromString),
+    updateAuthority: nullable(PublicKeyFromString),
     uri: string(),
 });
 
 export const TransferHook = type({
-    authority: optional(PublicKeyFromString),
-    programId: optional(PublicKeyFromString),
+    authority: nullable(PublicKeyFromString),
+    programId: nullable(PublicKeyFromString),
 });
 
 export const TransferHookAccount = type({
@@ -138,20 +138,20 @@ export const TransferHookAccount = type({
 });
 
 export const GroupPointer = type({
-    authority: optional(PublicKeyFromString),
-    groupAddress: optional(PublicKeyFromString),
+    authority: nullable(PublicKeyFromString),
+    groupAddress: nullable(PublicKeyFromString),
 });
 
 export const GroupMemberPointer = type({
-    authority: optional(PublicKeyFromString),
-    memberAddress: optional(PublicKeyFromString),
+    authority: nullable(PublicKeyFromString),
+    memberAddress: nullable(PublicKeyFromString),
 });
 
 export const TokenGroup = type({
     maxSize: number(),
     mint: PublicKeyFromString,
     size: number(),
-    updateAuthority: optional(PublicKeyFromString),
+    updateAuthority: nullable(PublicKeyFromString),
 });
 
 export const TokenGroupMember = type({

--- a/app/validators/accounts/token-extension.ts
+++ b/app/validators/accounts/token-extension.ts
@@ -1,0 +1,161 @@
+import { PublicKeyFromString } from '@validators/pubkey';
+import { any, array, boolean, enums, Infer, number, optional, string, type } from 'superstruct';
+
+export type TokenExtensionType = Infer<typeof ExtensionType>;
+const ExtensionType = enums([
+    'transferFeeConfig',
+    'transferFeeAmount',
+    'mintCloseAuthority',
+    'confidentialTransferMint',
+    'confidentialTransferAccount',
+    'defaultAccountState',
+    'immutableOwner',
+    'memoTransfer',
+    'nonTransferable',
+    'interestBearingConfig',
+    'cpiGuard',
+    'permanentDelegate',
+    'nonTransferableAccount',
+    'confidentialTransferFeeConfig',
+    'confidentialTransferFeeAmount',
+    'transferHook',
+    'transferHookAccount',
+    'metadataPointer',
+    'tokenMetadata',
+    'groupPointer',
+    'groupMemberPointer',
+    'tokenGroup',
+    'tokenGroupMember',
+    'unparseableExtension',
+]);
+
+export type TokenExtension = Infer<typeof TokenExtension>;
+export const TokenExtension = type({
+    extension: ExtensionType,
+    state: any(),
+});
+
+const TransferFee = type({
+    epoch: number(),
+    maximumFee: number(),
+    transferFeeBasisPoints: number(),
+});
+
+export const TransferFeeConfig = type({
+    newerTransferFee: TransferFee,
+    olderTransferFee: TransferFee,
+    transferFeeConfigAuthority: optional(PublicKeyFromString),
+    withdrawWithheldAuthority: optional(PublicKeyFromString),
+    withheldAmount: number(),
+});
+
+export const TransferFeeAmount = type({
+    withheldAmount: number(),
+});
+
+export const MintCloseAuthority = type({
+    closeAuthority: optional(PublicKeyFromString),
+});
+
+const AccountState = enums(['initialized', 'frozen']);
+export const DefaultAccountState = type({
+    accountState: AccountState,
+});
+
+export const MemoTransfer = type({
+    requireIncomingTransferMemos: boolean(),
+});
+
+export const CpiGuard = type({
+    lockCpi: boolean(),
+});
+
+export const PermanentDelegate = type({
+    delegate: optional(PublicKeyFromString),
+});
+
+export const InterestBearingConfig = type({
+    currentRate: number(),
+    initializationTimestamp: number(),
+    lastUpdateTimestamp: number(),
+    preUpdateAverageRate: number(),
+    rateAuthority: optional(PublicKeyFromString),
+});
+
+export const ConfidentialTransferMint = type({
+    auditorElgamalPubkey: optional(PublicKeyFromString),
+    authority: optional(PublicKeyFromString),
+    autoApproveNewAccounts: boolean(),
+});
+
+export const ConfidentialTransferFeeConfig = type({
+    authority: optional(PublicKeyFromString),
+    harvestToMintEnabled: boolean(),
+    withdrawWithheldAuthorityElgamalPubkey: optional(PublicKeyFromString),
+    withheldAmount: string(),
+});
+
+export const ConfidentialTransferAccount = type({
+    actualPendingBalanceCreditCounter: number(),
+    allowConfidentialCredits: boolean(),
+    allowNonConfidentialCredits: boolean(),
+    approved: boolean(),
+    availableBalance: string(),
+    decryptableAvailableBalance: string(),
+    elgamalPubkey: string(),
+    expectedPendingBalanceCreditCounter: number(),
+    maximumPendingBalanceCreditCounter: number(),
+    pendingBalanceCreditCounter: number(),
+    pendingBalanceHi: string(),
+    pendingBalanceLo: string(),
+});
+
+export const ConfidentialTransferFeeAmount = type({
+    withheldAmount: string(),
+});
+
+export const MetadataPointer = type({
+    authority: optional(PublicKeyFromString),
+    metadataAddress: optional(PublicKeyFromString),
+});
+
+export const TokenMetadata = type({
+    additionalMetadata: array(array(string())),
+    mint: PublicKeyFromString,
+    name: string(),
+    symbol: string(),
+    updateAuthority: optional(PublicKeyFromString),
+    uri: string(),
+});
+
+export const TransferHook = type({
+    authority: optional(PublicKeyFromString),
+    programId: optional(PublicKeyFromString),
+});
+
+export const TransferHookAccount = type({
+    transferring: boolean(),
+});
+
+export const GroupPointer = type({
+    authority: optional(PublicKeyFromString),
+    groupAddress: optional(PublicKeyFromString),
+});
+
+export const GroupMemberPointer = type({
+    authority: optional(PublicKeyFromString),
+    memberAddress: optional(PublicKeyFromString),
+});
+
+export const TokenGroup = type({
+    maxSize: number(),
+    mint: PublicKeyFromString,
+    size: number(),
+    updateAuthority: optional(PublicKeyFromString),
+});
+
+export const TokenGroupMember = type({
+    group: PublicKeyFromString,
+    memberNumber: number(),
+    mint: PublicKeyFromString,
+});

--- a/app/validators/accounts/token.ts
+++ b/app/validators/accounts/token.ts
@@ -21,6 +21,7 @@ export const TokenAccountInfo = type({
     closeAuthority: optional(PublicKeyFromString),
     delegate: optional(PublicKeyFromString),
     delegatedAmount: optional(TokenAmount),
+    extensions: optional(array(TokenExtension)),
     isNative: boolean(),
     mint: PublicKeyFromString,
     owner: PublicKeyFromString,

--- a/app/validators/accounts/token.ts
+++ b/app/validators/accounts/token.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 
+import { TokenExtension } from '@validators/accounts/token-extension';
 import { PublicKeyFromString } from '@validators/pubkey';
 import { any, array, boolean, enums, Infer, nullable, number, optional, string, type } from 'superstruct';
 
@@ -31,6 +32,7 @@ export const TokenAccountInfo = type({
 export type MintAccountInfo = Infer<typeof MintAccountInfo>;
 export const MintAccountInfo = type({
     decimals: number(),
+    extensions: optional(array(TokenExtension)),
     freezeAuthority: nullable(PublicKeyFromString),
     isInitialized: boolean(),
     mintAuthority: nullable(PublicKeyFromString),


### PR DESCRIPTION
#### Problem

Although the explorer has some support of token-2022, it doesn't show any mint or account extensions, which leads to a lot of confusion for people who create mints.

#### Solution

Everything is provided with JSON-parsed encoding, so:

* create types for all of the JSON-parsed returns
* show each extension

For the most part, each commit corresponds to an extension, except otherwise noted. I wasn't sure about the best way to display all of these, especially those with many fields, so I went with a little header line before showing each field. Let me know what you think of that.

Here are some screenshots of a mint with every extension (minus token group, group member, group pointer, and member pointer):

![image](https://github.com/solana-labs/explorer/assets/934662/7a1e46b5-acb7-49c4-ac50-5a1e647197c3)

![image](https://github.com/solana-labs/explorer/assets/934662/b5a4fb6f-1de1-4708-892f-dc7a2dd1feb2)

![image](https://github.com/solana-labs/explorer/assets/934662/b956f391-3665-4e57-9ba3-4a7a2e69afc1)

And an account with all extensions:

![image](https://github.com/solana-labs/explorer/assets/934662/62d738ec-1aa8-4d14-b41e-acd462e9020e)

![image](https://github.com/solana-labs/explorer/assets/934662/9967e50e-5bd4-43a3-947c-c79ee112d920)

And in case you care, here's how you can create your own mega-token:

```
set -ex
solana-keygen -o mint.json --no-passphrase
mint=$(solana-keygen pubkey mint.json)
solana-keygen -o source.json --no-passphrase
source_pubkey=$(solana-keygen pubkey source.json)
spl-token -ul \
  create-token \
  --enable-close \
  --enable-freeze \
  --enable-metadata \
  --enable-non-transferable \
  --enable-permanent-delegate \
  --enable-confidential-transfers auto \
  --default-account-state initialized \
  --interest-rate 5 \
  --transfer-fee 10 11 \
  --transfer-hook $mint \
  --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb \
  mint.json
spl-token -ul initialize-metadata $mint MegaToken MT https://spl.solana.com/token-2022
spl-token -ul update-metadata $mint Mega Token

spl-token -ul create-account --immutable $mint source.json
spl-token -ul enable-required-transfer-memos "$source_pubkey"
spl-token -ul enable-cpi-guard "$source_pubkey"
spl-token -ul configure-confidential-transfer-account --address "$source_pubkey"
```