### PR TITLE
Fix compressed nft hooks

### DIFF
--- a/app/components/account/CompressedNftCard.tsx
+++ b/app/components/account/CompressedNftCard.tsx
@@ -72,7 +72,6 @@ export function CompressedNftCard({ account }: { account: Account }) {
 export function CompressedNftAccountHeader({ account }: { account: Account }) {
     const { url } = useCluster();
     const compressedNft = useCompressedNft({ address: account.pubkey.toString(), url });
-    if (!compressedNft) throw new Error('Compressed NFT not found');
 
     if (compressedNft) {
         return (


### PR DESCRIPTION
previous cnft pr did not properly make hooks, causing perf issues.

this PR fixes it by using useSWRImmutable hooks to manage fetching & caching