### PR TITLE
fix(jazzicon): correct types and default export

### DIFF
--- a/app/types/metamask-jazzicon.d.ts
+++ b/app/types/metamask-jazzicon.d.ts
@@ -5,7 +5,7 @@ declare module '@metamask/jazzicon' {
      * @param seed - The seed used to generate the identicon pattern
      * @returns The HTML container element with the SVG identicon
      */
-    function generateIdenticon(diameter: string | number, seed: number | string): HTMLElement;
+    function Jazzicon(diameter: number, seed: number): HTMLElement;
 
-    export = generateIdenticon;
+    export default Jazzicon;
 }


### PR DESCRIPTION
**fix(jazzicon): Correct TypeScript types for account avatar rendering**

## Description
This pull request resolves the `TypeError: i.getRgba is not a function` encountered while displaying account avatars for public keys in the Solana Devnet. The error was caused by a mismatch in the TypeScript module declaration for `@metamask/jazzicon`, which previously used `export = generateIdenticon` instead of the actual default export.

## Changes Implemented
- Updated the `@metamask/jazzicon` module declaration to `export default Jazzicon`.
- Updated `diameter` and `seed` types to `number` for proper type safety.
- Ensures account avatars for Devnet public keys render correctly without runtime errors.

## Error Screenshot
<img width="1130" height="413" alt="Screenshot 2025-10-02 at 10 07 36 PM" src="https://github.com/user-attachments/assets/706c1e9b-f307-463d-8ff9-51d2a1c687a0" />


## Before
- Rendering avatars for public keys in Devnet caused: `i.getRgba is not a function`.

## After
- Public key avatars display correctly without errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes TypeScript type mismatch in `@metamask/jazzicon` module declaration to resolve runtime errors in avatar rendering.
> 
>   - **TypeScript Types**:
>     - Corrects `@metamask/jazzicon` module declaration to use `export default Jazzicon` instead of `export = generateIdenticon`.
>     - Updates `Jazzicon` function parameter types to `number` for `diameter` and `seed` in `metamask-jazzicon.d.ts`.
>   - **Behavior**:
>     - Fixes `TypeError: i.getRgba is not a function` when rendering account avatars for Solana Devnet public keys.
>     - Ensures avatars render correctly without runtime errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for f383790db3f430b9616cbcaa6dda283467616f6c. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->