### PR TITLE
Stop parsing idls from program binaries when loading anchor programs

### DIFF
--- a/app/providers/anchor.tsx
+++ b/app/providers/anchor.tsx
@@ -13,6 +13,7 @@ const cachedAnchorProgramPromises: Record<
     void | { __type: 'promise'; promise: Promise<void> } | { __type: 'result'; result: Idl | null }
 > = {};
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function useIdlFromSolanaProgramBinary(programAddress: string): Idl | null {
     const fetchAccountInfo = useFetchAccountInfo();
     const programInfo = useAccountInfo(programAddress);

--- a/app/providers/anchor.tsx
+++ b/app/providers/anchor.tsx
@@ -112,9 +112,10 @@ function useIdlFromAnchorProgramSeed(programAddress: string, url: string): Idl |
 }
 
 export function useAnchorProgram(programAddress: string, url: string): { program: Program | null; idl: Idl | null } {
-    const idlFromBinary = useIdlFromSolanaProgramBinary(programAddress);
+    // TODO(ngundotra): Rewrite this to be more efficient
+    // const idlFromBinary = useIdlFromSolanaProgramBinary(programAddress);
     const idlFromAnchorProgram = useIdlFromAnchorProgramSeed(programAddress, url);
-    const idl = idlFromBinary ?? idlFromAnchorProgram;
+    const idl = idlFromAnchorProgram;
     const program: Program<Idl> | null = useMemo(() => {
         if (!idl) return null;
         try {


### PR DESCRIPTION
This has been causing rate limiting issues when loading transactions that have a lot of program interactions because each instruction required fetching the entire program binary.

Also need a key flagship program to use this feature on mainnet to be useful.