### PR TITLE
Fix conversion of legacy idl seeds

### DIFF
--- a/app/utils/convertLegacyIdl.ts
+++ b/app/utils/convertLegacyIdl.ts
@@ -361,7 +361,7 @@ function convertInstructionAccounts(accounts: LegacyIdlAccounts): IdlInstruction
 
 function convertPda(pda: LegacyIdlPda): { seeds: any[]; programId?: any } {
     return {
-        programId: pda.programId ? convertSeed(pda.programId) : undefined,
+        ...(pda.programId ? { programId: convertSeed(pda.programId) } : {}),
         seeds: pda.seeds.map(convertSeed),
     };
 }
@@ -374,7 +374,7 @@ function convertSeed(seed: LegacyIdlSeed): any {
             return { kind: 'arg', path: seed.path, type: convertType(seed.type) };
         case 'account':
             return {
-                account: seed.account,
+                ...(seed.account ? { account: seed.account } : {}),
                 kind: 'account',
                 path: seed.path,
                 type: convertType(seed.type),


### PR DESCRIPTION
Fixes pages like https://explorer.solana.com/address/EH8hpNpwfDHxYYoFnF3AXWZMzm7hJLh3KmS6WGkRibFf/anchor-account?cluster=devnet

And any tx/account pages for programs using anchor idls with PDA seeds