### PR TITLE
[anchor] display bytes as hex

### DIFF
--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -9,6 +9,7 @@ import { getProgramName } from '@utils/tx';
 import React, { Fragment, ReactNode, useState } from 'react';
 import { ChevronDown, ChevronUp, CornerDownRight } from 'react-feather';
 import ReactJson from 'react-json-view';
+import { HexData } from '../components/common/HexData';
 
 export function getAnchorProgramName(program: Program | null): string | undefined {
     return program ? snakeToTitleCase(program.idl.name) : undefined;
@@ -174,7 +175,7 @@ function mapField(key: string, value: any, type: IdlType, idl: Idl, keySuffix?: 
                 <div>{numberWithSeparator(value.toString())}</div>
             </SimpleRow>
         );
-    } else if (type === 'bool' || type === 'bytes' || type === 'string') {
+    } else if (type === 'bool' || type === 'string') {
         return (
             <SimpleRow
                 key={keySuffix ? `${key}-${keySuffix}` : key}
@@ -186,6 +187,8 @@ function mapField(key: string, value: any, type: IdlType, idl: Idl, keySuffix?: 
                 <div>{value.toString()}</div>
             </SimpleRow>
         );
+    } else if (type === 'bytes') {
+        return <HexData raw={Buffer.from(value)} />
     } else if (type === 'publicKey') {
         return (
             <SimpleRow


### PR DESCRIPTION
Current the Anchor `bytes` type (`Vec<u8>` in rust) gets represented very poorly as it's interpreted as a utf-8 string. 
Instead it should be represented as a hex payload similar to serialized instruction data.

Current : ![image](https://github.com/solana-labs/explorer/assets/59208140/6116d540-06bc-48c3-8e54-ed24137773e7)
https://explorer.solana.com/tx/32dxbGfqTo7H56aZ9rNJWUy2tBEHgbnojVsBBJ6RiG17f4vNpZF6zzsWHojXA5943MxxTVobvjegURdVxeHAUqMy?cluster=devnet

After:
![image](https://github.com/solana-labs/explorer/assets/59208140/329e7093-2019-4a24-9163-0ef0bbb614c7)

