### PR TITLE
fix: accountHeader name 

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -41,9 +41,9 @@ import { useClusterPath } from '@utils/url';
 import { MetadataPointer, TokenMetadata } from '@validators/accounts/token-extension'
 import Link from 'next/link';
 import { redirect, useSelectedLayoutSegment } from 'next/navigation';
-import { create } from 'superstruct';
 import React, { PropsWithChildren, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { create } from 'superstruct';
 import useSWRImmutable from 'swr/immutable';
 import { Base58EncodedAddress } from 'web3js-experimental';
 

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -266,25 +266,18 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
 
 
             // Checks the uri, if it's json, return the the json's image tag
-            try {
-                if (tokenMetadata.uri.endsWith('.json')) {
-                    fetch(tokenMetadata.uri)
-                        .then(response => response.json())
-                        .then(metadata => {
-                            if (metadata && metadata.image) {
-                                token.logoURI = metadata.image;
-                            }
-                        })
-                        .catch(e => {
-                            token.logoURI = tokenMetadata.uri;
-                        });
-                } else {
-                    token.logoURI = tokenMetadata.uri;
-                }
-            } catch {
+            if (tokenMetadata.uri.endsWith('.json')) {
+                fetch(tokenMetadata.uri)
+                    .then(response => response.json())
+                    .then(metadata => {
+                        token.logoURI = metadata?.image || tokenMetadata.uri;
+                    })
+                    .catch(() => {
+                        token.logoURI = tokenMetadata.uri;
+                    });
+            } else {
                 token.logoURI = tokenMetadata.uri;
             }
-
         }
 
         // Fall back to legacy token list when there is stub metadata (blank uri), updatable by default by the mint authority

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -19,8 +19,6 @@ import { VoteAccountSection } from '@components/account/VoteAccountSection';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { Identicon } from '@components/common/Identicon';
 import { LoadingCard } from '@components/common/LoadingCard';
-import { create } from 'superstruct';
-import { MetadataPointer, TokenMetadata } from '@validators/accounts/token-extension'
 import {
     Account,
     AccountsProvider,
@@ -40,9 +38,11 @@ import { PublicKey } from '@solana/web3.js';
 import { Cluster, ClusterStatus } from '@utils/cluster';
 import { FEATURE_PROGRAM_ID } from '@utils/parseFeatureAccount';
 import { useClusterPath } from '@utils/url';
+import { MetadataPointer, TokenMetadata } from '@validators/accounts/token-extension'
 import Link from 'next/link';
 import { redirect, useSelectedLayoutSegment } from 'next/navigation';
 import React, { PropsWithChildren } from 'react';
+import { create } from 'superstruct';
 import useSWRImmutable from 'swr/immutable';
 import { Base58EncodedAddress } from 'web3js-experimental';
 
@@ -261,8 +261,8 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
             // Does not handle the case where MetadataPointer is pointing at a separate account.
             if (metadataAddress?.toString() === address) {
                 token = {
-                    name: tokenMetadata.name,
-                    logoURI: tokenMetadata.uri
+                    logoURI: tokenMetadata.uri,
+                    name: tokenMetadata.name
                 }
             }
 

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -263,20 +263,6 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
             if (metadataAddress?.toString() === address) {
                 token.name = tokenMetadata.name
             }
-
-
-            if (tokenMetadata.uri.endsWith('.json')) {
-                fetch(tokenMetadata.uri)
-                    .then(response => response.json())
-                    .then(metadata => {
-                        token.logoURI = metadata.image;
-                    })
-                    .catch(() => {
-                        console.error("Failed to resolve image from metadata pointer")
-                    });
-            } else {
-                token.logoURI = tokenMetadata.uri
-            }
     }
         // Fall back to legacy token list when there is stub metadata (blank uri), updatable by default by the mint authority
         else if (!parsedData?.nftData?.metadata.data.uri && tokenInfo) {

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -265,21 +265,19 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
             }
 
 
-            // Checks the uri, if it's json, return the the json's image tag
             if (tokenMetadata.uri.endsWith('.json')) {
                 fetch(tokenMetadata.uri)
                     .then(response => response.json())
                     .then(metadata => {
-                        token.logoURI = metadata?.image || tokenMetadata.uri;
+                        token.logoURI = metadata.image;
                     })
                     .catch(() => {
-                        token.logoURI = tokenMetadata.uri;
+                        console.error("Failed to resolve image from metadata pointer")
                     });
             } else {
-                token.logoURI = tokenMetadata.uri;
+                token.logoURI = tokenMetadata.uri
             }
-        }
-
+    }
         // Fall back to legacy token list when there is stub metadata (blank uri), updatable by default by the mint authority
         else if (!parsedData?.nftData?.metadata.data.uri && tokenInfo) {
             token = tokenInfo;

--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -281,7 +281,7 @@ function AccountHeader({ address, account, tokenInfo, isTokenInfoLoading }: { ad
                 } else {
                     token.logoURI = tokenMetadata.uri;
                 }
-            } catch (e) {
+            } catch {
                 token.logoURI = tokenMetadata.uri;
             }
 


### PR DESCRIPTION
Uses the metadata pointer to get the token name and renders in the AccountHeader