### PR TITLE
chore(ci): upgrade setup-node to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           version: 8.6.6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade `actions/setup-node` to v4 in `ci.yaml` for better compatibility with latest runner environments.
> 
>   - **CI Configuration**:
>     - Upgrade `actions/setup-node` from v3 to v4 in `ci.yaml` for improved compatibility with latest runner environments.
>     - No functional changes to the application or its behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for a22f46ea3f55a744a5891313d4540bedc3e54d46. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->