### PR TITLE
Add anchor details to instruction card on tx inspector

### DIFF
--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -90,7 +90,9 @@ function InstructionCard({
             innerCards: undefined,
             ix: transactionInstruction,
             // Always display success since it is too complicated to determine
-            // based on the logs which ix actually failed.
+            // based on the simulation and pass that result here. Could be added
+            // later if desired, possibly similar to innerCards from parsing tx
+            // sim logs.
             result: { err: null},
             // Signature is not needed.
             signature: '',

--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -83,9 +83,15 @@ function InstructionCard({
             anchorProgram: anchorProgram,
             childIndex: undefined,
             index: index,
+            // Inner cards and child are not used since we do not know what CPIs
+            // will be called until simulation happens, and even then, all we
+            // get is logs, not the TransactionInstructions
             innerCards: undefined,
             ix: transactionInstruction,
+            // Always display success since it is too complicated to determine
+            // based on the logs which ix actually failed.
             result: { err: null},
+            // Signature is not needed.
             signature: '',
         });
     }

--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -1,4 +1,3 @@
-import { useAnchorProgram } from '@/app/providers/anchor';
 import { HexData } from '@components/common/HexData';
 import { TableCardBody } from '@components/common/TableCardBody';
 import { useCluster } from '@providers/cluster';
@@ -8,8 +7,10 @@ import getInstructionCardScrollAnchorId from '@utils/get-instruction-card-scroll
 import { getProgramName } from '@utils/tx';
 import React from 'react';
 
-import { AddressFromLookupTableWithContext, AddressWithContext, programValidator } from './AddressWithContext';
+import { useAnchorProgram } from '@/app/providers/anchor';
+
 import AnchorDetailsCard from '../instruction/AnchorDetailsCard';
+import { AddressFromLookupTableWithContext, AddressWithContext, programValidator } from './AddressWithContext';
 
 export function InstructionsSection({ message }: { message: VersionedMessage }) {
     return (
@@ -79,13 +80,13 @@ function InstructionCard({
 
     if (anchorProgram) {
         return AnchorDetailsCard({
-            ix: transactionInstruction,
+            anchorProgram: anchorProgram,
+            childIndex: undefined,
             index: index,
+            innerCards: undefined,
+            ix: transactionInstruction,
             result: { err: null},
             signature: '',
-            innerCards: undefined,
-            childIndex: undefined,
-            anchorProgram: anchorProgram,
         });
     }
 

--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -2,7 +2,7 @@ import { HexData } from '@components/common/HexData';
 import { TableCardBody } from '@components/common/TableCardBody';
 import { useCluster } from '@providers/cluster';
 import { useScrollAnchor } from '@providers/scroll-anchor';
-import { AccountMeta, MessageCompiledInstruction, TransactionInstruction, VersionedMessage } from '@solana/web3.js';
+import { AccountMeta, MessageCompiledInstruction, PublicKey, TransactionInstruction, VersionedMessage } from '@solana/web3.js';
 import getInstructionCardScrollAnchorId from '@utils/get-instruction-card-scroll-anchor-id';
 import { getProgramName } from '@utils/tx';
 import React from 'react';
@@ -47,13 +47,16 @@ function InstructionCard({
         ),
     ];
 
-    const accountMetas = ix.accountKeyIndexes.map((accountIndex, index) => {
-        let lookup;
+    const { cluster, url } = useCluster();
+    const programName = getProgramName(programId.toBase58(), cluster);
+
+    const accountMetas = ix.accountKeyIndexes.map((accountIndex, _index) => {
+        let lookup: PublicKey;
         if (accountIndex >= message.staticAccountKeys.length) {
             const lookupIndex = accountIndex - message.staticAccountKeys.length;
             lookup = lookupsForAccountKeyIndex[lookupIndex].lookupTableKey;
         } else {
-            lookup = message.staticAccountKeys[index];
+            lookup = message.staticAccountKeys[accountIndex];
         }
 
         const signer = accountIndex < message.header.numRequiredSignatures;
@@ -73,8 +76,6 @@ function InstructionCard({
     });
 
     const [expanded, setExpanded] = React.useState(false);
-    const { cluster, url } = useCluster();
-    const programName = getProgramName(programId.toBase58(), cluster);
     const anchorProgram = useAnchorProgram(programId.toString(), url);
     const scrollAnchorRef = useScrollAnchor(getInstructionCardScrollAnchorId([index + 1]));
 


### PR DESCRIPTION
When possible, use the anchor description card instead of the default instruction card on the tx simulation page. This is useful because 

Before:
<img width="1238" alt="Screen Shot 2024-05-19 at 1 01 28 PM" src="https://github.com/solana-labs/explorer/assets/1320260/f11c902e-3fd1-4b30-8ecc-f79f103c1935">

After:
<img width="1273" alt="Screen Shot 2024-05-19 at 1 01 47 PM" src="https://github.com/solana-labs/explorer/assets/1320260/2733821e-e807-41be-91a0-50d58d9e7851">
