### PR TITLE
Add support for Lighthouse instructions

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -10,6 +10,7 @@ console.log (`Checking for package peerDependency overrides`);
 
 const remapPeerDependencies = [
   { package: '@solana-program/compute-budget', packageVersion: '0.6.1', peerDependency: '@solana/web3.js', newVersion: '2.0.0' },
+  { package: 'lighthouse-sdk', packageVersion: '2.0.1', peerDependency: '@solana/web3.js', newVersion: '2.0.0' },
 ];
 
 function overridesPeerDependencies(pkg) {

--- a/app/components/instruction/InstructionCard.tsx
+++ b/app/components/instruction/InstructionCard.tsx
@@ -51,7 +51,6 @@ export function InstructionCard({
 
         return setShowRaw(r => !r);
     };
-    // Need to wrap this in a useEffect to avoid hydration errors
     const scrollAnchorRef = useScrollAnchor(
         getInstructionCardScrollAnchorId(childIndex != null ? [index + 1, childIndex + 1] : [index + 1])
     );

--- a/app/components/instruction/InstructionCard.tsx
+++ b/app/components/instruction/InstructionCard.tsx
@@ -51,6 +51,7 @@ export function InstructionCard({
 
         return setShowRaw(r => !r);
     };
+    // Need to wrap this in a useEffect to avoid hydration errors
     const scrollAnchorRef = useScrollAnchor(
         getInstructionCardScrollAnchorId(childIndex != null ? [index + 1, childIndex + 1] : [index + 1])
     );

--- a/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
+++ b/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
@@ -50,6 +50,7 @@ function upcastTransactionInstruction(ix: TransactionInstruction) {
         programAddress: address(ix.programId.toBase58()),
     };
 }
+
 type ParsedCodamaInstruction = {
     programAddress: TAddress;
     accounts?: Record<string, IAccountMeta>;
@@ -78,6 +79,7 @@ export function LighthouseDetailsCard({
         </InstructionCard>
     );
 }
+
 function parseLighthouseInstruction(ix: ReturnType<typeof upcastTransactionInstruction>) {
     let title = 'Unknown';
     let info: ParsedCodamaInstruction;

--- a/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
+++ b/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
@@ -40,6 +40,7 @@ import { camelToTitleCase } from '@/app/utils';
 import { ExpandableRow } from '@/app/utils/anchor';
 import { AccountDataAssertion } from 'lighthouse-sdk/dist/types/hooked';
 import { CornerDownRight } from 'react-feather';
+import React from 'react';
 
 function upcastTransactionInstruction(ix: TransactionInstruction): IInstruction {
     return {
@@ -366,23 +367,33 @@ function CodamaCard({ ix, parsedIx }: { ix: IInstruction; parsedIx: ParsedCodama
 }
 
 function mapIxArgsToRows(data: any, nestingLevel: number = 0) {
-    return Object.entries(data).map(([key, value]) => {
+    return Object.entries(data).map(([key, value], index) => {
         if (key === '__kind' || key === 'discriminator') {
             return null;
         }
 
         let type = 'unknown';
 
+        const baseKey = `${nestingLevel}-${index}`;
         if (Array.isArray(value)) {
             type = `Array[${value.length}]`;
             return (
-                <ExpandableRow fieldName={key} fieldType={type} nestingLevel={nestingLevel}>
+                <ExpandableRow
+                    key={`${nestingLevel}-${index}`}
+                    fieldName={key}
+                    fieldType={type}
+                    nestingLevel={nestingLevel}
+                >
                     {value.map((item, i) => {
                         if (typeof item === 'object') {
-                            return mapIxArgsToRows({ [`#${i}`]: item }, nestingLevel + 1);
+                            return (
+                                <React.Fragment key={`${baseKey}-${i}`}>
+                                    {mapIxArgsToRows({ [`#${i}`]: item }, nestingLevel + 1)}
+                                </React.Fragment>
+                            );
                         }
                         return (
-                            <tr key={i}>
+                            <tr key={`${baseKey}-${i}`}>
                                 <td>
                                     <div className="d-flex align-items-center">
                                         <div className="me-2">{`#${i}`}</div>
@@ -400,7 +411,7 @@ function mapIxArgsToRows(data: any, nestingLevel: number = 0) {
         if (typeof value === 'object' && value !== null) {
             type = (value as any).__kind || 'Object';
             return (
-                <ExpandableRow fieldName={key} fieldType={type} nestingLevel={nestingLevel}>
+                <ExpandableRow key={baseKey} fieldName={key} fieldType={type} nestingLevel={nestingLevel}>
                     {mapIxArgsToRows(value, nestingLevel + 1)}
                 </ExpandableRow>
             );
@@ -417,7 +428,7 @@ function mapIxArgsToRows(data: any, nestingLevel: number = 0) {
         }
 
         return (
-            <tr>
+            <tr key={baseKey}>
                 <td className="d-flex flex-row">
                     {nestingLevel > 0 && (
                         <span style={{ paddingLeft: `${15 * nestingLevel}px` }}>

--- a/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
+++ b/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
@@ -1,0 +1,458 @@
+import { PublicKey, SignatureResult, TransactionInstruction } from '@solana/web3.js';
+import {
+    identifyLighthouseInstruction,
+    LighthouseInstruction,
+    parseAssertAccountDataInstruction,
+    parseAssertAccountDataMultiInstruction,
+    parseAssertAccountDeltaInstruction,
+    parseAssertAccountInfoInstruction,
+    parseAssertAccountInfoMultiInstruction,
+    parseAssertBubblegumTreeConfigAccountInstruction,
+    parseAssertMerkleTreeAccountInstruction,
+    parseAssertMintAccountInstruction,
+    parseAssertMintAccountMultiInstruction,
+    parseAssertStakeAccountInstruction,
+    parseAssertStakeAccountMultiInstruction,
+    parseAssertSysvarClockInstruction,
+    parseAssertTokenAccountInstruction,
+    parseAssertTokenAccountMultiInstruction,
+    parseAssertUpgradeableLoaderAccountInstruction,
+    parseAssertUpgradeableLoaderAccountMultiInstruction,
+    parseMemoryCloseInstruction,
+    parseMemoryWriteInstruction,
+    IntegerOperator,
+    EquatableOperator,
+    ParsedLighthouseInstruction,
+    AccountInfoAssertion,
+    TokenAccountAssertion,
+    MintAccountAssertion,
+    StakeAccountAssertion,
+    UpgradeableLoaderStateAssertion,
+    MerkleTreeAssertion,
+    BubblegumTreeConfigAssertion,
+    DataValueAssertion,
+} from 'lighthouse-sdk';
+import { AccountRole, address, IAccountMeta, IInstruction, Address as TAddress } from 'web3js-experimental';
+
+import { InstructionCard } from '../InstructionCard';
+import { Address } from '../../common/Address';
+import { LIGHTHOUSE_ADDRESS } from './types';
+import { camelToTitleCase } from '@/app/utils';
+import { ExpandableRow } from '@/app/utils/anchor';
+import { AccountDataAssertion } from 'lighthouse-sdk/dist/types/hooked';
+import { assert } from 'console';
+import { CornerDownRight } from 'react-feather';
+
+function upcastTransactionInstruction(ix: TransactionInstruction): IInstruction {
+    return {
+        accounts: ix.keys.map(key => ({
+            address: address(key.pubkey.toBase58()),
+            role: key.isSigner
+                ? key.isWritable
+                    ? AccountRole.WRITABLE_SIGNER
+                    : AccountRole.READONLY_SIGNER
+                : key.isWritable
+                ? AccountRole.WRITABLE
+                : AccountRole.READONLY,
+        })),
+        data: ix.data,
+        programAddress: address(ix.programId.toBase58()),
+    };
+}
+type ParsedCodamaInstruction = {
+    programAddress: TAddress;
+    accounts?: Record<string, IAccountMeta>;
+    data: any;
+};
+
+export function LighthouseDetailsCard({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+}: {
+    ix: TransactionInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: JSX.Element[];
+    childIndex?: number;
+}) {
+    let _ix = upcastTransactionInstruction(ix);
+    const { title, info } = parseLighthouseInstruction(_ix);
+
+    return (
+        <InstructionCard title={`Lighthouse: ${title}`} {...{ ix, index, childIndex, result, innerCards }}>
+            <CodamaCard ix={_ix} parsedIx={info} />
+        </InstructionCard>
+    );
+}
+function parseLighthouseInstruction(ix: IInstruction) {
+    let title = 'Unknown';
+    let info: ParsedCodamaInstruction;
+    const subEnum = (pix: ParsedCodamaInstruction, key: string, array: boolean = false) => {
+        console.log(pix.data, key, array);
+        if (array) {
+            pix.data[key].forEach((assertion: Parameters<typeof renderEnumsAsStrings>[0]) => {
+                renderEnumsAsStrings(assertion);
+            });
+        } else {
+            renderEnumsAsStrings(pix.data[key]);
+        }
+        return pix;
+    };
+    switch (identifyLighthouseInstruction(ix)) {
+        case LighthouseInstruction.MemoryClose:
+            title = 'Memory Close';
+            info = parseMemoryCloseInstruction(ix);
+            return { title, info };
+        case LighthouseInstruction.MemoryWrite:
+            title = 'Memory Write';
+            info = parseMemoryWriteInstruction(ix);
+            return { title, info };
+        case LighthouseInstruction.AssertMerkleTreeAccount:
+            title = 'Assert Merkle Tree Account';
+            info = subEnum(parseAssertMerkleTreeAccountInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertMintAccount:
+            title = 'Assert Mint Account';
+            info = subEnum(parseAssertMintAccountInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertAccountData:
+            title = 'Assert Account Data';
+            info = subEnum(parseAssertAccountDataInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertAccountDataMulti:
+            title = 'Assert Account Data Multi';
+            info = subEnum(parseAssertAccountDataMultiInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertTokenAccount:
+            title = 'Assert Token Account';
+            info = subEnum(parseAssertTokenAccountInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertAccountDelta:
+            title = 'Assert Account Delta';
+            info = subEnum(parseAssertAccountDeltaInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertAccountInfo:
+            title = 'Assert Account Info';
+            info = subEnum(parseAssertAccountInfoInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertAccountInfoMulti:
+            title = 'Assert Account Info Multi';
+            info = subEnum(parseAssertAccountInfoMultiInstruction(ix), 'assertions', true);
+            return { title, info };
+        case LighthouseInstruction.AssertMintAccountMulti:
+            title = 'Assert Mint Account Multi';
+            info = subEnum(parseAssertMintAccountMultiInstruction(ix), 'assertions', true);
+            return { title, info };
+        case LighthouseInstruction.AssertTokenAccountMulti:
+            title = 'Assert Token Account Multi';
+            info = subEnum(parseAssertTokenAccountMultiInstruction(ix), 'assertions', true);
+            return { title, info };
+        case LighthouseInstruction.AssertStakeAccount:
+            title = 'Assert Stake Account';
+            info = subEnum(parseAssertStakeAccountInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertStakeAccountMulti:
+            title = 'Assert Stake Account Multi';
+            info = subEnum(parseAssertStakeAccountMultiInstruction(ix), 'assertions', true);
+            return { title, info };
+        case LighthouseInstruction.AssertUpgradeableLoaderAccount:
+            title = 'Assert Upgradeable Loader Account';
+            info = subEnum(parseAssertUpgradeableLoaderAccountInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertUpgradeableLoaderAccountMulti:
+            title = 'Assert Upgradeable Loader Account Multi';
+            info = subEnum(parseAssertUpgradeableLoaderAccountMultiInstruction(ix), 'assertions', true);
+            return { title, info };
+        case LighthouseInstruction.AssertSysvarClock:
+            title = 'Assert Sysvar Clock';
+            info = subEnum(parseAssertSysvarClockInstruction(ix), 'assertion');
+            return { title, info };
+        case LighthouseInstruction.AssertBubblegumTreeConfigAccount:
+            title = 'Assert Bubblegum Tree Config Account';
+            info = subEnum(parseAssertBubblegumTreeConfigAccountInstruction(ix), 'assertion');
+            return { title, info };
+    }
+}
+
+function renderEnumsAsStrings(
+    assertion:
+        | AccountInfoAssertion
+        | AccountDataAssertion
+        | DataValueAssertion
+        | MintAccountAssertion
+        | TokenAccountAssertion
+        | StakeAccountAssertion
+        | UpgradeableLoaderStateAssertion
+        | MerkleTreeAssertion
+        | BubblegumTreeConfigAssertion
+) {
+    if ('offset' in assertion) {
+        renderEnumsAsStrings(assertion.assertion);
+        return;
+    }
+    switch (assertion.__kind) {
+        case 'State':
+        case 'U8':
+        case 'I8':
+        case 'U16':
+        case 'I16':
+        case 'U32':
+        case 'I32':
+        case 'U64':
+        case 'I64':
+        case 'I128':
+        case 'U128':
+        case 'Lamports':
+        case 'DataLength':
+        case 'RentEpoch':
+        case 'TotalMintCapacity':
+        case 'NumMinted':
+        case 'Supply':
+        case 'Decimals':
+        case 'Amount':
+        case 'DelegatedAmount':
+            // @ts-ignore
+            assertion.operator = renderIntegerOperator(assertion.operator);
+            break;
+
+        case 'MetaAssertion':
+        case 'StakeAssertion':
+        case 'Buffer':
+        case 'Program':
+        case 'ProgramData':
+            assertion.fields.forEach(field => {
+                switch (field.__kind) {
+                    case 'RentExemptReserve':
+                    case 'LockupEpoch':
+                    case 'LockupUnixTimestamp':
+                    case 'DelegationStake':
+                    case 'DelegationActivationEpoch':
+                    case 'DelegationDeactivationEpoch':
+                    case 'CreditsObserved':
+                    case 'Slot':
+                        // @ts-ignore
+                        field.operator = renderIntegerOperator(field.operator);
+                        break;
+                    case 'AuthorizedWithdrawer':
+                    case 'LockupCustodian':
+                    case 'AuthorizedStaker':
+                    case 'DelegationVoterPubkey':
+                    case 'Authority':
+                    case 'ProgramDataAddress':
+                    case 'UpgradeAuthority':
+                        // @ts-ignore
+                        field.operator = renderEquatableOperator(field.operator);
+                        break;
+                }
+            });
+            break;
+
+        case 'StakeFlags':
+        case 'CloseAuthority':
+        case 'Delegate':
+        case 'IsNative':
+        case 'Mint':
+        case 'FreezeAuthority':
+        case 'IsInitialized':
+        case 'Pubkey':
+        case 'MintAuthority':
+        case 'TreeCreator':
+        case 'TreeDelegate':
+        case 'Bytes':
+        case 'IsPublic':
+        case 'IsDecompressible':
+        case 'KnownOwner':
+        case 'IsSigner':
+        case 'IsWritable':
+        case 'Executable':
+        case 'Bool':
+        case 'Owner':
+            // @ts-ignore
+            assertion.operator = renderEquatableOperator(assertion.operator);
+            break;
+
+        case 'VerifyDatahash':
+        case 'VerifyLeaf':
+        case 'TokenAccountOwnerIsDerived':
+            break;
+    }
+}
+
+function renderIntegerOperator(operator: IntegerOperator) {
+    switch (operator) {
+        case IntegerOperator.GreaterThan:
+            return '>';
+        case IntegerOperator.LessThan:
+            return '<';
+        case IntegerOperator.GreaterThanOrEqual:
+            return '>=';
+        case IntegerOperator.LessThanOrEqual:
+            return '<=';
+        case IntegerOperator.Equal:
+            return '=';
+    }
+}
+
+function renderEquatableOperator(operator: EquatableOperator) {
+    switch (operator) {
+        case EquatableOperator.Equal:
+            return '=';
+        case EquatableOperator.NotEqual:
+            return '!=';
+    }
+}
+
+function CodamaCard({ ix, parsedIx }: { ix: IInstruction; parsedIx: ParsedCodamaInstruction }) {
+    const programName = 'Lighthouse';
+    const programId = new PublicKey(LIGHTHOUSE_ADDRESS);
+
+    const parsedAccountsLength = parsedIx.accounts ? Object.keys(parsedIx.accounts).length : 0;
+    const accountMap = parsedIx.accounts
+        ? new Map(Object.entries(parsedIx.accounts).map(([key, value]) => [value.address, key]))
+        : new Map();
+    return (
+        <>
+            <tr>
+                <td>Program</td>
+                <td className="text-lg-end" colSpan={2}>
+                    <Address pubkey={programId} alignRight link raw overrideText={programName} />
+                </td>
+            </tr>
+            <tr className="table-sep">
+                <td>Account Name</td>
+                <td className="text-lg-end" colSpan={2}>
+                    Address
+                </td>
+            </tr>
+            {ix.accounts?.map(({ address, role }, keyIndex) => {
+                return (
+                    <tr key={keyIndex}>
+                        <td>
+                            <div className="me-2 d-md-inline">
+                                {parsedIx.accounts
+                                    ? keyIndex < parsedAccountsLength
+                                        ? `${camelToTitleCase(accountMap.get(address) ?? 'Unknown')}`
+                                        : `Remaining Account #${keyIndex + 1 - parsedAccountsLength}`
+                                    : `Account #${keyIndex + 1}`}
+                            </div>
+                            {role == AccountRole.WRITABLE ||
+                                (role == AccountRole.WRITABLE_SIGNER && (
+                                    <span className="badge bg-danger-soft me-1">Writable</span>
+                                ))}
+                            {role == AccountRole.READONLY_SIGNER ||
+                                (role == AccountRole.WRITABLE_SIGNER && (
+                                    <span className="badge bg-info-soft me-1">Signer</span>
+                                ))}
+                        </td>
+                        <td className="text-lg-end" colSpan={2}>
+                            <Address pubkey={new PublicKey(address)} alignRight link />
+                        </td>
+                    </tr>
+                );
+            })}
+
+            {parsedIx.data && (
+                <>
+                    <tr className="table-sep">
+                        <td>Argument Name</td>
+                        <td>Type</td>
+                        <td className="text-lg-end">Value</td>
+                    </tr>
+                    {mapIxArgsToRows(parsedIx.data)}
+                </>
+            )}
+        </>
+    );
+}
+
+function mapIxArgsToRows(data: any, nestingLevel: number = 0) {
+    return Object.entries(data).map(([key, value]) => {
+        if (key === '__kind' || key === 'discriminator') {
+            return null;
+        }
+
+        let type = 'unknown';
+
+        if (Array.isArray(value)) {
+            type = `Array[${value.length}]`;
+            return (
+                <ExpandableRow fieldName={key} fieldType={type} nestingLevel={nestingLevel}>
+                    {value.map((item, i) => {
+                        if (typeof item === 'object') {
+                            return mapIxArgsToRows({ [`#${i}`]: item }, nestingLevel + 1);
+                        }
+                        return (
+                            <tr key={i}>
+                                <td>
+                                    <div className="d-flex align-items-center">
+                                        <div className="me-2">{`#${i}`}</div>
+                                    </div>
+                                </td>
+                                <td>{typeof item}</td>
+                                <td className="text-lg-end">{String(item)}</td>
+                            </tr>
+                        );
+                    })}
+                </ExpandableRow>
+            );
+        }
+
+        if (typeof value === 'object' && value !== null) {
+            type = (value as any).__kind || 'Object';
+            return (
+                <ExpandableRow fieldName={key} fieldType={type} nestingLevel={nestingLevel}>
+                    {mapIxArgsToRows(value, nestingLevel + 1)}
+                </ExpandableRow>
+            );
+        }
+
+        // Infer how to render values
+        // TODO: Fix this for enum values
+        type = inferType(value);
+        let displayValue;
+        if (type === 'pubkey') {
+            displayValue = <Address pubkey={new PublicKey(value as string)} alignRight link />;
+        } else {
+            displayValue = <>{String(value)}</>;
+        }
+
+        return (
+            <tr
+            // style={{
+            //     ...(nestingLevel === 0 ? {} : { backgroundColor: '#141816' }),
+            // }}
+            >
+                <td className="d-flex flex-row">
+                    {nestingLevel > 0 && (
+                        <span style={{ paddingLeft: `${15 * nestingLevel}px` }}>
+                            <CornerDownRight className="me-2" size={15} />
+                        </span>
+                    )}
+                    <div>{key}</div>
+                </td>
+                <td>{type}</td>
+                <td className="text-lg-end">{displayValue}</td>
+            </tr>
+        );
+    });
+}
+
+function inferType(value: any) {
+    if (typeof value === 'string') {
+        try {
+            new PublicKey(value);
+            return 'pubkey';
+        } catch {
+            return 'string';
+        }
+    } else if (typeof value === 'number') {
+        return 'number';
+    } else if (typeof value === 'bigint') {
+        return 'bignum';
+    } else {
+        return typeof value;
+    }
+}

--- a/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
+++ b/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
@@ -197,11 +197,11 @@ type ComplexAssertion = {
 };
 
 function renderEnumsAsStrings(assertion: Assertion | OffsetAssertion): any {
-    // Handle offset assertions first
-    if ('offset' in assertion) {
+    // Handle offset assertion & AccountInfo assertion
+    if ('offset' in assertion || 'assertion' in assertion) {
         return {
             ...assertion,
-            assertion: renderEnumsAsStrings(assertion.assertion),
+            assertion: renderEnumsAsStrings((assertion as { assertion: Assertion }).assertion),
         };
     }
 

--- a/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
+++ b/app/components/instruction/lighthouse/LighthouseDetailsCard.tsx
@@ -22,7 +22,6 @@ import {
     parseMemoryWriteInstruction,
     IntegerOperator,
     EquatableOperator,
-    ParsedLighthouseInstruction,
     AccountInfoAssertion,
     TokenAccountAssertion,
     MintAccountAssertion,
@@ -40,7 +39,6 @@ import { LIGHTHOUSE_ADDRESS } from './types';
 import { camelToTitleCase } from '@/app/utils';
 import { ExpandableRow } from '@/app/utils/anchor';
 import { AccountDataAssertion } from 'lighthouse-sdk/dist/types/hooked';
-import { assert } from 'console';
 import { CornerDownRight } from 'react-feather';
 
 function upcastTransactionInstruction(ix: TransactionInstruction): IInstruction {
@@ -91,7 +89,6 @@ function parseLighthouseInstruction(ix: IInstruction) {
     let title = 'Unknown';
     let info: ParsedCodamaInstruction;
     const subEnum = (pix: ParsedCodamaInstruction, key: string, array: boolean = false) => {
-        console.log(pix.data, key, array);
         if (array) {
             pix.data[key].forEach((assertion: Parameters<typeof renderEnumsAsStrings>[0]) => {
                 renderEnumsAsStrings(assertion);
@@ -420,11 +417,7 @@ function mapIxArgsToRows(data: any, nestingLevel: number = 0) {
         }
 
         return (
-            <tr
-            // style={{
-            //     ...(nestingLevel === 0 ? {} : { backgroundColor: '#141816' }),
-            // }}
-            >
+            <tr>
                 <td className="d-flex flex-row">
                     {nestingLevel > 0 && (
                         <span style={{ paddingLeft: `${15 * nestingLevel}px` }}>

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -345,47 +345,56 @@ describe('LighthouseDetailsCard', () => {
             expect(ixArgs0b).toHaveTextContent('assertions');
             expect(ixArgs0b).toHaveTextContent('Array[3]');
 
-            // Two of the followingrows have the same data-testid 'ix-args-1-0'
+            // Two of the following rows have the same data-testid 'ix-args-1-0'
+            // eslint-disable-next-line testing-library/no-node-access
             const ixArgs0bChildren = ixArgs0b.nextElementSibling;
 
             const ixArgs1a = ixArgs0bChildren;
             expect(ixArgs1a).toHaveTextContent('#0');
             expect(ixArgs1a).toHaveTextContent('Lamports');
 
-            const ixArgs1aChild0 = ixArgs1a.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1aChild0 = ixArgs1a!.nextElementSibling;
             expect(ixArgs1aChild0).toHaveTextContent('value');
             expect(ixArgs1aChild0).toHaveTextContent('bignum');
             expect(ixArgs1aChild0).toHaveTextContent('40305008');
 
-            const ixArgs1aChild1 = ixArgs1aChild0.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1aChild1 = ixArgs1aChild0!.nextElementSibling;
             expect(ixArgs1aChild1).toHaveTextContent('operator');
             expect(ixArgs1aChild1).toHaveTextContent('string');
             expect(ixArgs1aChild1).toHaveTextContent('>=');
 
-            const ixArgs1b = ixArgs1aChild1.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1b = ixArgs1aChild1!.nextElementSibling;
             expect(ixArgs1b).toHaveTextContent('#1');
             expect(ixArgs1b).toHaveTextContent('Lamports');
 
-            const ixArgs1bChild0 = ixArgs1b.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1bChild0 = ixArgs1b!.nextElementSibling;
             expect(ixArgs1bChild0).toHaveTextContent('value');
             expect(ixArgs1bChild0).toHaveTextContent('bignum');
             expect(ixArgs1bChild0).toHaveTextContent('67175012');
 
-            const ixArgs1bChild1 = ixArgs1bChild0.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1bChild1 = ixArgs1bChild0!.nextElementSibling;
             expect(ixArgs1bChild1).toHaveTextContent('operator');
             expect(ixArgs1bChild1).toHaveTextContent('string');
             expect(ixArgs1bChild1).toHaveTextContent('<=');
 
-            const ixArgs1c = ixArgs1bChild1.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1c = ixArgs1bChild1!.nextElementSibling;
             expect(ixArgs1c).toHaveTextContent('#2');
             expect(ixArgs1c).toHaveTextContent('KnownOwner');
 
-            const ixArgs1cChild0 = ixArgs1c.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1cChild0 = ixArgs1c!.nextElementSibling;
             expect(ixArgs1cChild0).toHaveTextContent('value');
             expect(ixArgs1cChild0).toHaveTextContent('number');
             expect(ixArgs1cChild0).toHaveTextContent('0');
 
-            const ixArgs1cChild1 = ixArgs1cChild0.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            const ixArgs1cChild1 = ixArgs1cChild0!.nextElementSibling;
             expect(ixArgs1cChild1).toHaveTextContent('operator');
             expect(ixArgs1cChild1).toHaveTextContent('string');
             expect(ixArgs1cChild1).toHaveTextContent('=');
@@ -428,6 +437,7 @@ describe('LighthouseDetailsCard', () => {
             expect(ixArgs0b).toHaveTextContent('Array[3]');
 
             // Two of the followingrows have the same data-testid 'ix-args-1-0'
+            // eslint-disable-next-line testing-library/no-node-access
             const ixArgs0bChildren = ixArgs0b.nextElementSibling;
 
             // 1st assertion
@@ -435,66 +445,80 @@ describe('LighthouseDetailsCard', () => {
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('MetaAssertion');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('AuthorizedWithdrawer');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('pubkey');
             expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('=');
 
             // 2nd assertion
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('#1');
             expect(next).toHaveTextContent('MetaAssertion');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('AuthorizedStaker');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('pubkey');
             expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('=');
 
             // 3rd assertion
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('#2');
             expect(next).toHaveTextContent('StakeAssertion');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('DelegationStake');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('bignum');
             expect(next).toHaveTextContent('2200000');
 
-            next = next.nextElementSibling;
+            // eslint-disable-next-line testing-library/no-node-access, @typescript-eslint/no-non-null-assertion
+            next = next!.nextElementSibling;
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('>=');

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -289,6 +289,201 @@ describe('LighthouseDetailsCard', () => {
             expect(ixArgs3b).toHaveTextContent('string');
             expect(ixArgs3b).toHaveTextContent('=');
         });
+
+        it('Renders Assert Account Delta instruction', () => {
+            // 66hhUzJEyouUj6Zge5kK8UQxKncTbmntXCPeHAL9pLEQQKeAAVKoyTwSRuF59EuMAhJcwgwEgyY6X3svHdSgHZzL
+            const ix = {
+                data: Buffer.from([
+                    4, 1, 0, 0, 0, 0, 31, 10, 250, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 4,
+                ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h'),
+                    },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u'),
+                    },
+                ],
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Account Delta')).toBeInTheDocument();
+
+            const accountRowA = screen.getByTestId('account-row-0');
+            expect(accountRowA).toHaveTextContent('Account A');
+            expect(accountRowA).toHaveTextContent('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h');
+
+            const accountRowB = screen.getByTestId('account-row-1');
+            expect(accountRowB).toHaveTextContent('Account B');
+            expect(accountRowB).toHaveTextContent('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('1');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('AccountInfo');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('aOffset');
+            expect(ixArgs1).toHaveTextContent('0');
+
+            const ixArgs2 = screen.getByTestId('ix-args-1-2');
+            expect(ixArgs2).toHaveTextContent('assertion');
+            expect(ixArgs2).toHaveTextContent('Lamports');
+
+            const ixArgs3 = screen.getByTestId('ix-args-2-1');
+            expect(ixArgs3).toHaveTextContent('value');
+            expect(ixArgs3).toHaveTextContent('bignum');
+            expect(ixArgs3).toHaveTextContent('-100000000');
+
+            const ixArgs4 = screen.getByTestId('ix-args-2-2');
+            expect(ixArgs4).toHaveTextContent('operator');
+            expect(ixArgs4).toHaveTextContent('string');
+            expect(ixArgs4).toHaveTextContent('>=');
+        });
+
+        it('Renders Memory Write instruction', () => {
+            // 66hhUzJEyouUj6Zge5kK8UQxKncTbmntXCPeHAL9pLEQQKeAAVKoyTwSRuF59EuMAhJcwgwEgyY6X3svHdSgHZzL
+            const ix = {
+                data: Buffer.from([0, 0, 254, 0, 1, 1]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+                    },
+                    { isSigner: false, isWritable: false, pubkey: new PublicKey('11111111111111111111111111111111') },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u'),
+                    },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h'),
+                    },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u'),
+                    },
+                ],
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Memory Write')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Program Id');
+            expect(accountRow).toHaveTextContent('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95');
+
+            const accountRow1 = screen.getByTestId('account-row-1');
+            expect(accountRow1).toHaveTextContent('System Program');
+            expect(accountRow1).toHaveTextContent('11111111111111111111111111111111');
+
+            const accountRow2 = screen.getByTestId('account-row-2');
+            expect(accountRow2).toHaveTextContent('Source Account');
+            expect(accountRow2).toHaveTextContent('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u');
+
+            const accountRow3 = screen.getByTestId('account-row-3');
+            expect(accountRow3).toHaveTextContent('Memory');
+            expect(accountRow3).toHaveTextContent('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h');
+
+            const accountRow4 = screen.getByTestId('account-row-4');
+            expect(accountRow4).toHaveTextContent('Source Account');
+            expect(accountRow4).toHaveTextContent('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('memoryId');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('0');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('memoryBump');
+            expect(ixArgs0b).toHaveTextContent('number');
+            expect(ixArgs0b).toHaveTextContent('254');
+
+            const ixArgs0c = screen.getByTestId('ix-args-0-3');
+            expect(ixArgs0c).toHaveTextContent('writeOffset');
+            expect(ixArgs0c).toHaveTextContent('number');
+            expect(ixArgs0c).toHaveTextContent('0');
+
+            const ixArgs0d = screen.getByTestId('ix-args-0-4');
+            expect(ixArgs0d).toHaveTextContent('writeType');
+            expect(ixArgs0d).toHaveTextContent('AccountInfoField');
+
+            const ixArgs1a = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1a).toHaveTextContent('fields');
+            expect(ixArgs1a).toHaveTextContent('Array[1]');
+
+            const ixArgs1b = screen.getByTestId('ix-args-1-1-0');
+            expect(ixArgs1b).toHaveTextContent('#0');
+            expect(ixArgs1b).toHaveTextContent('number');
+            expect(ixArgs1b).toHaveTextContent('1');
+        });
+
+        it('Renders Memory Close instruction', () => {
+            // 4L7Bfjj8P5GyChqaVmVFbxxgzrhzAkBJU6Tk3DtsL75m35GYTS35q9mQbUUcpffDj2g14xxWRARWFtMUGpeEDxnG
+            const ix = {
+                data: Buffer.from([1, 0, 254]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+                    },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u'),
+                    },
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h'),
+                    },
+                ],
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Memory Close')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Program Id');
+            expect(accountRow).toHaveTextContent('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95');
+
+            const accountRow1 = screen.getByTestId('account-row-1');
+            expect(accountRow1).toHaveTextContent('Payer');
+            expect(accountRow1).toHaveTextContent('6Le7uLy8Y2JvCq5x5huvF3pSQBvP1Y6W325wNpFz4s4u');
+
+            const accountRow2 = screen.getByTestId('account-row-2');
+            expect(accountRow2).toHaveTextContent('Memory');
+            expect(accountRow2).toHaveTextContent('14gyJnETr2upBHRoCVFfvqcaGGEZuJT1vYXzWCJGJ45h');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('memoryId');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('0');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('memoryBump');
+            expect(ixArgs0b).toHaveTextContent('number');
+            expect(ixArgs0b).toHaveTextContent('254');
+        });
     });
 
     describe('Assert Multi Instructions', () => {

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, act } from '@testing-library/react';
+import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { LIGHTHOUSE_ADDRESS } from '../types';
+import * as lighthouseSdk from 'lighthouse-sdk';
+
+// In your test setup
+// global.document = {
+// Add required document properties
+// };
+
+// Mock the dependencies
+jest.mock('react-feather', () => ({
+    CornerDownRight: () => <div data-testid="corner-down-right" />,
+}));
+
+// Mock InstructionCard
+jest.mock('../../InstructionCard', () => ({
+    InstructionCard: ({ children, title }: { children: React.ReactNode; title: string }) => (
+        <div data-testid="instruction-card" className="card">
+            <div className="card-header">
+                <div>{title}</div>
+            </div>
+            <div className="table-responsive mb-0">
+                <table className="table table-sm table-nowrap card-table">
+                    <tbody className="list">{children}</tbody>
+                </table>
+            </div>
+        </div>
+    ),
+}));
+
+// Mock Address component
+jest.mock('../../../common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: PublicKey }) => <div data-testid="address">{pubkey.toBase58()}</div>,
+}));
+
+// Mock ExpandableRow
+jest.mock('../../../../utils/anchor', () => ({
+    ExpandableRow: ({ children, fieldName }: { children: React.ReactNode; fieldName: string }) => (
+        <tr data-testid="expandable-row">
+            <td colSpan={3}>
+                <table className="table">
+                    <tbody>
+                        <tr>
+                            <td>{fieldName}</td>
+                        </tr>
+                        {children}
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    ),
+}));
+
+jest.mock('change-case', () => ({
+    split: jest.fn(() => 'mocked-split'),
+}));
+
+describe('LighthouseDetailsCard', () => {
+    const defaultProps = {
+        index: 0,
+        result: { err: null },
+        innerCards: undefined,
+        childIndex: undefined,
+    };
+
+    const createInstruction = (data: Buffer): TransactionInstruction => ({
+        programId: new PublicKey(LIGHTHOUSE_ADDRESS),
+        keys: [{ pubkey: new PublicKey('11111111111111111111111111111111'), isSigner: false, isWritable: true }],
+        data,
+    });
+
+    beforeEach(() => {
+        jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction');
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe.skip('Memory Instructions', () => {
+        it('renders MemoryClose instruction', () => {
+            const mockData = Buffer.from([0]); // Replace with actual MemoryClose instruction data
+            jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction').mockReturnValue(
+                lighthouseSdk.LighthouseInstruction.MemoryClose
+            );
+
+            render(<LighthouseDetailsCard ix={createInstruction(mockData)} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Memory Close')).toBeInTheDocument();
+        });
+
+        it('renders MemoryWrite instruction', () => {
+            const mockData = Buffer.from([1]); // Replace with actual MemoryWrite instruction data
+            jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction').mockReturnValue(
+                lighthouseSdk.LighthouseInstruction.MemoryWrite
+            );
+
+            render(<LighthouseDetailsCard ix={createInstruction(mockData)} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Memory Write')).toBeInTheDocument();
+        });
+    });
+
+    describe('Assert Instructions', () => {
+        it('renders AssertSysvarClock instruction', () => {
+            const ix = {
+                keys: [],
+                data: Buffer.from([15, 0, 0, 166, 238, 134, 18, 0, 0, 0, 0, 3]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Sysvar Clock')).toBeInTheDocument();
+        });
+
+        it('renders Assert Account Info instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('AUuYypaXez7kXWWWYecmsb89prMCnba6g2tBWm3BxKQV'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([5, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Account Info')).toBeInTheDocument();
+        });
+
+        it('renders Assert Token Account instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('5bjPLjnXeCfVPa3khXYzdiHaUYrW6zwveZywNJydaumJ'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([9, 0, 2, 102, 198, 105, 197, 1, 0, 0, 0, 2]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Token Account')).toBeInTheDocument();
+        });
+
+        it('renders Assert Bubblegum Tree Config instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('FMPNEcpSDsAskMHGtB6b6vh4CipN9NNdhWtHKTDqZ9oS'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([
+                    17, 4, 1, 2, 134, 9, 147, 82, 122, 185, 62, 253, 58, 44, 51, 49, 20, 153, 54, 6, 230, 246, 131, 112,
+                    125, 179, 20, 217, 213, 24, 172, 55, 152, 38, 45, 0,
+                ]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Bubblegum Tree Config Account')).toBeInTheDocument();
+        });
+
+        it('renders Assert Upgradeable Loader Account instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('DatucYgNGQn1qtsAJ7LDzt3n2mZstbTuLqyXDGbEwZDP'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([
+                    13, 4, 3, 0, 1, 22, 81, 71, 137, 179, 144, 181, 85, 107, 85, 94, 131, 115, 192, 111, 181, 1, 164,
+                    59, 203, 113, 59, 100, 131, 63, 109, 1, 41, 231, 66, 35, 227, 0,
+                ]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Upgradeable Loader Account')).toBeInTheDocument();
+        });
+    });
+
+    describe('Assert Multi Instructions', () => {
+        it('renders AssertTokenAccountMulti instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('BasxJXmna7VWFdcrBSgmkPnfGaRmxU5iVQpRUoyNpX5Y'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([
+                    10, 5, 6, 8, 2, 204, 80, 128, 133, 6, 0, 0, 0, 4, 2, 168, 134, 128, 222, 10, 0, 0, 0, 5, 3, 0, 0, 6,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 238, 1, 64, 143, 245, 9, 77, 0, 80, 251, 252, 27, 68, 110, 244, 105,
+                    249, 207, 89, 9, 156, 201, 247, 154, 75, 187, 221, 13, 238, 195, 38, 246, 0,
+                ]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Token Account Multi')).toBeInTheDocument();
+        });
+
+        it('renders AssertAccountInfoMulti instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('H2596LHcqWoaX3MAtTCZdtJixdL8K6ZLHLkQ8QmU2rVb'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([
+                    6, 5, 3, 0, 139, 61, 114, 1, 0, 0, 0, 0, 4, 0, 61, 17, 105, 2, 0, 0, 0, 0, 5, 3, 0, 0,
+                ]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Account Info Multi')).toBeInTheDocument();
+        });
+
+        it('renders AssertStakeAccountMulti instruction', () => {
+            const ix = {
+                keys: [
+                    {
+                        pubkey: new PublicKey('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8'),
+                        isWritable: false,
+                        isSigner: false,
+                    },
+                ],
+                data: Buffer.from([
+                    12, 5, 3, 1, 2, 216, 76, 74, 189, 47, 32, 227, 219, 8, 122, 136, 58, 66, 174, 136, 66, 117, 115, 83,
+                    186, 248, 44, 153, 55, 108, 154, 8, 139, 235, 47, 189, 139, 0, 1, 1, 216, 76, 74, 189, 47, 32, 227,
+                    219, 8, 122, 136, 58, 66, 174, 136, 66, 117, 115, 83, 186, 248, 44, 153, 55, 108, 154, 8, 139, 235,
+                    47, 189, 139, 0, 2, 1, 192, 145, 33, 0, 0, 0, 0, 0, 4,
+                ]),
+                programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
+            };
+
+            render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
+
+            expect(screen.getByText('Lighthouse: Assert Stake Account Multi')).toBeInTheDocument();
+        });
+    });
+});

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -72,7 +72,8 @@ describe('LighthouseDetailsCard', () => {
     });
 
     describe('Assert Instructions', () => {
-        it('renders AssertSysvarClock instruction', () => {
+        it('renders Assert Sysvar Clock instruction', () => {
+            // 5dakXwp5QTySbvc6P1Wp9MLZubnnG4R1Dh6cWSgNv6w1xt2JMsTp7EZvWEUxk9YLbJZHG97TT3jMVJ4yMTXKjM2L
             const ix = {
                 data: Buffer.from([15, 0, 0, 166, 238, 134, 18, 0, 0, 0, 0, 3]),
                 keys: [],
@@ -82,9 +83,29 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Sysvar Clock')).toBeInTheDocument();
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('0');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('Slot');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('value');
+            expect(ixArgs1).toHaveTextContent('bignum');
+            expect(ixArgs1).toHaveTextContent('310832806');
+
+            const ixArgs2 = screen.getByTestId('ix-args-1-2');
+            expect(ixArgs2).toHaveTextContent('operator');
+            expect(ixArgs2).toHaveTextContent('string');
+            expect(ixArgs2).toHaveTextContent('<');
         });
 
         it('renders Assert Account Info instruction', () => {
+            // 43PnzYerXr5b4LNf8A1j8kqztt8Voa7oiL9pzDTmWwSKCeLdZbLLJRd9A2XebiJvRP6kjNW6pF4mnGYnbSsRNXoU
             const ix = {
                 data: Buffer.from([5, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
                 keys: [
@@ -100,9 +121,33 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Account Info')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('AUuYypaXez7kXWWWYecmsb89prMCnba6g2tBWm3BxKQV');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('4');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('Lamports');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('value');
+            expect(ixArgs1).toHaveTextContent('bignum');
+            expect(ixArgs1).toHaveTextContent('0');
+
+            const ixArgs2 = screen.getByTestId('ix-args-1-2');
+            expect(ixArgs2).toHaveTextContent('operator');
+            expect(ixArgs2).toHaveTextContent('string');
+            expect(ixArgs2).toHaveTextContent('=');
         });
 
         it('renders Assert Token Account instruction', () => {
+            // 5ZtLCLaUGDVXyCZhKLiiNTFqasqUAwahpEeFNHM86amL2awLDByWkuWAdz6C7gdt1GRmfDbjUooh8ozL6a5LUyeZ
             const ix = {
                 data: Buffer.from([9, 0, 2, 102, 198, 105, 197, 1, 0, 0, 0, 2]),
                 keys: [
@@ -118,9 +163,33 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Token Account')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('5bjPLjnXeCfVPa3khXYzdiHaUYrW6zwveZywNJydaumJ');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('0');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('Amount');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('value');
+            expect(ixArgs1).toHaveTextContent('bignum');
+            expect(ixArgs1).toHaveTextContent('7607010918');
+
+            const ixArgs2 = screen.getByTestId('ix-args-1-2');
+            expect(ixArgs2).toHaveTextContent('operator');
+            expect(ixArgs2).toHaveTextContent('string');
+            expect(ixArgs2).toHaveTextContent('>');
         });
 
         it('renders Assert Bubblegum Tree Config instruction', () => {
+            // 5WA6DR6vBbyk6wsyxfFAQcsyFLLFamPFKWwgYMSpWbFdUBCCP2WweVggGKtrnJmUa8yyZE5ykqeaQe97daxpPMKZ
             const ix = {
                 data: Buffer.from([
                     17, 4, 1, 2, 134, 9, 147, 82, 122, 185, 62, 253, 58, 44, 51, 49, 20, 153, 54, 6, 230, 246, 131, 112,
@@ -139,9 +208,33 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Bubblegum Tree Config Account')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('FMPNEcpSDsAskMHGtB6b6vh4CipN9NNdhWtHKTDqZ9oS');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('4');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('TreeDelegate');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('value');
+            expect(ixArgs1).toHaveTextContent('pubkey');
+            expect(ixArgs1).toHaveTextContent('ArMorTp7EVn3SVVo8SJ92BiJAKETEczng6fyN743W3e');
+
+            const ixArgs2 = screen.getByTestId('ix-args-1-2');
+            expect(ixArgs2).toHaveTextContent('operator');
+            expect(ixArgs2).toHaveTextContent('string');
+            expect(ixArgs2).toHaveTextContent('=');
         });
 
         it('renders Assert Upgradeable Loader Account instruction', () => {
+            // 2PmrAtG26M6g8YiokmgbqrJYT4Rhe3kRN3AY3WCcu7NPuX4Jc4aiXoNb5aZuFK48vYhm8pDmwZhVZ9sP6KMAdsKw
             const ix = {
                 data: Buffer.from([
                     13, 4, 3, 0, 1, 22, 81, 71, 137, 179, 144, 181, 85, 107, 85, 94, 131, 115, 192, 111, 181, 1, 164,
@@ -221,16 +314,15 @@ describe('LighthouseDetailsCard', () => {
             expect(screen.getByText('Lighthouse: Assert Token Account Multi')).toBeInTheDocument();
         });
 
-        it('renders AssertAccountInfoMulti instruction', () => {
+        it('renders Assert Account Info Multi instruction', () => {
+            // 6LHBhFVLwuqiH93znCkyzMBZCkye5eHSBBeNZsz7m7M4SmJny9PQkiWtzdquEQvPfHVmn6bT6AeMa4pjNCVbefA
             const ix = {
-                data: Buffer.from([
-                    6, 5, 3, 0, 139, 61, 114, 1, 0, 0, 0, 0, 4, 0, 61, 17, 105, 2, 0, 0, 0, 0, 5, 3, 0, 0,
-                ]),
+                data: Buffer.from([6, 5, 3, 0, 112, 1, 103, 2, 0, 0, 0, 0, 4, 0, 100, 2, 1, 4, 0, 0, 0, 0, 5, 3, 0, 0]),
                 keys: [
                     {
                         isSigner: false,
                         isWritable: false,
-                        pubkey: new PublicKey('H2596LHcqWoaX3MAtTCZdtJixdL8K6ZLHLkQ8QmU2rVb'),
+                        pubkey: new PublicKey('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY'),
                     },
                 ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
@@ -239,9 +331,68 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Account Info Multi')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('5');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertions');
+            expect(ixArgs0b).toHaveTextContent('Array[3]');
+
+            // Two of the followingrows have the same data-testid 'ix-args-1-0'
+            const ixArgs0bChildren = ixArgs0b.nextElementSibling;
+
+            const ixArgs1a = ixArgs0bChildren;
+            expect(ixArgs1a).toHaveTextContent('#0');
+            expect(ixArgs1a).toHaveTextContent('Lamports');
+
+            const ixArgs1aChild0 = ixArgs1a.nextElementSibling;
+            expect(ixArgs1aChild0).toHaveTextContent('value');
+            expect(ixArgs1aChild0).toHaveTextContent('bignum');
+            expect(ixArgs1aChild0).toHaveTextContent('40305008');
+
+            const ixArgs1aChild1 = ixArgs1aChild0.nextElementSibling;
+            expect(ixArgs1aChild1).toHaveTextContent('operator');
+            expect(ixArgs1aChild1).toHaveTextContent('string');
+            expect(ixArgs1aChild1).toHaveTextContent('>=');
+
+            const ixArgs1b = ixArgs1aChild1.nextElementSibling;
+            expect(ixArgs1b).toHaveTextContent('#1');
+            expect(ixArgs1b).toHaveTextContent('Lamports');
+
+            const ixArgs1bChild0 = ixArgs1b.nextElementSibling;
+            expect(ixArgs1bChild0).toHaveTextContent('value');
+            expect(ixArgs1bChild0).toHaveTextContent('bignum');
+            expect(ixArgs1bChild0).toHaveTextContent('67175012');
+
+            const ixArgs1bChild1 = ixArgs1bChild0.nextElementSibling;
+            expect(ixArgs1bChild1).toHaveTextContent('operator');
+            expect(ixArgs1bChild1).toHaveTextContent('string');
+            expect(ixArgs1bChild1).toHaveTextContent('<=');
+
+            const ixArgs1c = ixArgs1bChild1.nextElementSibling;
+            expect(ixArgs1c).toHaveTextContent('#2');
+            expect(ixArgs1c).toHaveTextContent('KnownOwner');
+
+            const ixArgs1cChild0 = ixArgs1c.nextElementSibling;
+            expect(ixArgs1cChild0).toHaveTextContent('value');
+            expect(ixArgs1cChild0).toHaveTextContent('number');
+            expect(ixArgs1cChild0).toHaveTextContent('0');
+
+            const ixArgs1cChild1 = ixArgs1cChild0.nextElementSibling;
+            expect(ixArgs1cChild1).toHaveTextContent('operator');
+            expect(ixArgs1cChild1).toHaveTextContent('string');
+            expect(ixArgs1cChild1).toHaveTextContent('=');
         });
 
-        it('renders AssertStakeAccountMulti instruction', () => {
+        it('renders Assert Stake Account Multi instruction', () => {
+            // 6LHBhFVLwuqiH93znCkyzMBZCkye5eHSBBeNZsz7m7M4SmJny9PQkiWtzdquEQvPfHVmn6bT6AeMa4pjNCVbefA
             const ix = {
                 data: Buffer.from([
                     12, 5, 3, 1, 2, 216, 76, 74, 189, 47, 32, 227, 219, 8, 122, 136, 58, 66, 174, 136, 66, 117, 115, 83,
@@ -262,6 +413,91 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Stake Account Multi')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('5');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertions');
+            expect(ixArgs0b).toHaveTextContent('Array[3]');
+
+            // Two of the followingrows have the same data-testid 'ix-args-1-0'
+            const ixArgs0bChildren = ixArgs0b.nextElementSibling;
+
+            // 1st assertion
+            let next = ixArgs0bChildren;
+            expect(next).toHaveTextContent('#0');
+            expect(next).toHaveTextContent('MetaAssertion');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('fields');
+            expect(next).toHaveTextContent('Array[1]');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('#0');
+            expect(next).toHaveTextContent('AuthorizedWithdrawer');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('value');
+            expect(next).toHaveTextContent('pubkey');
+            expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('operator');
+            expect(next).toHaveTextContent('string');
+            expect(next).toHaveTextContent('=');
+
+            // 2nd assertion
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('#1');
+            expect(next).toHaveTextContent('MetaAssertion');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('fields');
+            expect(next).toHaveTextContent('Array[1]');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('#0');
+            expect(next).toHaveTextContent('AuthorizedStaker');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('value');
+            expect(next).toHaveTextContent('pubkey');
+            expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('operator');
+            expect(next).toHaveTextContent('string');
+            expect(next).toHaveTextContent('=');
+
+            // 3rd assertion
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('#2');
+            expect(next).toHaveTextContent('StakeAssertion');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('fields');
+            expect(next).toHaveTextContent('Array[1]');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('#0');
+            expect(next).toHaveTextContent('DelegationStake');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('value');
+            expect(next).toHaveTextContent('bignum');
+            expect(next).toHaveTextContent('2200000');
+
+            next = next.nextElementSibling;
+            expect(next).toHaveTextContent('operator');
+            expect(next).toHaveTextContent('string');
+            expect(next).toHaveTextContent('>=');
         });
     });
 });

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -1,9 +1,8 @@
-import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { render, screen } from '@testing-library/react';
 import * as lighthouseSdk from 'lighthouse-sdk';
 
 import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
-import { LIGHTHOUSE_ADDRESS } from '../types';
 
 jest.mock('react-feather', () => ({
     CornerDownRight: () => <div data-testid="corner-down-right" />,
@@ -29,19 +28,26 @@ jest.mock('../../../common/Address', () => ({
 }));
 
 jest.mock('../../../../utils/anchor', () => ({
-    ExpandableRow: ({ children, fieldName }: { children: React.ReactNode; fieldName: string }) => (
-        <tr data-testid="expandable-row">
-            <td colSpan={3}>
-                <table className="table">
-                    <tbody>
-                        <tr>
-                            <td>{fieldName}</td>
-                        </tr>
-                        {children}
-                    </tbody>
-                </table>
-            </td>
-        </tr>
+    ExpandableRow: ({
+        fieldName,
+        fieldType,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        nestingLevel,
+        children,
+        ...props
+    }: {
+        children: React.ReactNode;
+        fieldName: string;
+        fieldType: string;
+        nestingLevel: number;
+    } & React.HTMLAttributes<HTMLTableRowElement>) => (
+        <>
+            <tr {...props}>
+                <td>{fieldName}</td>
+                <td>{fieldType}</td>
+            </tr>
+            {children}
+        </>
     ),
 }));
 
@@ -57,42 +63,12 @@ describe('LighthouseDetailsCard', () => {
         result: { err: null },
     };
 
-    const createInstruction = (data: Buffer): TransactionInstruction => ({
-        data,
-        keys: [{ isSigner: false, isWritable: true, pubkey: new PublicKey('11111111111111111111111111111111') }],
-        programId: new PublicKey(LIGHTHOUSE_ADDRESS),
-    });
-
     beforeEach(() => {
         jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction');
     });
 
     afterEach(() => {
         jest.clearAllMocks();
-    });
-
-    describe.skip('Memory Instructions', () => {
-        it('renders MemoryClose instruction', () => {
-            const mockData = Buffer.from([0]); // Replace with actual MemoryClose instruction data
-            jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction').mockReturnValue(
-                lighthouseSdk.LighthouseInstruction.MemoryClose
-            );
-
-            render(<LighthouseDetailsCard ix={createInstruction(mockData)} {...defaultProps} />);
-
-            expect(screen.getByText('Lighthouse: Memory Close')).toBeInTheDocument();
-        });
-
-        it('renders MemoryWrite instruction', () => {
-            const mockData = Buffer.from([1]); // Replace with actual MemoryWrite instruction data
-            jest.spyOn(lighthouseSdk, 'identifyLighthouseInstruction').mockReturnValue(
-                lighthouseSdk.LighthouseInstruction.MemoryWrite
-            );
-
-            render(<LighthouseDetailsCard ix={createInstruction(mockData)} {...defaultProps} />);
-
-            expect(screen.getByText('Lighthouse: Memory Write')).toBeInTheDocument();
-        });
     });
 
     describe('Assert Instructions', () => {
@@ -184,6 +160,41 @@ describe('LighthouseDetailsCard', () => {
             render(<LighthouseDetailsCard ix={ix} {...defaultProps} />);
 
             expect(screen.getByText('Lighthouse: Assert Upgradeable Loader Account')).toBeInTheDocument();
+
+            const accountRow = screen.getByTestId('account-row-0');
+            expect(accountRow).toHaveTextContent('Target Account');
+            expect(accountRow).toHaveTextContent('DatucYgNGQn1qtsAJ7LDzt3n2mZstbTuLqyXDGbEwZDP');
+
+            const ixArgs0a = screen.getByTestId('ix-args-0-1');
+            expect(ixArgs0a).toHaveTextContent('logLevel');
+            expect(ixArgs0a).toHaveTextContent('number');
+            expect(ixArgs0a).toHaveTextContent('4');
+
+            const ixArgs0b = screen.getByTestId('ix-args-0-2');
+            expect(ixArgs0b).toHaveTextContent('assertion');
+            expect(ixArgs0b).toHaveTextContent('ProgramData');
+
+            const ixArgs1 = screen.getByTestId('ix-args-1-1');
+            expect(ixArgs1).toHaveTextContent('fields');
+            expect(ixArgs1).toHaveTextContent('Array[1]');
+
+            const ixArgs2 = screen.getByTestId('ix-args-2-0');
+            expect(ixArgs2).toHaveTextContent('#0');
+            expect(ixArgs2).toHaveTextContent('UpgradeAuthority');
+
+            const ixArgs3a = screen.getByTestId('ix-args-3-1');
+            expect(ixArgs3a).toHaveTextContent('value');
+            expect(ixArgs3a).toHaveTextContent('Option(Some)');
+
+            const ixArgs4b = screen.getByTestId('ix-args-4-1');
+            expect(ixArgs4b).toHaveTextContent('value');
+            expect(ixArgs4b).toHaveTextContent('pubkey');
+            expect(ixArgs4b).toHaveTextContent('2W7rVWpiRMzex7sGBnww6sozQp94xFBzCGYUzUKZw2X4');
+
+            const ixArgs3b = screen.getByTestId('ix-args-3-2');
+            expect(ixArgs3b).toHaveTextContent('operator');
+            expect(ixArgs3b).toHaveTextContent('string');
+            expect(ixArgs3b).toHaveTextContent('=');
         });
     });
 

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -1,20 +1,14 @@
-import { render, screen, act } from '@testing-library/react';
-import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
-import { LIGHTHOUSE_ADDRESS } from '../types';
+import { render, screen } from '@testing-library/react';
 import * as lighthouseSdk from 'lighthouse-sdk';
 
-// In your test setup
-// global.document = {
-// Add required document properties
-// };
+import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
+import { LIGHTHOUSE_ADDRESS } from '../types';
 
-// Mock the dependencies
 jest.mock('react-feather', () => ({
     CornerDownRight: () => <div data-testid="corner-down-right" />,
 }));
 
-// Mock InstructionCard
 jest.mock('../../InstructionCard', () => ({
     InstructionCard: ({ children, title }: { children: React.ReactNode; title: string }) => (
         <div data-testid="instruction-card" className="card">
@@ -30,12 +24,10 @@ jest.mock('../../InstructionCard', () => ({
     ),
 }));
 
-// Mock Address component
 jest.mock('../../../common/Address', () => ({
     Address: ({ pubkey }: { pubkey: PublicKey }) => <div data-testid="address">{pubkey.toBase58()}</div>,
 }));
 
-// Mock ExpandableRow
 jest.mock('../../../../utils/anchor', () => ({
     ExpandableRow: ({ children, fieldName }: { children: React.ReactNode; fieldName: string }) => (
         <tr data-testid="expandable-row">
@@ -59,16 +51,16 @@ jest.mock('change-case', () => ({
 
 describe('LighthouseDetailsCard', () => {
     const defaultProps = {
-        index: 0,
-        result: { err: null },
-        innerCards: undefined,
         childIndex: undefined,
+        index: 0,
+        innerCards: undefined,
+        result: { err: null },
     };
 
     const createInstruction = (data: Buffer): TransactionInstruction => ({
-        programId: new PublicKey(LIGHTHOUSE_ADDRESS),
-        keys: [{ pubkey: new PublicKey('11111111111111111111111111111111'), isSigner: false, isWritable: true }],
         data,
+        keys: [{ isSigner: false, isWritable: true, pubkey: new PublicKey('11111111111111111111111111111111') }],
+        programId: new PublicKey(LIGHTHOUSE_ADDRESS),
     });
 
     beforeEach(() => {
@@ -106,8 +98,8 @@ describe('LighthouseDetailsCard', () => {
     describe('Assert Instructions', () => {
         it('renders AssertSysvarClock instruction', () => {
             const ix = {
-                keys: [],
                 data: Buffer.from([15, 0, 0, 166, 238, 134, 18, 0, 0, 0, 0, 3]),
+                keys: [],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -118,14 +110,14 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders Assert Account Info instruction', () => {
             const ix = {
+                data: Buffer.from([5, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
                 keys: [
                     {
-                        pubkey: new PublicKey('AUuYypaXez7kXWWWYecmsb89prMCnba6g2tBWm3BxKQV'),
-                        isWritable: false,
                         isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('AUuYypaXez7kXWWWYecmsb89prMCnba6g2tBWm3BxKQV'),
                     },
                 ],
-                data: Buffer.from([5, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -136,14 +128,14 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders Assert Token Account instruction', () => {
             const ix = {
+                data: Buffer.from([9, 0, 2, 102, 198, 105, 197, 1, 0, 0, 0, 2]),
                 keys: [
                     {
-                        pubkey: new PublicKey('5bjPLjnXeCfVPa3khXYzdiHaUYrW6zwveZywNJydaumJ'),
-                        isWritable: false,
                         isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('5bjPLjnXeCfVPa3khXYzdiHaUYrW6zwveZywNJydaumJ'),
                     },
                 ],
-                data: Buffer.from([9, 0, 2, 102, 198, 105, 197, 1, 0, 0, 0, 2]),
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -154,17 +146,17 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders Assert Bubblegum Tree Config instruction', () => {
             const ix = {
-                keys: [
-                    {
-                        pubkey: new PublicKey('FMPNEcpSDsAskMHGtB6b6vh4CipN9NNdhWtHKTDqZ9oS'),
-                        isWritable: false,
-                        isSigner: false,
-                    },
-                ],
                 data: Buffer.from([
                     17, 4, 1, 2, 134, 9, 147, 82, 122, 185, 62, 253, 58, 44, 51, 49, 20, 153, 54, 6, 230, 246, 131, 112,
                     125, 179, 20, 217, 213, 24, 172, 55, 152, 38, 45, 0,
                 ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('FMPNEcpSDsAskMHGtB6b6vh4CipN9NNdhWtHKTDqZ9oS'),
+                    },
+                ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -175,17 +167,17 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders Assert Upgradeable Loader Account instruction', () => {
             const ix = {
-                keys: [
-                    {
-                        pubkey: new PublicKey('DatucYgNGQn1qtsAJ7LDzt3n2mZstbTuLqyXDGbEwZDP'),
-                        isWritable: false,
-                        isSigner: false,
-                    },
-                ],
                 data: Buffer.from([
                     13, 4, 3, 0, 1, 22, 81, 71, 137, 179, 144, 181, 85, 107, 85, 94, 131, 115, 192, 111, 181, 1, 164,
                     59, 203, 113, 59, 100, 131, 63, 109, 1, 41, 231, 66, 35, 227, 0,
                 ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('DatucYgNGQn1qtsAJ7LDzt3n2mZstbTuLqyXDGbEwZDP'),
+                    },
+                ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -198,18 +190,18 @@ describe('LighthouseDetailsCard', () => {
     describe('Assert Multi Instructions', () => {
         it('renders AssertTokenAccountMulti instruction', () => {
             const ix = {
-                keys: [
-                    {
-                        pubkey: new PublicKey('BasxJXmna7VWFdcrBSgmkPnfGaRmxU5iVQpRUoyNpX5Y'),
-                        isWritable: false,
-                        isSigner: false,
-                    },
-                ],
                 data: Buffer.from([
                     10, 5, 6, 8, 2, 204, 80, 128, 133, 6, 0, 0, 0, 4, 2, 168, 134, 128, 222, 10, 0, 0, 0, 5, 3, 0, 0, 6,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 238, 1, 64, 143, 245, 9, 77, 0, 80, 251, 252, 27, 68, 110, 244, 105,
                     249, 207, 89, 9, 156, 201, 247, 154, 75, 187, 221, 13, 238, 195, 38, 246, 0,
                 ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('BasxJXmna7VWFdcrBSgmkPnfGaRmxU5iVQpRUoyNpX5Y'),
+                    },
+                ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -220,16 +212,16 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders AssertAccountInfoMulti instruction', () => {
             const ix = {
-                keys: [
-                    {
-                        pubkey: new PublicKey('H2596LHcqWoaX3MAtTCZdtJixdL8K6ZLHLkQ8QmU2rVb'),
-                        isWritable: false,
-                        isSigner: false,
-                    },
-                ],
                 data: Buffer.from([
                     6, 5, 3, 0, 139, 61, 114, 1, 0, 0, 0, 0, 4, 0, 61, 17, 105, 2, 0, 0, 0, 0, 5, 3, 0, 0,
                 ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('H2596LHcqWoaX3MAtTCZdtJixdL8K6ZLHLkQ8QmU2rVb'),
+                    },
+                ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 
@@ -240,19 +232,19 @@ describe('LighthouseDetailsCard', () => {
 
         it('renders AssertStakeAccountMulti instruction', () => {
             const ix = {
-                keys: [
-                    {
-                        pubkey: new PublicKey('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8'),
-                        isWritable: false,
-                        isSigner: false,
-                    },
-                ],
                 data: Buffer.from([
                     12, 5, 3, 1, 2, 216, 76, 74, 189, 47, 32, 227, 219, 8, 122, 136, 58, 66, 174, 136, 66, 117, 115, 83,
                     186, 248, 44, 153, 55, 108, 154, 8, 139, 235, 47, 189, 139, 0, 1, 1, 216, 76, 74, 189, 47, 32, 227,
                     219, 8, 122, 136, 58, 66, 174, 136, 66, 117, 115, 83, 186, 248, 44, 153, 55, 108, 154, 8, 139, 235,
                     47, 189, 139, 0, 2, 1, 192, 145, 33, 0, 0, 0, 0, 0, 4,
                 ]),
+                keys: [
+                    {
+                        isSigner: false,
+                        isWritable: false,
+                        pubkey: new PublicKey('2mWhJDFtX2LGKggEPVhznvs8cPzy5HM8HhsVPj5YxqA8'),
+                    },
+                ],
                 programId: new PublicKey('L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95'),
             };
 

--- a/app/components/instruction/lighthouse/types.ts
+++ b/app/components/instruction/lighthouse/types.ts
@@ -1,0 +1,7 @@
+import { TransactionInstruction } from '@solana/web3.js';
+
+export const LIGHTHOUSE_ADDRESS = 'L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95';
+
+export function isLighthouseInstruction(instruction: TransactionInstruction): boolean {
+    return instruction.programId.toBase58() === LIGHTHOUSE_ADDRESS;
+}

--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -43,6 +43,8 @@ import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import AnchorDetailsCard from '../instruction/AnchorDetailsCard';
+import { LighthouseDetailsCard } from '../instruction/lighthouse/LighthouseDetailsCard';
+import { isLighthouseInstruction } from '../instruction/lighthouse/types';
 import { isMangoInstruction } from '../instruction/mango/types';
 
 export type InstructionDetailsProps = {
@@ -231,6 +233,8 @@ function InstructionCard({
         return <PythDetailsCard key={key} {...props} />;
     } else if (ComputeBudgetProgram.programId.equals(transactionIx.programId)) {
         return <ComputeBudgetDetailsCard key={key} {...props} />;
+    } else if (isLighthouseInstruction(transactionIx)) {
+        return <LighthouseDetailsCard key={key} {...props} />;
     } else if (anchorProgram) {
         return (
             <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>

--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -435,7 +435,7 @@ export function ExpandableRow({
         <>
             <tr
                 style={{
-                    ...(nestingLevel === 0 ? {} : { backgroundColor: '#141816' }),
+                    backgroundColor: '#141816',
                 }}
             >
                 <td className="d-flex flex-row">

--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -6,7 +6,7 @@ import { useAnchorProgram } from '@providers/anchor';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { camelToTitleCase, numberWithSeparator, snakeToTitleCase } from '@utils/index';
-import { getProgramName, programLabel } from '@utils/tx';
+import { programLabel } from '@utils/tx';
 import React, { Fragment, ReactNode, useState } from 'react';
 import { ChevronDown, ChevronUp, CornerDownRight } from 'react-feather';
 import ReactJson from 'react-json-view';

--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -6,7 +6,7 @@ import { useAnchorProgram } from '@providers/anchor';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { camelToTitleCase, numberWithSeparator, snakeToTitleCase } from '@utils/index';
-import { getProgramName } from '@utils/tx';
+import { getProgramName, programLabel } from '@utils/tx';
 import React, { Fragment, ReactNode, useState } from 'react';
 import { ChevronDown, ChevronUp, CornerDownRight } from 'react-feather';
 import ReactJson from 'react-json-view';
@@ -37,7 +37,10 @@ export function AnchorProgramName({
 }
 
 export function ProgramName({ programId, cluster, url }: { programId: PublicKey; cluster: Cluster; url: string }) {
-    const defaultProgramName = getProgramName(programId.toBase58(), cluster);
+    const defaultProgramName = programLabel(programId.toBase58(), cluster);
+    if (defaultProgramName) {
+        return <>{defaultProgramName}</>;
+    }
     return (
         <React.Suspense fallback={<>{defaultProgramName}</>}>
             <AnchorProgramName programId={programId} url={url} defaultName={defaultProgramName} />

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -215,10 +215,6 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
         deployments: [Cluster.Devnet, Cluster.MainnetBeta],
         name: PROGRAM_NAMES.FINTERNET_USER_MANAGER,
     },
-    L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95: {
-        deployments: [Cluster.MainnetBeta],
-        name: PROGRAM_NAMES.LIGHTHOUSE_PROGRAM,
-    },
     ComputeBudget111111111111111111111111111111: {
         deployments: ALL_CLUSTERS,
         name: PROGRAM_NAMES.COMPUTE_BUDGET,
@@ -286,6 +282,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     KeccakSecp256k11111111111111111111111111111: {
         deployments: ALL_CLUSTERS,
         name: PROGRAM_NAMES.SECP256K1,
+    },
+    L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95: {
+        deployments: [Cluster.MainnetBeta],
+        name: PROGRAM_NAMES.LIGHTHOUSE_PROGRAM,
     },
     LendZqTs7gn5CTSJU1jWKhKuVpjJGom45nnwPb2AMTi: {
         deployments: LIVE_CLUSTERS,

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -91,6 +91,9 @@ export enum PROGRAM_NAMES {
     ZK_LIGHT_SYSTEM_PROGRAM = 'Light System Program',
     ZK_COMPRESSED_TOKEN_PROGRAM = 'ZK Compressed Token Program',
     ZK_ACCOUNT_COMPRESSION_PROGRAM = 'ZK Account Compression Program',
+
+    // Lighthouse
+    LIGHTHOUSE_PROGRAM = 'Lighthouse Program',
 }
 
 const ALL_CLUSTERS = [Cluster.Custom, Cluster.Devnet, Cluster.Testnet, Cluster.MainnetBeta];
@@ -211,6 +214,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     CmFuqQTLs2nQof5uaktJn1a6k2VdbGmZPfrJufB2Vm3F: {
         deployments: [Cluster.Devnet, Cluster.MainnetBeta],
         name: PROGRAM_NAMES.FINTERNET_USER_MANAGER,
+    },
+    L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95: {
+        deployments: [Cluster.MainnetBeta],
+        name: PROGRAM_NAMES.LIGHTHOUSE_PROGRAM,
     },
     ComputeBudget111111111111111111111111111111: {
         deployments: ALL_CLUSTERS,

--- a/app/utils/tx.ts
+++ b/app/utils/tx.ts
@@ -22,7 +22,7 @@ export function getProgramName(address: string, cluster: Cluster): string {
     return `Unknown Program (${address})`;
 }
 
-function programLabel(address: string, cluster: Cluster): string | undefined {
+export function programLabel(address: string, cluster: Cluster): string | undefined {
     const programInfo = PROGRAM_INFO_BY_ID[address];
     if (programInfo && programInfo.deployments.includes(cluster)) {
         return programInfo.name;

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,15 +9,12 @@ const createJestConfig = nextJest({
 const customJestConfig = {
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     testEnvironment: 'jsdom',
-    // Add these configurations:
-    transformIgnorePatterns: [
-        // The pattern below tells Jest to not transform these packages
-        '/node_modules/(?!(@noble|change-case)/)',
-    ],
     transform: {
         '^.+\\.(t|j)sx?$': ['@swc/jest'],
     },
-
+    transformIgnorePatterns: [
+        '/node_modules/(?!(@noble|change-case)/)',
+    ],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,16 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-    testEnvironment: 'jest-environment-jsdom',
+    testEnvironment: 'jsdom',
+    // Add these configurations:
+    transformIgnorePatterns: [
+        // The pattern below tells Jest to not transform these packages
+        '/node_modules/(?!(@noble|change-case)/)',
+    ],
+    transform: {
+        '^.+\\.(t|j)sx?$': ['@swc/jest'],
+    },
+
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,4 +3,4 @@
 
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "eslint": "8.39.0",
         "eslint-config-next": "14.2.5",
         "humanize-duration-ts": "^2.1.1",
+        "lighthouse-sdk": "^2.0.1",
         "moment": "^2.29.4",
         "next": "14.2.5",
         "p-limit": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "devDependencies": {
         "@solana/eslint-config-solana": "^1.0.1",
         "@solana/prettier-config-solana": "^0.0.2",
+        "@swc/jest": "^0.2.37",
         "@testing-library/jest-dom": "5.16.4",
         "@testing-library/react": "14.0.0",
         "@testing-library/user-event": "14.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@solana/prettier-config-solana':
         specifier: ^0.0.2
         version: 0.0.2(prettier@2.8.8)
+      '@swc/jest':
+        specifier: ^0.2.37
+        version: 0.2.37(@swc/core@1.10.4(@swc/helpers@0.5.12))
       '@testing-library/jest-dom':
         specifier: 5.16.4
         version: 5.16.4
@@ -820,6 +823,10 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/create-cache-key-function@29.7.0':
+    resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/environment@29.5.0':
     resolution: {integrity: sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -853,6 +860,10 @@ packages:
     resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/source-map@29.4.3':
     resolution: {integrity: sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -871,6 +882,10 @@ packages:
 
   '@jest/types@29.5.0':
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.3':
@@ -1166,6 +1181,9 @@ packages:
 
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
   '@sinonjs/commons@2.0.0':
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
@@ -1643,6 +1661,75 @@ packages:
     resolution: {integrity: sha512-O9CMipBlq5OObdt1uKJGIzm9cdjpPWfj+a+Zw9EgWKxaMNHKC7EU7X9taj3H0EGQNLOSq2jAcOa3EzxlfHsD6w==}
     engines: {node: '>=8'}
 
+  '@swc/core-darwin-arm64@1.10.4':
+    resolution: {integrity: sha512-sV/eurLhkjn/197y48bxKP19oqcLydSel42Qsy2zepBltqUx+/zZ8+/IS0Bi7kaWVFxerbW1IPB09uq8Zuvm3g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.10.4':
+    resolution: {integrity: sha512-gjYNU6vrAUO4+FuovEo9ofnVosTFXkF0VDuo1MKPItz6e2pxc2ale4FGzLw0Nf7JB1sX4a8h06CN16/pLJ8Q2w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.10.4':
+    resolution: {integrity: sha512-zd7fXH5w8s+Sfvn2oO464KDWl+ZX1MJiVmE4Pdk46N3PEaNwE0koTfgx2vQRqRG4vBBobzVvzICC3618WcefOA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.10.4':
+    resolution: {integrity: sha512-+UGfoHDxsMZgFD3tABKLeEZHqLNOkxStu+qCG7atGBhS4Slri6h6zijVvf4yI5X3kbXdvc44XV/hrP/Klnui2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.10.4':
+    resolution: {integrity: sha512-cDDj2/uYsOH0pgAnDkovLZvKJpFmBMyXkxEG6Q4yw99HbzO6QzZ5HDGWGWVq/6dLgYKlnnmpjZCPPQIu01mXEg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.10.4':
+    resolution: {integrity: sha512-qJXh9D6Kf5xSdGWPINpLGixAbB5JX8JcbEJpRamhlDBoOcQC79dYfOMEIxWPhTS1DGLyFakAx2FX/b2VmQmj0g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.10.4':
+    resolution: {integrity: sha512-A76lIAeyQnHCVt0RL/pG+0er8Qk9+acGJqSZOZm67Ve3B0oqMd871kPtaHBM0BW3OZAhoILgfHW3Op9Q3mx3Cw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.10.4':
+    resolution: {integrity: sha512-e6j5kBu4fIY7fFxFxnZI0MlEovRvp50Lg59Fw+DVbtqHk3C85dckcy5xKP+UoXeuEmFceauQDczUcGs19SRGSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.10.4':
+    resolution: {integrity: sha512-RSYHfdKgNXV/amY5Tqk1EWVsyQnhlsM//jeqMLw5Fy9rfxP592W9UTumNikNRPdjI8wKKzNMXDb1U29tQjN0dg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.10.4':
+    resolution: {integrity: sha512-1ujYpaqfqNPYdwKBlvJnOqcl+Syn3UrQ4XE0Txz6zMYgyh6cdU6a3pxqLqIUSJ12MtXRA9ZUhEz1ekU3LfLWXw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.10.4':
+    resolution: {integrity: sha512-ut3zfiTLORMxhr6y/GBxkHmzcGuVpwJYX4qyXWuBKkpw/0g0S5iO1/wW7RnLnZbAi8wS/n0atRZoaZlXWBkeJg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '*'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -1651,6 +1738,15 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@swc/jest@0.2.37':
+    resolution: {integrity: sha512-CR2BHhmXKGxTiFr21DYPRHQunLkX3mNIFGFkxBGji6r9uyIR5zftTOVYj1e0sFNMV2H7mf/+vpaglqaryBtqfQ==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.17':
+    resolution: {integrity: sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==}
 
   '@testing-library/dom@9.2.0':
     resolution: {integrity: sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==}
@@ -3622,6 +3718,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -6169,6 +6268,10 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/create-cache-key-function@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+
   '@jest/environment@29.5.0':
     dependencies:
       '@jest/fake-timers': 29.5.0
@@ -6238,6 +6341,10 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.25.24
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
   '@jest/source-map@29.4.3':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
@@ -6281,6 +6388,15 @@ snapshots:
   '@jest/types@29.5.0':
     dependencies:
       '@jest/schemas': 29.4.3
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.16.3
+      '@types/yargs': 17.0.24
+      chalk: 4.1.2
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
       '@types/node': 18.16.3
@@ -6752,6 +6868,8 @@ snapshots:
   '@sideway/pinpoint@2.0.0': {}
 
   '@sinclair/typebox@0.25.24': {}
+
+  '@sinclair/typebox@0.27.8': {}
 
   '@sinonjs/commons@2.0.0':
     dependencies:
@@ -7530,6 +7648,53 @@ snapshots:
 
   '@supercharge/promise-pool@2.4.0': {}
 
+  '@swc/core-darwin-arm64@1.10.4':
+    optional: true
+
+  '@swc/core-darwin-x64@1.10.4':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.10.4':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.10.4':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.10.4':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.10.4':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.10.4':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.10.4':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.10.4':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.10.4':
+    optional: true
+
+  '@swc/core@1.10.4(@swc/helpers@0.5.12)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.17
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.10.4
+      '@swc/core-darwin-x64': 1.10.4
+      '@swc/core-linux-arm-gnueabihf': 1.10.4
+      '@swc/core-linux-arm64-gnu': 1.10.4
+      '@swc/core-linux-arm64-musl': 1.10.4
+      '@swc/core-linux-x64-gnu': 1.10.4
+      '@swc/core-linux-x64-musl': 1.10.4
+      '@swc/core-win32-arm64-msvc': 1.10.4
+      '@swc/core-win32-ia32-msvc': 1.10.4
+      '@swc/core-win32-x64-msvc': 1.10.4
+      '@swc/helpers': 0.5.12
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.12':
@@ -7540,6 +7705,17 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.7.0
+
+  '@swc/jest@0.2.37(@swc/core@1.10.4(@swc/helpers@0.5.12))':
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@swc/core': 1.10.4(@swc/helpers@0.5.12)
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.17':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@testing-library/dom@9.2.0':
     dependencies:
@@ -10149,6 +10325,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonparse@1.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   node-fetch: ^2.6.9
   uuid: ^9.0.0
 
-pnpmfileChecksum: stj755pkhcr6askuiq2lbw4piy
+pnpmfileChecksum: vg4cnl3slj2ctz3ln6baqe5c4y
 
 importers:
 
@@ -109,6 +109,9 @@ importers:
       humanize-duration-ts:
         specifier: ^2.1.1
         version: 2.1.1
+      lighthouse-sdk:
+        specifier: ^2.0.1
+        version: 2.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
       moment:
         specifier: ^2.29.4
         version: 2.29.4
@@ -968,6 +971,9 @@ packages:
       '@metaplex-foundation/mpl-token-vault': ^0.0.2
       '@solana/spl-token': ^0.1.8
       '@solana/web3.js': ^1.30.2
+
+  '@minhducsun2002/leb128@1.0.0':
+    resolution: {integrity: sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==}
 
   '@next/env@14.2.5':
     resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
@@ -1856,6 +1862,12 @@ packages:
   '@wallet-standard/features@1.0.3':
     resolution: {integrity: sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==}
     engines: {node: '>=16'}
+
+  '@webassemblyjs/leb128@1.14.1':
+    resolution: {integrity: sha512-SxIMbt0XzSD/wmkbCdU0Efy4xSlKe0M7DJOoFimyAPBJ5BI6E1RaSQSloU7aKk8ZaCz3T/FFy3MEbAyyYLQI9A==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -3641,6 +3653,9 @@ packages:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
     engines: {node: '> 0.8'}
 
+  leb@1.0.0:
+    resolution: {integrity: sha512-Y3c3QZfvKWHX60BVOQPhLCvVGmDYWyJEiINE3drOog6KCyN2AOwvuQQzlS3uJg1J85kzpILXIUwRXULWavir+w==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -3652,6 +3667,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lighthouse-sdk@2.0.1:
+    resolution: {integrity: sha512-jB+yYwFX9zGB/jQxP8nQIEtA62JF6wQRlzrotbUjb40GG58wMydzNnUIP64q0BK9W9cQTNI2rVpCRMv2wVFYXA==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -6526,6 +6544,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@minhducsun2002/leb128@1.0.0': {}
+
   '@next/env@14.2.5': {}
 
   '@next/eslint-plugin-next@14.2.5':
@@ -7784,6 +7804,12 @@ snapshots:
   '@wallet-standard/features@1.0.3':
     dependencies:
       '@wallet-standard/base': 1.0.1
+
+  '@webassemblyjs/leb128@1.14.1':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/long@4.2.2': {}
 
   JSONStream@1.3.5:
     dependencies:
@@ -10149,6 +10175,8 @@ snapshots:
 
   lazy-ass@1.6.0: {}
 
+  leb@1.0.0: {}
+
   leven@3.1.0: {}
 
   levn@0.3.0:
@@ -10160,6 +10188,17 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lighthouse-sdk@2.0.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@minhducsun2002/leb128': 1.0.0
+      '@solana/web3.js': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@7.5.10(bufferutil@4.0.7)(utf-8-validate@5.0.10))
+      '@webassemblyjs/leb128': 1.14.1
+      leb: 1.0.0
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - ws
 
   lines-and-columns@1.2.4: {}
 


### PR DESCRIPTION
This PR adds support for [Lighthouse protocol](https://github.com/Jac0xb/lighthouse), which implements safety check instructions that enforce safety checks during transaction execution.

- [x] Instruction Cards
- [x] Logs
- [x] Tests
