### PR TITLE
Wrap pmp idls in try catch when casting to Codama

### DIFF
--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -260,11 +260,15 @@ function InstructionCard({
             </ErrorBoundary>
         );
     } else if (codamaIdl) {
-        const parsedIx = parseInstruction(codamaIdl as RootNode, upcastTransactionInstruction(transactionIx));
-        if (!parsedIx) {
+        try {
+            const parsedIx = parseInstruction(codamaIdl as RootNode, upcastTransactionInstruction(transactionIx));
+            if (!parsedIx) {
+                return <UnknownDetailsCard key={key} {...props} />;
+            }
+            return <CodamaInstructionCard key={key} {...props} parsedIx={parsedIx} />;
+        } catch (error) {
             return <UnknownDetailsCard key={key} {...props} />;
         }
-        return <CodamaInstructionCard key={key} {...props} parsedIx={parsedIx} />;
     } else if (anchorProgram) {
         return (
             <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fix issue where non-Codama IDLs uploaded via PMP throw application error

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Wraps `parseInstruction` in `try-catch` in `InstructionCard` to handle non-Codama IDLs without errors.
> 
>   - **Bug Fix**:
>     - Wraps `parseInstruction` call in `try-catch` in `InstructionCard` in `InstructionsSection.tsx` to handle non-Codama IDLs without throwing errors.
>     - Returns `UnknownDetailsCard` on error or if `parsedIx` is null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for c288b21b2143a1c2fef50a65addcd27662d62bc0. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->