### PR TITLE
nit: temporarily pull verified build info until API registry permissions fixed

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -70,11 +70,11 @@ const TABS_LOOKUP: { [id: string]: Tab[] } = {
             slug: 'security',
             title: 'Security',
         },
-        {
-            path: 'verified-build',
-            slug: 'verified-build',
-            title: 'Verified Build',
-        },
+        // {
+        //     path: 'verified-build',
+        //     slug: 'verified-build',
+        //     title: 'Verified Build',
+        // },
     ],
     'nftoken:collection': [
         {
@@ -563,7 +563,7 @@ export type MoreTabs =
     | 'entries'
     | 'concurrent-merkle-tree'
     | 'compression'
-    | 'verified-build'
+    // | 'verified-build'
     | 'program-multisig';
 
 function MoreSection({ children, tabs }: { children: React.ReactNode; tabs: (JSX.Element | null)[] }) {
@@ -710,7 +710,9 @@ function getCustomLinkedTabs(pubkey: PublicKey, account: Account) {
                 <ProgramMultisigLink
                     tab={programMultisigTab}
                     address={pubkey.toString()}
-                    authority={(account.data.parsed as UpgradeableLoaderAccountData | undefined)?.programData?.authority}
+                    authority={
+                        (account.data.parsed as UpgradeableLoaderAccountData | undefined)?.programData?.authority
+                    }
                 />
             </React.Suspense>
         ),

--- a/app/address/[address]/verified-build/page.tsx
+++ b/app/address/[address]/verified-build/page.tsx
@@ -1,7 +1,8 @@
 import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
+import { redirect } from 'next/navigation';
 import { Metadata } from 'next/types';
 
-import VerifiedBuildClient from './page-client';
+// import VerifiedBuildClient from './page-client';
 
 export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
@@ -17,5 +18,6 @@ type Props = Readonly<{
 }>;
 
 export default function VerifiedBuildPage(props: Props) {
-    return <VerifiedBuildClient {...props} />;
+    // return <VerifiedBuildClient {...props} />;
+    throw redirect(`/address/${props.params.address}`);
 }

--- a/app/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/app/components/account/UpgradeableLoaderAccountSection.tsx
@@ -24,7 +24,7 @@ import { useSquadsMultisigLookup } from '@/app/providers/squadsMultisig';
 import { Cluster } from '@/app/utils/cluster';
 import { useClusterPath } from '@/app/utils/url';
 
-import { VerifiedProgramBadge } from '../common/VerifiedProgramBadge';
+// import { VerifiedProgramBadge } from '../common/VerifiedProgramBadge';
 
 export function UpgradeableLoaderAccountSection({
     account,
@@ -119,14 +119,14 @@ export function UpgradeableProgramSection({
                             <td>Upgradeable</td>
                             <td className="text-lg-end">{programData.authority !== null ? 'Yes' : 'No'}</td>
                         </tr>
-                        <tr>
+                        {/* <tr>
                             <td>
                                 <VerifiedLabel />
                             </td>
                             <td className="text-lg-end">
                                 <VerifiedProgramBadge programData={programData} pubkey={account.pubkey} />
                             </td>
-                        </tr>
+                        </tr> */}
                         <tr>
                             <td>
                                 <SecurityLabel />
@@ -183,6 +183,7 @@ function SecurityLabel() {
     );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function VerifiedLabel() {
     return (
         <InfoTooltip text="Verified builds allow users can ensure that the hash of the on-chain program matches the hash of the program of the given codebase (registry hosted by osec.io).">

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -10,6 +10,7 @@ import { Cluster } from './cluster';
 const OSEC_REGISTRY_URL = 'https://verify.osec.io';
 const VERIFY_PROGRAM_ID = 'verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export enum VerificationStatus {
     Verified = 'Verified Build',
     PdaUploaded = 'Not verified Build',


### PR DESCRIPTION
The API we are using to provide verified build information allows 3rd parties to overwrite any verified build to a trivially passing verified build.

This can be mitigated by having the API restrict verification requests to only come from the program authority.

This information will be hidden from the explorer until this issue has been mitigated..