### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install package manager
         uses: pnpm/action-setup@v2

--- a/.github/workflows/update-feature-gates.yml
+++ b/.github/workflows/update-feature-gates.yml
@@ -12,7 +12,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `actions/checkout` to v5 in workflows for future-proofing against Node 24 runner updates.
> 
>   - **Workflows**:
>     - Update `actions/checkout` to v5 in `ci.yaml` and `update-feature-gates.yml` for future-proofing against Node 24 runner updates.
>     - Requires runner v2.327.1+.
>   - **Behavior**:
>     - Workflows compile the same with no changes to steps or logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 913782cbee314709bc5baf534448fdda76fbe655. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->