### PR TITLE
Only show Trusted Verified Build information

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -70,11 +70,11 @@ const TABS_LOOKUP: { [id: string]: Tab[] } = {
             slug: 'security',
             title: 'Security',
         },
-        // {
-        //     path: 'verified-build',
-        //     slug: 'verified-build',
-        //     title: 'Verified Build',
-        // },
+        {
+            path: 'verified-build',
+            slug: 'verified-build',
+            title: 'Verified Build',
+        },
     ],
     'nftoken:collection': [
         {
@@ -563,7 +563,7 @@ export type MoreTabs =
     | 'entries'
     | 'concurrent-merkle-tree'
     | 'compression'
-    // | 'verified-build'
+    | 'verified-build'
     | 'program-multisig';
 
 function MoreSection({ children, tabs }: { children: React.ReactNode; tabs: (JSX.Element | null)[] }) {

--- a/app/address/[address]/verified-build/page.tsx
+++ b/app/address/[address]/verified-build/page.tsx
@@ -1,8 +1,7 @@
 import getReadableTitleFromAddress, { AddressPageMetadataProps } from '@utils/get-readable-title-from-address';
-import { redirect } from 'next/navigation';
 import { Metadata } from 'next/types';
 
-// import VerifiedBuildClient from './page-client';
+import VerifiedBuildClient from './page-client';
 
 export async function generateMetadata(props: AddressPageMetadataProps): Promise<Metadata> {
     return {
@@ -18,6 +17,5 @@ type Props = Readonly<{
 }>;
 
 export default function VerifiedBuildPage(props: Props) {
-    // return <VerifiedBuildClient {...props} />;
-    throw redirect(`/address/${props.params.address}`);
+    return <VerifiedBuildClient {...props} />;
 }

--- a/app/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/app/components/account/UpgradeableLoaderAccountSection.tsx
@@ -24,7 +24,7 @@ import { useSquadsMultisigLookup } from '@/app/providers/squadsMultisig';
 import { Cluster } from '@/app/utils/cluster';
 import { useClusterPath } from '@/app/utils/url';
 
-// import { VerifiedProgramBadge } from '../common/VerifiedProgramBadge';
+import { VerifiedProgramBadge } from '../common/VerifiedProgramBadge';
 
 export function UpgradeableLoaderAccountSection({
     account,
@@ -119,14 +119,14 @@ export function UpgradeableProgramSection({
                             <td>Upgradeable</td>
                             <td className="text-lg-end">{programData.authority !== null ? 'Yes' : 'No'}</td>
                         </tr>
-                        {/* <tr>
+                        <tr>
                             <td>
                                 <VerifiedLabel />
                             </td>
                             <td className="text-lg-end">
                                 <VerifiedProgramBadge programData={programData} pubkey={account.pubkey} />
                             </td>
-                        </tr> */}
+                        </tr>
                         <tr>
                             <td>
                                 <SecurityLabel />
@@ -183,7 +183,6 @@ function SecurityLabel() {
     );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function VerifiedLabel() {
     return (
         <InfoTooltip text="Verified builds allow users can ensure that the hash of the on-chain program matches the hash of the program of the given codebase (registry hosted by osec.io).">

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -2,6 +2,7 @@ import { ErrorCard } from '@components/common/ErrorCard';
 import { TableCardBody } from '@components/common/TableCardBody';
 import { UpgradeableLoaderAccountData } from '@providers/accounts';
 import { PublicKey } from '@solana/web3.js';
+import Link from 'next/link';
 import { ExternalLink } from 'react-feather';
 
 import { OsecRegistryInfo, useVerifiedProgram, VerificationStatus } from '@/app/utils/verified-builds';
@@ -26,7 +27,16 @@ export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAcc
     }
 
     if (!registryInfo) {
-        return <ErrorCard text="Verified build information not yet uploaded by program authority" />;
+        return (
+            <div className="card">
+                <div className="card-body text-center">
+                    Verified build information not yet uploaded by program authority. For more information, see the{' '}
+                    <Link href="https://solana.com/developers/guides/advanced/verified-builds" target="_blank">
+                        Verified Build Guide
+                    </Link>
+                </div>
+            </div>
+        );
     }
 
     // Define the message based on the verification status
@@ -54,7 +64,7 @@ export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAcc
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    Verified Builds Docs <ExternalLink className="align-text-top ms-1" size={13} />
+                    Verified Builds Guide <ExternalLink className="align-text-top ms-1" size={13} />
                 </a>
                 .
             </div>

--- a/app/components/common/VerifiedProgramBadge.tsx
+++ b/app/components/common/VerifiedProgramBadge.tsx
@@ -2,7 +2,7 @@ import { PublicKey } from '@solana/web3.js';
 import Link from 'next/link';
 
 import { useClusterPath } from '@/app/utils/url';
-import { useVerifiedProgramRegistry } from '@/app/utils/verified-builds';
+import { useVerifiedProgram } from '@/app/utils/verified-builds';
 import { ProgramDataAccountInfo } from '@/app/validators/accounts/upgradeable-program';
 
 export function VerifiedProgramBadge({
@@ -12,7 +12,7 @@ export function VerifiedProgramBadge({
     programData: ProgramDataAccountInfo;
     pubkey: PublicKey;
 }) {
-    const { isLoading, data: registryInfo } = useVerifiedProgramRegistry({
+    const { isLoading, data: registryInfo } = useVerifiedProgram({
         programAuthority: programData.authority ? new PublicKey(programData.authority) : null,
         programData: programData,
         programId: pubkey,

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -211,22 +211,8 @@ function coalesceCommandFromPda(verifiedData: OsecRegistryInfo, programId: Publi
 
     // Add additional args if available, for example mount-path and --library-name
     if (pdaData.args && pdaData.args.length > 0) {
-        const filteredArgs = [];
-
-        for (let i = 0; i < pdaData.args.length; i++) {
-            const arg = pdaData.args[i];
-
-            if (arg === '-b' || arg === '--base-image') {
-                i++; // Also skip the parameter
-                continue;
-            }
-            filteredArgs.push(arg);
-        }
-
-        if (filteredArgs.length > 0) {
-            const argsString = filteredArgs.join(' ');
-            verifiedData.verify_command += ` ${argsString}`;
-        }
+        const argsString = pdaData.args.join(' ');
+        verifiedData.verify_command += ` ${argsString}`;
     }
     verifiedData.repo_url = pdaData.gitUrl;
     if (verifiedData.verification_status === VerificationStatus.NotVerified) {

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -19,6 +19,7 @@ export enum VerificationStatus {
 
 export type OsecRegistryInfo = {
     verification_status: VerificationStatus;
+    signer: string;
     is_verified: boolean;
     message: string;
     on_chain_hash: string;
@@ -26,6 +27,21 @@ export type OsecRegistryInfo = {
     last_verified_at: string | null;
     repo_url: string;
     verify_command: string;
+};
+
+export type OsecInfo = {
+    signer: string;
+    is_verified: boolean;
+    on_chain_hash: string;
+    executable_hash: string;
+    repo_url: string;
+    commit: string;
+    last_verified_at: string;
+};
+
+const TRUSTED_SIGNERS: Record<string, string> = {
+    '9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU': 'OtterSecurity',
+    CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn: 'Explorer',
 };
 
 export function useVerifiedProgramRegistry({
@@ -39,9 +55,6 @@ export function useVerifiedProgramRegistry({
     options?: { suspense: boolean };
     programData?: ProgramDataAccountInfo;
 }) {
-    const { url: clusterUrl, cluster: cluster } = useCluster();
-    const connection = new Connection(clusterUrl);
-
     const {
         data: registryData,
         error: registryError,
@@ -49,101 +62,178 @@ export function useVerifiedProgramRegistry({
     } = useSWRImmutable(
         `${programId.toBase58()}`,
         async (programId: string) => {
-            const response = await fetch(`${OSEC_REGISTRY_URL}/status/${programId}`);
+            const response = await fetch(`${OSEC_REGISTRY_URL}/status-all/${programId}`);
 
-            return response.json();
+            return response.json() as Promise<OsecInfo[]>;
         },
         { suspense: options?.suspense }
     );
 
-    if (programData && registryData) {
-        const hash = hashProgramData(programData);
-        registryData.verification_status =
-            hash === registryData['on_chain_hash'] ? VerificationStatus.Verified : VerificationStatus.NotVerified;
+    if (!programData || !registryData) {
+        return { data: null, error: registryError, isLoading: isRegistryLoading };
     }
+
+    // Only trust entries that are verified and signed by a trusted signer or the program authority
+    const trustedEntries = registryData.filter(
+        entry => (TRUSTED_SIGNERS[entry.signer] || entry.signer === programAuthority?.toBase58()) && entry.is_verified
+    );
+
+    // Update the verification status of the trusted entries based on the on-chain hash
+    const hash = hashProgramData(programData);
+    trustedEntries.forEach(entry => {
+        entry.is_verified = hash === entry['on_chain_hash'];
+    });
+
+    return { data: trustedEntries, isLoading: isRegistryLoading };
+}
+
+// Method to fetch verified build information for a given program
+// Returns the first verified entry that is signed by the program authority or a trusted signer
+export function useVerifiedProgram({
+    programId,
+    programAuthority,
+    options,
+    programData,
+}: {
+    programId: PublicKey;
+    programAuthority: PublicKey | null;
+    options?: { suspense: boolean };
+    programData?: ProgramDataAccountInfo;
+}) {
+    const { data: registryData } = useVerifiedProgramRegistry({
+        options,
+        programAuthority,
+        programData,
+        programId,
+    });
+
+    const mappedBySigner: Record<string, OsecInfo> = {};
+
+    // Map the registryData by signer in order to enforce hierarchy of trust
+    registryData?.forEach(entry => {
+        mappedBySigner[entry.signer] = entry;
+    });
+
+    // Get the program authority's entry first, then the trusted signers
+    const hierarchy = [...(programAuthority ? [programAuthority.toBase58()] : []), ...Object.keys(TRUSTED_SIGNERS)];
+    const orderedVerifiedEntries: OsecInfo[] = [];
+    for (const signer of hierarchy) {
+        if (mappedBySigner[signer]) {
+            orderedVerifiedEntries.push(mappedBySigner[signer]);
+        }
+    }
+
+    // Get the first verified entry
+    const verifiedData = orderedVerifiedEntries.find(entry => entry.is_verified);
+
+    return useEnrichedOsecInfo({ options, osecInfo: verifiedData, programId });
+}
+
+// Internal method to enrich the osec info with the verify command (requires fetching the on-chain PDA)
+function useEnrichedOsecInfo({
+    programId,
+    osecInfo,
+    options,
+}: {
+    programId: PublicKey;
+    osecInfo: OsecInfo | undefined;
+    options?: { suspense: boolean };
+}) {
+    const { url: clusterUrl, cluster: cluster } = useCluster();
+    const connection = new Connection(clusterUrl);
 
     const { program: accountAnchorProgram } = useAnchorProgram(VERIFY_PROGRAM_ID, connection.rpcEndpoint);
 
     // Fetch the PDA derived from the program upgrade authority
-    // TODO: Add getting verifier pubkey from the security.txt as second option once implemented
     const {
         data: pdaData,
         error: pdaError,
         isLoading: isPdaLoading,
     } = useSWRImmutable(
-        programAuthority && accountAnchorProgram ? `pda-${programId.toBase58()}` : null,
+        accountAnchorProgram ? `pda-${programId.toBase58()}-${osecInfo?.signer}` : null,
         async () => {
-            if (!programAuthority) {
-                console.log('Program authority not defined');
+            if (!osecInfo || !accountAnchorProgram) {
                 return null;
             }
+
             const [pda] = PublicKey.findProgramAddressSync(
-                [Buffer.from('otter_verify'), programAuthority.toBuffer(), programId.toBuffer()],
+                [Buffer.from('otter_verify'), new PublicKey(osecInfo.signer).toBuffer(), programId.toBuffer()],
                 new PublicKey(VERIFY_PROGRAM_ID)
             );
-            const pdaAccountInfo = await connection.getAccountInfo(pda);
-            if (!pdaAccountInfo || !pdaAccountInfo.data) {
-                console.log('PDA account info not found');
+
+            const pdaAccountInfo = await (accountAnchorProgram.account as any).buildParams.fetch(pda);
+            if (!pdaAccountInfo) {
                 return null;
             }
-            return accountAnchorProgram?.coder.accounts.decode('buildParams', pdaAccountInfo.data);
+            return pdaAccountInfo;
         },
         { suspense: options?.suspense }
     );
 
-    const isLoading = isRegistryLoading || isPdaLoading;
-
-    if (registryError || pdaError) {
-        return { data: null, error: registryError || pdaError, isLoading };
+    if (!osecInfo || pdaError) {
+        return { data: null, error: pdaError, isLoading: isPdaLoading };
+    }
+    if (isPdaLoading) {
+        return { data: null, isLoading: isPdaLoading };
     }
 
-    // Create command from the args of the verify PDA
-    if (registryData && pdaData && !isLoading) {
-        const verifiedData = registryData as OsecRegistryInfo;
-        verifiedData.verify_command = `solana-verify verify-from-repo -um --program-id ${programId.toBase58()} ${
-            pdaData.gitUrl
-        }`;
+    const message = TRUSTED_SIGNERS[osecInfo?.signer || '']
+        ? 'Verification information provided by a trusted signer.'
+        : 'Verification information provided by the program authority.';
 
-        if (pdaData.commit) {
-            verifiedData.verify_command += ` --commit-hash ${pdaData.commit}`;
-        }
-
-        // Add additional args if available, for example mount-path and --library-name
-        if (pdaData.args && pdaData.args.length > 0) {
-            const filteredArgs = [];
-
-            for (let i = 0; i < pdaData.args.length; i++) {
-                const arg = pdaData.args[i];
-
-                if (arg === '-b' || arg === '--base-image') {
-                    i++; // Also skip the parameter
-                    continue;
-                }
-                filteredArgs.push(arg);
-            }
-
-            if (filteredArgs.length > 0) {
-                const argsString = filteredArgs.join(' ');
-                verifiedData.verify_command += ` ${argsString}`;
-            }
-        }
-        verifiedData.repo_url = pdaData.gitUrl;
-        if (registryData.verification_status === VerificationStatus.NotVerified) {
-            verifiedData.message = 'Verify command was provided by the program authority.';
-            verifiedData.verification_status = VerificationStatus.PdaUploaded;
-        }
-        return { data: verifiedData, isLoading };
-    }
-    if (registryData && pdaData == null && !isLoading) {
-        const verifiedData = registryData as OsecRegistryInfo;
-
-        verifiedData.verify_command = isMainnet(cluster)
+    const enrichedOsecInfo: OsecRegistryInfo = {
+        ...osecInfo,
+        message,
+        signer: osecInfo?.signer || '',
+        verification_status: VerificationStatus.Verified,
+        verify_command: '',
+    };
+    if (pdaData) {
+        // Create command from the args of the verify PDA
+        const verifiedData = coalesceCommandFromPda(enrichedOsecInfo, programId, pdaData);
+        return { data: verifiedData, isLoading: isPdaLoading };
+    } else {
+        enrichedOsecInfo.verify_command = isMainnet(cluster)
             ? 'Program does not have a verify PDA uploaded.'
             : 'Verify command only available on mainnet.';
-        return { data: verifiedData, isLoading };
+        return { data: enrichedOsecInfo, isLoading: isPdaLoading };
+    }
+}
+
+function coalesceCommandFromPda(verifiedData: OsecRegistryInfo, programId: PublicKey, pdaData: any) {
+    verifiedData.verify_command = `solana-verify verify-from-repo -um --program-id ${programId.toBase58()} ${
+        pdaData.gitUrl
+    }`;
+
+    if (pdaData.commit) {
+        verifiedData.verify_command += ` --commit-hash ${pdaData.commit}`;
     }
 
-    return { data: null, isLoading };
+    // Add additional args if available, for example mount-path and --library-name
+    if (pdaData.args && pdaData.args.length > 0) {
+        const filteredArgs = [];
+
+        for (let i = 0; i < pdaData.args.length; i++) {
+            const arg = pdaData.args[i];
+
+            if (arg === '-b' || arg === '--base-image') {
+                i++; // Also skip the parameter
+                continue;
+            }
+            filteredArgs.push(arg);
+        }
+
+        if (filteredArgs.length > 0) {
+            const argsString = filteredArgs.join(' ');
+            verifiedData.verify_command += ` ${argsString}`;
+        }
+    }
+    verifiedData.repo_url = pdaData.gitUrl;
+    if (verifiedData.verification_status === VerificationStatus.NotVerified) {
+        verifiedData.message = 'Verify command was provided by the program authority.';
+        verifiedData.verification_status = VerificationStatus.PdaUploaded;
+    }
+    return verifiedData;
 }
 
 function isMainnet(currentCluster: Cluster): boolean {


### PR DESCRIPTION
Verified Build information was susceptible to a "griefing" attack disclosed by security firm Accretion. The vulnerability stemmed from the fact that anyone could overwrite verified build information in the OSec API by providing a more recent verified build information. This allowed malicious actors to overwrite protocol's GitHub repo url in the OSec API.

This has now been patched by OtterSec. The fix requires that program developers write their verified build arguments on-chain using their program authority. 

For previously verified programs, their verification information was uploaded by the OSec team. However, to update previously verified information, teams must deploy their verified build information onchain.

For teams using multisig program authorities, we've described a process to prepare this transaction using `solana-verify` `v0.4.0` here: https://solana.com/developers/guides/advanced/verified-builds#how-to-verify-your-program-when-its-controlled-by-a-multisig-like-squads