### PR TITLE
Use validators.app info for mainnet  ping chart

### DIFF
--- a/app/api/ping/[network]/route.ts
+++ b/app/api/ping/[network]/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 
 type Params = {
     params: {
-        network: 'mainnet' | 'devnet';
+        network: 'mainnet';
     };
 };
 

--- a/app/api/ping/[network]/route.ts
+++ b/app/api/ping/[network]/route.ts
@@ -43,7 +43,7 @@ export async function GET(_request: Request, { params: { network } }: Params) {
 
     return NextResponse.json(data, {
         headers: {
-            'Cache-Control': 'no-store, max-age=0',
+            'Cache-Control': 'public, max-age=30',
         },
     });
 }

--- a/app/api/ping/[network]/route.ts
+++ b/app/api/ping/[network]/route.ts
@@ -1,0 +1,49 @@
+import { fetch } from 'cross-fetch';
+import { NextResponse } from 'next/server';
+
+type Params = {
+    params: {
+        network: 'mainnet' | 'devnet';
+    };
+};
+
+export type ValidatorsAppPingStats = {
+    interval: number;
+    max: number;
+    median: number;
+    min: number;
+    network: string;
+    num_of_records: number;
+    time_from: string;
+    average_slot_latency: number;
+    tps: number;
+};
+
+const PING_INTERVALS: number[] = [1, 3, 12];
+
+export async function GET(_request: Request, { params: { network } }: Params) {
+    const responses = await Promise.all(
+        PING_INTERVALS.map(interval =>
+            fetch(`https://www.validators.app/api/v1/ping-thing-stats/${network}.json?interval=${interval}`, {
+                cache: 'no-store',
+                headers: {
+                    'Cache-Control': 'no-store, max-age=0',
+                    Token: process.env.PING_API_KEY || '',
+                },
+            })
+        )
+    );
+    const data: { [interval: number]: ValidatorsAppPingStats[] } = {};
+    await Promise.all(
+        responses.map(async (response, index) => {
+            const interval = PING_INTERVALS[index];
+            data[interval] = await response.json();
+        })
+    );
+
+    return NextResponse.json(data, {
+        headers: {
+            'Cache-Control': 'no-store, max-age=0',
+        },
+    });
+}

--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -49,7 +49,7 @@ export function LiveTransactionStatsCard() {
                 <h4 className="card-header-title">Live Transaction Stats</h4>
             </div>
             <TpsCardBody series={series} setSeries={setSeries} />
-            {cluster === Cluster.MainnetBeta || cluster === Cluster.Devnet ? (
+            {cluster === Cluster.MainnetBeta ? (
                 <ValidatorsAppPingStatsCardBody series={series} setSeries={setSeries} />
             ) : (
                 <PingStatsCardBody series={series} setSeries={setSeries} />

--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -48,16 +48,11 @@ export function LiveTransactionStatsCard() {
             <div className="card-header">
                 <h4 className="card-header-title">Live Transaction Stats</h4>
             </div>
+            <TpsCardBody series={series} setSeries={setSeries} />
             {cluster === Cluster.MainnetBeta || cluster === Cluster.Devnet ? (
-                <>
-                    <ValidatorsAppTpsCardBody series={series} setSeries={setSeries} />
-                    <ValidatorsAppPingStatsCardBody series={series} setSeries={setSeries} />
-                </>
+                <ValidatorsAppPingStatsCardBody series={series} setSeries={setSeries} />
             ) : (
-                <>
-                    <TpsCardBody series={series} setSeries={setSeries} />
-                    <PingStatsCardBody series={series} setSeries={setSeries} />
-                </>
+                <PingStatsCardBody series={series} setSeries={setSeries} />
             )}
         </div>
     );
@@ -73,6 +68,7 @@ function TpsCardBody({ series, setSeries }: { series: Series; setSeries: SetSeri
     return <TpsBarChart performanceInfo={performanceInfo} series={series} setSeries={setSeries} />;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ValidatorsAppTpsCardBody({ series, setSeries }: { series: Series; setSeries: SetSeries }) {
     const performanceInfo = usePerformanceInfo();
     const statsInfo = useValidatorsAppPingStats();

--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -12,6 +12,14 @@ import { Bar } from 'react-chartjs-2';
 import CountUp from 'react-countup';
 import { RefreshCw } from 'react-feather';
 
+import { useCluster } from '../providers/cluster';
+import {
+    useValidatorsAppPingStats,
+    ValidatorsAppPingStatsInfo,
+    ValidatorsAppPingStatsRecord,
+} from '../providers/stats/ValidatorsAppStatsProvider';
+import { Cluster } from '../utils/cluster';
+
 Chart.register(BarElement, CategoryScale, LinearScale, Tooltip);
 
 type Series = 'short' | 'medium' | 'long';
@@ -34,24 +42,23 @@ const SERIES_INFO = {
 
 export function LiveTransactionStatsCard() {
     const [series, setSeries] = React.useState<Series>('short');
+    const { cluster } = useCluster();
     return (
         <div className="card">
             <div className="card-header">
                 <h4 className="card-header-title">Live Transaction Stats</h4>
             </div>
-            <TpsCardBody series={series} setSeries={setSeries} />
-            <div className="alert alert-warning m-2" role="alert">
-                Note: We are aware of an issue with ping statistic reporting. Ping statistics may not reflect actual
-                network performance. Please see{' '}
-                <a
-                    href="https://www.validators.app/ping-thing?locale=en&network=mainnet"
-                    className="text-white text-decoration-underline"
-                >
-                    validators.app
-                </a>{' '}
-                for more information.
-            </div>
-            <PingStatsCardBody series={series} setSeries={setSeries} />
+            {cluster === Cluster.MainnetBeta || cluster === Cluster.Devnet ? (
+                <>
+                    <ValidatorsAppTpsCardBody series={series} setSeries={setSeries} />
+                    <ValidatorsAppPingStatsCardBody series={series} setSeries={setSeries} />
+                </>
+            ) : (
+                <>
+                    <TpsCardBody series={series} setSeries={setSeries} />
+                    <PingStatsCardBody series={series} setSeries={setSeries} />
+                </>
+            )}
         </div>
     );
 }
@@ -64,6 +71,28 @@ function TpsCardBody({ series, setSeries }: { series: Series; setSeries: SetSeri
     }
 
     return <TpsBarChart performanceInfo={performanceInfo} series={series} setSeries={setSeries} />;
+}
+
+function ValidatorsAppTpsCardBody({ series, setSeries }: { series: Series; setSeries: SetSeries }) {
+    const performanceInfo = usePerformanceInfo();
+    const statsInfo = useValidatorsAppPingStats();
+
+    if (performanceInfo.status !== ClusterStatsStatus.Ready || statsInfo.status !== PingStatus.Ready) {
+        return (
+            <StatsNotReady
+                error={performanceInfo.status === ClusterStatsStatus.Error || statsInfo.status === PingStatus.Error}
+            />
+        );
+    }
+
+    return (
+        <ValidatorsAppTpsBarChart
+            statsInfo={statsInfo}
+            performanceInfo={performanceInfo}
+            series={series}
+            setSeries={setSeries}
+        />
+    );
 }
 
 const TPS_CHART_OPTIONS = (historyMaxTps: number): ChartOptions<'bar'> => {
@@ -156,6 +185,84 @@ const TPS_CHART_OPTIONS = (historyMaxTps: number): ChartOptions<'bar'> => {
         },
     };
 };
+
+type ValidatorsAppTpsBarChartProps = {
+    performanceInfo: PerformanceInfo;
+    statsInfo: ValidatorsAppPingStatsInfo;
+    series: Series;
+    setSeries: SetSeries;
+};
+function ValidatorsAppTpsBarChart({ statsInfo, performanceInfo, series, setSeries }: ValidatorsAppTpsBarChartProps) {
+    const seriesData = statsInfo[series] || [];
+    const avgTps = Math.round(
+        (statsInfo[SERIES[2]] || [])?.map(val => val.tps).reduce((a, b) => a + b, 0) / seriesData.length
+    );
+    const historyMaxTps = (statsInfo[SERIES[2]] || [])?.map(val => val.tps).reduce((a, b) => Math.max(a, b), 0);
+    const averageTps = Math.round(avgTps).toLocaleString('en-US');
+    const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
+    const chartOptions = React.useMemo<ChartOptions<'bar'>>(() => TPS_CHART_OPTIONS(historyMaxTps), [historyMaxTps]);
+
+    const now = new Date();
+    const chartData: ChartData<'bar'> = {
+        datasets: [
+            {
+                backgroundColor: '#00D192',
+                borderWidth: 0,
+                data: seriesData.map(val => (val.tps >= historyMaxTps ? avgTps : val.tps || 0)),
+                hoverBackgroundColor: '#00D192',
+            },
+        ],
+        labels: seriesData.map(val => {
+            const minAgo = Math.round((now.getTime() - val.timestamp.getTime()) / 60000);
+            return `${minAgo}min ago`;
+        }),
+    };
+
+    return (
+        <>
+            <TableCardBody>
+                <tr>
+                    <td className="w-100">Transaction count</td>
+                    <td className="text-lg-end font-monospace">{transactionCount} </td>
+                </tr>
+                <tr>
+                    <td className="w-100">Transactions per second (TPS)</td>
+                    <td className="text-lg-end font-monospace">{averageTps} </td>
+                </tr>
+            </TableCardBody>
+
+            <hr className="my-0" />
+
+            <div className="card-body py-3">
+                <div className="align-box-row align-items-start justify-content-between">
+                    <div className="d-flex justify-content-between w-100">
+                        <span className="mb-0 font-size-sm">TPS history</span>
+
+                        <div className="font-size-sm">
+                            {SERIES.map(key => (
+                                <button
+                                    key={key}
+                                    onClick={() => setSeries(key)}
+                                    className={classNames('btn btn-sm btn-white ms-2', {
+                                        active: series === key,
+                                    })}
+                                >
+                                    {SERIES_INFO[key].interval}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div id="perf-history" className="mt-3 d-flex justify-content-end flex-row w-100">
+                        <div className="w-100">
+                            <Bar data={chartData} options={chartOptions} height={80} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}
 
 type TpsBarChartProps = {
     performanceInfo: PerformanceInfo;
@@ -285,6 +392,16 @@ function PingStatsCardBody({ series, setSeries }: { series: Series; setSeries: S
     }
 
     return <PingBarChart pingInfo={pingInfo} series={series} setSeries={setSeries} />;
+}
+
+function ValidatorsAppPingStatsCardBody({ series, setSeries }: { series: Series; setSeries: SetSeries }) {
+    const pingInfo = useValidatorsAppPingStats();
+
+    if (pingInfo.status !== PingStatus.Ready) {
+        return <PingStatsNotReady error={pingInfo.status === PingStatus.Error} retry={pingInfo.retry} />;
+    }
+
+    return <ValidatorsAppPingBarChart pingInfo={pingInfo} series={series} setSeries={setSeries} />;
 }
 
 type StatsNotReadyProps = { error: boolean; retry?: () => void };
@@ -463,6 +580,95 @@ function PingBarChart({
                     : ''
             }
             ${SERIES_INFO[series].label(seriesLength - i)}min ago
+            </div>
+          `;
+        }),
+    };
+
+    return (
+        <div className="card-body py-3">
+            <div className="align-box-row align-items-start justify-content-between">
+                <div className="d-flex justify-content-between w-100">
+                    <span className="mb-0 font-size-sm">Average Ping Time</span>
+
+                    <div className="font-size-sm">
+                        {SERIES.map(key => (
+                            <button
+                                key={key}
+                                onClick={() => setSeries(key)}
+                                className={classNames('btn btn-sm btn-white ms-2', {
+                                    active: series === key,
+                                })}
+                            >
+                                {SERIES_INFO[key].interval}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                <div id="perf-history" className="mt-3 d-flex justify-content-end flex-row w-100">
+                    <div className="w-100">
+                        <Bar data={chartData} options={PING_CHART_OPTIONS} height={80} />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function ValidatorsAppPingBarChart({
+    pingInfo,
+    series,
+    setSeries,
+}: {
+    pingInfo: ValidatorsAppPingStatsInfo;
+    series: Series;
+    setSeries: SetSeries;
+}) {
+    const seriesData = pingInfo[series] || [];
+    const maxMedian = seriesData.reduce((a, b) => {
+        return Math.max(a, b.median);
+    }, 0);
+    const backgroundColor = (val: ValidatorsAppPingStatsRecord) => {
+        if (val.submitted === 0) {
+            return '#08a274';
+        }
+
+        return '#00D192';
+    };
+    const now = new Date();
+    const chartData: ChartData<'bar'> = {
+        datasets: [
+            {
+                backgroundColor: seriesData.map(backgroundColor),
+                borderWidth: 0,
+                data: seriesData.map(val => {
+                    if (val.submitted === 0) {
+                        return maxMedian * 0.5;
+                    }
+                    return val.median || 0;
+                }),
+                hoverBackgroundColor: seriesData.map(backgroundColor),
+                minBarLength: 2,
+            },
+        ],
+        labels: seriesData.map(val => {
+            const minutesAgo = Math.round((now.getTime() - val.timestamp.getTime()) / (60 * 1000));
+            if (val.submitted === 0) {
+                return `
+            <div class="label">
+              <p class="mb-0">Ping statistics unavailable</p>
+              ${minutesAgo} min ago
+            </div>
+            `;
+            }
+
+            return `
+            <div class="value">${val.median} ms</div>
+            <div class="label">
+              <p class="mb-0">${val.submitted} confirmed</p>
+            ${`<p class="mb-0">${val.average_slot_latency.toLocaleString(undefined)} Average Slot Latency</p>`}
+            ${minutesAgo}min ago
             </div>
           `;
         }),

--- a/app/providers/stats/ValidatorsAppStatsProvider.tsx
+++ b/app/providers/stats/ValidatorsAppStatsProvider.tsx
@@ -82,12 +82,7 @@ export function ValidatorsAppStatsProvider({ children }: Props) {
         let stale = false;
         const fetchPingMetrics = async () => {
             try {
-                const response = await fetch(url, {
-                    cache: 'no-store',
-                    headers: {
-                        'Cache-Control': 'no-store, max-age=0',
-                    },
-                });
+                const response = await fetch(url);
                 if (stale) {
                     return;
                 }

--- a/app/providers/stats/ValidatorsAppStatsProvider.tsx
+++ b/app/providers/stats/ValidatorsAppStatsProvider.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCluster } from '@providers/cluster';
+import { useStatsProvider } from '@providers/stats/solanaClusterStats';
+import { Cluster } from '@utils/cluster';
+import { fetch } from 'cross-fetch';
+import React from 'react';
+import useTabVisibility from 'use-tab-visibility';
+
+import { ValidatorsAppPingStats } from '@/app/api/ping/[network]/route';
+
+const PING_INTERVALS: number[] = [1, 3, 12];
+
+const FETCH_PING_INTERVAL = 60 * 1000;
+
+function getClusterSlug(cluster: Cluster) {
+    switch (cluster) {
+        case Cluster.MainnetBeta:
+            return 'mainnet';
+        case Cluster.Devnet:
+            return 'devnet';
+        default:
+            throw new Error(`Invalid cluster: ${cluster}`);
+    }
+}
+
+function getUrl(cluster: Cluster) {
+    return `/api/ping/${getClusterSlug(cluster)}`;
+}
+
+export enum PingStatus {
+    Loading,
+    Ready,
+    Error,
+}
+
+export type ValidatorsAppPingStatsInfo = {
+    status: PingStatus;
+    short?: ValidatorsAppPingStatsRecord[];
+    medium?: ValidatorsAppPingStatsRecord[];
+    long?: ValidatorsAppPingStatsRecord[];
+    retry?: () => void;
+};
+
+export type ValidatorsAppPingStatsRecord = {
+    tps: number;
+    median: number;
+    submitted: number;
+    average_slot_latency: number;
+    timestamp: Date;
+};
+
+const ValidatorsAppStatsContext = React.createContext<ValidatorsAppPingStatsInfo | undefined>(undefined);
+
+type Props = { children: React.ReactNode };
+
+export function ValidatorsAppStatsProvider({ children }: Props) {
+    const { cluster } = useCluster();
+    const { active } = useStatsProvider();
+    const [rollup, setRollup] = React.useState<ValidatorsAppPingStatsInfo | undefined>({
+        status: PingStatus.Loading,
+    });
+    const { visible: isTabVisible } = useTabVisibility();
+    React.useEffect(() => {
+        if (!active || !isTabVisible) {
+            return;
+        }
+
+        if (cluster === Cluster.Testnet || cluster === Cluster.Custom) {
+            return;
+        }
+
+        const url = getUrl(cluster);
+
+        setRollup({
+            status: PingStatus.Loading,
+        });
+
+        if (!url) {
+            return;
+        }
+        let stale = false;
+        const fetchPingMetrics = async () => {
+            try {
+                const response = await fetch(url, {
+                    cache: 'no-store',
+                    headers: {
+                        'Cache-Control': 'no-store, max-age=0',
+                    },
+                });
+                if (stale) {
+                    return;
+                }
+                const json: { [interval: number]: ValidatorsAppPingStats[] } = await response.json();
+                if (stale) {
+                    return;
+                }
+                const simplify = (data: ValidatorsAppPingStats[]) =>
+                    data.map<ValidatorsAppPingStatsRecord>(
+                        ({ tps, median, time_from, num_of_records, average_slot_latency }: ValidatorsAppPingStats) => {
+                            return {
+                                average_slot_latency,
+                                median,
+                                submitted: num_of_records,
+                                timestamp: new Date(time_from),
+                                tps,
+                            };
+                        }
+                    );
+
+                const short = simplify(json[PING_INTERVALS[0]]).slice(-30);
+                const medium = simplify(json[PING_INTERVALS[1]]).slice(-30);
+                const long = simplify(json[PING_INTERVALS[2]]).slice(-30);
+
+                setRollup({
+                    long,
+                    medium,
+                    short,
+                    status: PingStatus.Ready,
+                });
+            } catch {
+                setRollup({
+                    retry: () => {
+                        setRollup({
+                            status: PingStatus.Loading,
+                        });
+
+                        fetchPingMetrics();
+                    },
+                    status: PingStatus.Error,
+                });
+            }
+        };
+
+        const fetchPingInterval = setInterval(() => {
+            fetchPingMetrics();
+        }, FETCH_PING_INTERVAL);
+        fetchPingMetrics();
+        return () => {
+            clearInterval(fetchPingInterval);
+            stale = true;
+        };
+    }, [active, cluster, isTabVisible]);
+
+    return <ValidatorsAppStatsContext.Provider value={rollup}>{children}</ValidatorsAppStatsContext.Provider>;
+}
+
+export function useValidatorsAppPingStats() {
+    const context = React.useContext(ValidatorsAppStatsContext);
+    if (!context) {
+        throw new Error(`useContext must be used within a StatsProvider`);
+    }
+    return context;
+}

--- a/app/providers/stats/index.tsx
+++ b/app/providers/stats/index.tsx
@@ -2,12 +2,15 @@ import { SolanaPingProvider } from '@providers/stats/SolanaPingProvider';
 import React from 'react';
 
 import { SolanaClusterStatsProvider } from './solanaClusterStats';
+import { ValidatorsAppStatsProvider } from './ValidatorsAppStatsProvider';
 
 type Props = { children: React.ReactNode };
 export function StatsProvider({ children }: Props) {
     return (
         <SolanaClusterStatsProvider>
-            <SolanaPingProvider>{children}</SolanaPingProvider>
+            <SolanaPingProvider>
+                <ValidatorsAppStatsProvider>{children}</ValidatorsAppStatsProvider>
+            </SolanaPingProvider>
         </SolanaClusterStatsProvider>
     );
 }


### PR DESCRIPTION
# Changes to Note

- Mainnet ping chart is now provided as the median confirmation time for transactions as reported by [validators.app](https://www.validators.app/ping-thing?locale=en&network=mainnet)

Not a change, but worth calling out- TPS chart timing has never been 1-1 with ping information because TPS and Ping signals have different sampling rates
