### PR TITLE
Add verify command to verified build tab

### DIFF
--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -6,11 +6,13 @@ import { ExternalLink } from 'react-feather';
 
 import { OsecRegistryInfo, useVerifiedProgramRegistry } from '@/app/utils/verified-builds';
 
+import { Copyable } from '../common/Copyable';
 import { LoadingCard } from '../common/LoadingCard';
 
 export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAccountData; pubkey: PublicKey }) {
     const { data: registryInfo, isLoading } = useVerifiedProgramRegistry({
         options: { suspense: true },
+        programAuthority: data.programData?.authority ? new PublicKey(data.programData.authority) : null,
         programId: pubkey,
     });
     if (!data.programData) {
@@ -50,6 +52,7 @@ enum DisplayType {
     String,
     URL,
     Date,
+    LongString,
 }
 
 type TableRow = {
@@ -85,6 +88,11 @@ const ROWS: TableRow[] = [
         type: DisplayType.Date,
     },
     {
+        display: 'Verify Command',
+        key: 'verify_command',
+        type: DisplayType.LongString,
+    },
+    {
         display: 'Repository URL',
         key: 'repo_url',
         type: DisplayType.URL,
@@ -100,7 +108,32 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
                 </td>
             );
         case DisplayType.String:
-            return <td className="text-lg-end font-monospace" style={{whiteSpace: 'pre'}}>{value && (value as string).length > 1 ? value : '-'}</td>;
+            return (
+                <td className="text-lg-end font-monospace" style={{ whiteSpace: 'pre' }}>
+                    {value && (value as string).length > 1 ? value : '-'}
+                </td>
+            );
+        case DisplayType.LongString:
+            return (
+                <td
+                    className="text-lg-end font-monospace"
+                    style={{
+                        overflowWrap: 'break-word',
+                        position: 'relative',
+                        whiteSpace: 'pre-wrap',
+                        wordWrap: 'break-word',
+                    }}
+                >
+                    {value && (value as string).length > 1 ? (
+                        <>
+                            <Copyable text={value as string}> </Copyable>
+                            <span>{value}</span>
+                        </>
+                    ) : (
+                        '-'
+                    )}
+                </td>
+            );
         case DisplayType.URL:
             if (isValidLink(value as string)) {
                 return (
@@ -120,7 +153,11 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
                 </td>
             );
         case DisplayType.Date:
-            return <td className="text-lg-end font-monospace">{value && (value as string).length > 1 ? new Date(value as string).toUTCString() : '-'}</td>;
+            return (
+                <td className="text-lg-end font-monospace">
+                    {value && (value as string).length > 1 ? new Date(value as string).toUTCString() : '-'}
+                </td>
+            );
         default:
             break;
     }

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -33,6 +33,26 @@ export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAcc
                 <h3 className="card-header-title mb-0 d-flex align-items-center">Verified Build</h3>
                 <small>Information provided by osec.io</small>
             </div>
+            <div
+                className="alert mt-2"
+                style={{
+                    backgroundColor: '#2a3b3c',
+                    borderRadius: '5px',
+                    color: '#c9e2e1',
+                    padding: '10px',
+                }}
+            >
+                <strong>Note:</strong> Verified builds indicate that the onchain build was built from the source code
+                that is publicly available, but this does not imply a security audit. For more details, refer to the{' '}
+                <a
+                    href="https://solana.com/developers/guides/advanced/verified-builds"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Verified Builds Docs <ExternalLink className="align-text-top ms-1" size={13} />
+                </a>
+                .
+            </div>
             <TableCardBody>
                 {ROWS.filter(x => x.key in registryInfo).map((x, idx) => {
                     return (

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -33,17 +33,9 @@ export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAcc
                 <h3 className="card-header-title mb-0 d-flex align-items-center">Verified Build</h3>
                 <small>Information provided by osec.io</small>
             </div>
-            <div
-                className="alert mt-2"
-                style={{
-                    backgroundColor: '#2a3b3c',
-                    borderRadius: '5px',
-                    color: '#c9e2e1',
-                    padding: '10px',
-                }}
-            >
-                <strong>Note:</strong> Verified builds indicate that the onchain build was built from the source code
-                that is publicly available, but this does not imply a security audit. For more details, refer to the{' '}
+            <div className="alert mt-2 mb-2">
+                Verified builds indicate that the onchain build was built from the source code that is publicly
+                available, but this does not imply a security audit. For more details, refer to the{' '}
                 <a
                     href="https://solana.com/developers/guides/advanced/verified-builds"
                     target="_blank"

--- a/app/components/common/VerifiedProgramBadge.tsx
+++ b/app/components/common/VerifiedProgramBadge.tsx
@@ -12,7 +12,7 @@ export function VerifiedProgramBadge({
     programData: ProgramDataAccountInfo;
     pubkey: PublicKey;
 }) {
-    const { isLoading, data: registryInfo } = useVerifiedProgramRegistry({ programId: pubkey });
+    const { isLoading, data: registryInfo } = useVerifiedProgramRegistry({ programAuthority: programData.authority ? new PublicKey(programData.authority) : null, programId: pubkey });
     const verifiedBuildTabPath = useClusterPath({ pathname: `/address/${pubkey.toBase58()}/verified-build` });
 
     const hash = hashProgramData(programData);

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -65,7 +65,7 @@ export function useVerifiedProgramRegistry({
                 console.log('PDA account info not found');
                 return null;
             }
-            return accountAnchorProgram.coder.accounts.decode('buildParams', pdaAccountInfo.data);
+            return accountAnchorProgram?.coder.accounts.decode('buildParams', pdaAccountInfo.data);
         },
         { suspense: options?.suspense }
     );

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -85,8 +85,22 @@ export function useVerifiedProgramRegistry({
 
         // Add additional args if available, for example mount-path and --library-name
         if (pdaData.args && pdaData.args.length > 0) {
-            const argsString = pdaData.args.join(' ');
-            verifiedData.verify_command += ` ${argsString}`;
+            const filteredArgs = [];
+
+            for (let i = 0; i < pdaData.args.length; i++) {
+                const arg = pdaData.args[i];
+
+                if (arg === '-b' || arg === '--base-image') {
+                    i++; // Also skip the parameter
+                    continue;
+                }
+                filteredArgs.push(arg);
+            }
+
+            if (filteredArgs.length > 0) {
+                const argsString = filteredArgs.join(' ');
+                verifiedData.verify_command += ` ${argsString}`;
+            }
         }
 
         return { data: verifiedData, isLoading };

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -61,7 +61,8 @@ export function useVerifiedProgramRegistry({
             );
             const pdaAccountInfo = await connection.getAccountInfo(pda);
             if (!pdaAccountInfo || !pdaAccountInfo.data) {
-                throw new Error('PDA account info not found');
+                console.log('PDA account info not found');
+                return null;
             }
             return accountAnchorProgram.coder.accounts.decode('buildParams', pdaAccountInfo.data);
         },
@@ -87,6 +88,11 @@ export function useVerifiedProgramRegistry({
             verifiedData.verify_command += ` ${argsString}`;
         }
 
+        return { data: verifiedData, isLoading };
+    }
+    if (registryData && pdaData == null && !isLoading) {
+        const verifiedData = registryData as OsecRegistryInfo;
+        verifiedData.verify_command = 'Program does not have a verify PDA uploaded.';
         return { data: verifiedData, isLoading };
     }
 

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -5,6 +5,7 @@ import useSWRImmutable from 'swr/immutable';
 import { useAnchorProgram } from '../providers/anchor';
 import { useCluster } from '../providers/cluster';
 import { ProgramDataAccountInfo } from '../validators/accounts/upgradeable-program';
+import { Cluster } from './cluster';
 
 const OSEC_REGISTRY_URL = 'https://verify.osec.io';
 const VERIFY_PROGRAM_ID = 'verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC';
@@ -28,7 +29,7 @@ export function useVerifiedProgramRegistry({
     programAuthority: PublicKey | null;
     options?: { suspense: boolean };
 }) {
-    const { url: clusterUrl } = useCluster();
+    const { url: clusterUrl, cluster: cluster } = useCluster();
     const connection = new Connection(clusterUrl);
 
     const {
@@ -92,11 +93,18 @@ export function useVerifiedProgramRegistry({
     }
     if (registryData && pdaData == null && !isLoading) {
         const verifiedData = registryData as OsecRegistryInfo;
-        verifiedData.verify_command = 'Program does not have a verify PDA uploaded.';
+
+        verifiedData.verify_command = isMainnet(cluster)
+            ? 'Program does not have a verify PDA uploaded.'
+            : 'Verify command only available on mainnet.';
         return { data: verifiedData, isLoading };
     }
 
     return { data: null, isLoading };
+}
+
+function isMainnet(currentCluster: Cluster): boolean {
+    return currentCluster == Cluster.MainnetBeta;
 }
 
 // Helper function to hash program data


### PR DESCRIPTION
- Deriving the PDA from the upgrade authority and the program id, then getting the parameter from the PDA and composing it into a solana-verify comand

Like this people can easily copy the command from the explorer and verify for themselfs. 

Related Issue: 
https://github.com/solana-labs/explorer/issues/393 

Looks like this: 
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/708a886a-dc9b-4ab1-ac69-1465210c7611">

And like this when there is no Verify PDA:
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/d4952dd4-f996-4764-a7d8-3492bd24f396">
