### PR TITLE
Prune unused anchor types so layouts can be constructed from legacy IDLs with bad types

### DIFF
--- a/app/providers/anchor.tsx
+++ b/app/providers/anchor.tsx
@@ -121,7 +121,7 @@ export function useAnchorProgram(programAddress: string, url: string): { program
             const program = new Program(formatIdl(idl, programAddress), getProvider(url));
             return program;
         } catch (e) {
-            console.error('Error creating anchor program', e, { idl });
+            console.error('Error creating anchor program for', programAddress, e, { idl });
             return null;
         }
     }, [idl, programAddress, url]);


### PR DESCRIPTION
Kamino YVaults program was not loading on the explorer with #374 due to bad type "ScopeConversionChain" having undefined type "ScopePriceId" which was not included in the IDL. 

This PR fixes YVaults IDL loading by pruning unused anchor types. 

Example tx:
- https://explorer.solana.com/tx/3KgAexzvZ8Kdmj1TCkdZ4RCrV5q9ihyZ1xUnXcSCwybybgCupQ8Mf21tZqQWx2eJh45ATZhMWg2FbbzxhYW6UoU6
Example account
- https://explorer.solana.com/address/H8h7ZyS5qJR2cwLxvZQdPaNzLik17cRxB5pDvjdXeuBg/anchor-account
