### PR TITLE
Add support for emit-based metadata on t22 tokens

### DIFF
--- a/app/providers/token22Metadata.tsx
+++ b/app/providers/token22Metadata.tsx
@@ -1,0 +1,37 @@
+import { createEmitInstruction, unpack } from '@solana/spl-token-metadata';
+import { Connection, PublicKey, Transaction } from '@solana/web3.js';
+import useSWRImmutable from 'swr/immutable';
+
+export function useMetadataExtensionSimulation(
+    address: string | undefined,
+    programId: string | undefined,
+    url: string
+) {
+    return useSWRImmutable(programId ? [address, programId, url] : null, async ([addr, programId, clusterUrl]) => {
+        if (!addr) {
+            return null;
+        }
+
+        const ix = createEmitInstruction({
+            metadata: new PublicKey(addr),
+            programId: new PublicKey(programId),
+        });
+        const tx = new Transaction().add(ix);
+
+        // toly.sol
+        tx.feePayer = new PublicKey('86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY');
+        const connection = new Connection(clusterUrl);
+        const result = await connection.simulateTransaction(tx);
+
+        if (result.value.err) {
+            console.log(result.value.logs);
+            return null;
+        }
+
+        if (result.value.returnData) {
+            return unpack(Buffer.from(result.value.returnData.data[0], 'base64'));
+        }
+
+        return null;
+    });
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@solana/buffer-layout": "^3.0.0",
         "@solana/spl-account-compression": "^0.1.8",
         "@solana/spl-token": "^0.1.8",
+        "@solana/spl-token-metadata": "^0.1.6",
         "@solana/web3.js": "^1.66.6",
         "@solflare-wallet/utl-sdk": "^1.4.0",
         "@types/bn.js": "5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@solana/spl-token':
         specifier: ^0.1.8
         version: 0.1.8(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      '@solana/spl-token-metadata':
+        specifier: ^0.1.6
+        version: 0.1.6(@solana/web3.js@1.95.3(bufferutil@4.0.7)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
       '@solana/web3.js':
         specifier: ^1.66.6
         version: 1.95.3(bufferutil@4.0.7)(utf-8-validate@5.0.10)
@@ -1422,15 +1425,30 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/codecs-data-structures@2.0.0':
     resolution: {integrity: sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/codecs-numbers@2.0.0':
     resolution: {integrity: sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==}
     engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
     peerDependencies:
       typescript: '>=5'
 
@@ -1441,15 +1459,32 @@ packages:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
   '@solana/codecs@2.0.0':
     resolution: {integrity: sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/errors@2.0.0':
     resolution: {integrity: sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==}
     engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
     hasBin: true
     peerDependencies:
       typescript: '>=5'
@@ -1493,6 +1528,11 @@ packages:
   '@solana/options@2.0.0':
     resolution: {integrity: sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==}
     engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
       typescript: '>=5'
 
@@ -1597,6 +1637,12 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.50.1
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
 
   '@solana/spl-token@0.1.8':
     resolution: {integrity: sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==}
@@ -7237,11 +7283,23 @@ snapshots:
       '@solana/errors': 2.0.0(typescript@5.0.4)
       typescript: 5.0.4
 
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.0.4)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@5.0.4)
+      typescript: 5.0.4
+
   '@solana/codecs-data-structures@2.0.0(typescript@5.0.4)':
     dependencies:
       '@solana/codecs-core': 2.0.0(typescript@5.0.4)
       '@solana/codecs-numbers': 2.0.0(typescript@5.0.4)
       '@solana/errors': 2.0.0(typescript@5.0.4)
+      typescript: 5.0.4
+
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.0.4)
       typescript: 5.0.4
 
   '@solana/codecs-numbers@2.0.0(typescript@5.0.4)':
@@ -7250,11 +7308,25 @@ snapshots:
       '@solana/errors': 2.0.0(typescript@5.0.4)
       typescript: 5.0.4
 
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.0.4)
+      typescript: 5.0.4
+
   '@solana/codecs-strings@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
     dependencies:
       '@solana/codecs-core': 2.0.0(typescript@5.0.4)
       '@solana/codecs-numbers': 2.0.0(typescript@5.0.4)
       '@solana/errors': 2.0.0(typescript@5.0.4)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.0.4
+
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.0.4)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.0.4
 
@@ -7269,7 +7341,24 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/errors@2.0.0(typescript@5.0.4)':
+    dependencies:
+      chalk: 5.3.0
+      commander: 12.1.0
+      typescript: 5.0.4
+
+  '@solana/errors@2.0.0-rc.1(typescript@5.0.4)':
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
@@ -7316,6 +7405,17 @@ snapshots:
       '@solana/codecs-numbers': 2.0.0(typescript@5.0.4)
       '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
       '@solana/errors': 2.0.0(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.0.4)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -7486,6 +7586,14 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.95.3(bufferutil@4.0.7)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/web3.js': 1.95.3(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
 
   '@solana/spl-token@0.1.8(bufferutil@4.0.7)(utf-8-validate@5.0.10)':
     dependencies:


### PR DESCRIPTION
Also rips out the need for respecting token metadata pointer. 

This change however, by default assumes metadata pointer is pointing to mint. 

So on a conflict of extensions (metadataPointer points away from mint, but `MetadataExtension` is set, `MetadataExtension` takes higher priority).

Spec design for `emit` here: https://forum.solana.com/t/srfc-00017-token-metadata-interface/283
