### PR TITLE
feature: Fetch IDL from RPC endpoint fails

### DIFF
--- a/app/providers/anchor.tsx
+++ b/app/providers/anchor.tsx
@@ -84,11 +84,12 @@ function useIdlFromAnchorProgramSeed(programAddress: string, url: string, cluste
                 .catch(_ => {
                     cachedAnchorProgramPromises[key] = { __type: 'result', result: null };
                 });
-            cachedAnchorProgramPromises[key] = {
-                __type: 'promise',
-                promise,
-            };
         }
+
+        cachedAnchorProgramPromises[key] = {
+            __type: 'promise',
+            promise,
+        };
         throw promise;
     } else if (cacheEntry.__type === 'promise') {
         throw cacheEntry.promise;


### PR DESCRIPTION
## Description

Fallback to try to fetch a program's IDL via RPC if the `/api/anchor` endpoint fails.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Testing

Simulated `/api/anchor` failing by mocking responses.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds fallback to fetch IDL via RPC if API endpoint fails in `anchor.tsx`.
> 
>   - **Behavior**:
>     - Adds `fetchIdlFromApi()` and `fetchIdlFromRpc()` functions in `anchor.tsx` to fetch IDL from API and RPC respectively.
>     - Modifies `useIdlFromAnchorProgramSeed()` to use `fetchIdlFromApi()` and fallback to `fetchIdlFromRpc()` if API call fails.
>   - **Error Handling**:
>     - Throws errors with specific messages if IDL fetching fails from both API and RPC.
>   - **Caching**:
>     - Updates `cachedAnchorProgramPromises` to store promises and results for IDL fetching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 5befcc587815ee0d42f3d9c980e1e42c23771758. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->