### PR TITLE
Adjust MAX_CU_PER_BLOCK to reflect SIMD 256 activation

### DIFF
--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -19,7 +19,7 @@ import { getEpochForSlot } from '@/app/utils/epoch-schedule';
 
 type Props = PropsWithChildren<{ params: { slot: string } }>;
 
-const MAX_CU_PER_BLOCK = 50_000_000;
+const MAX_CU_PER_BLOCK = 60_000_000;
 
 function BlockLayoutInner({ children, params: { slot } }: Props) {
     const slotNumber = Number(slot);


### PR DESCRIPTION
## Description

Adjust static value MAX_CU_PER_BLOCK to reflect SIMD 256 changes on max cu block limit

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ x] Other (please describe): Static value adjusted for display in explorer, following SIMD 256 activation on mainnet


## Related Issues

[SIMD 256](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0256-raise-block-limits-to-60M.md)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `MAX_CU_PER_BLOCK` in `layout.tsx` to 60,000,000 for SIMD 256 activation.
> 
>   - **Behavior**:
>     - Update `MAX_CU_PER_BLOCK` from 50,000,000 to 60,000,000 in `layout.tsx` to reflect SIMD 256 activation.
>   - **Context**:
>     - This change aligns with the new block limits as per the [SIMD 256 proposal](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0256-raise-block-limits-to-60M.md).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for b05ed4eee5223bf65d567571d7bf0a988eec168e. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->