### PR TITLE
Fix 0 avgTps

### DIFF
--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -151,7 +151,7 @@ type TpsBarChartProps = {
 };
 function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
     const { perfHistory, avgTps, historyMaxTps } = performanceInfo;
-    const averageTps = Math.round(avgTps).toLocaleString('en-US');
+    const averageTps = Math.round(avgTps != null ? avgTps : 0.0).toLocaleString('en-US');
     const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
     const seriesData = perfHistory[series];
     const chartOptions = React.useMemo<ChartOptions<'bar'>>(() => TPS_CHART_OPTIONS(historyMaxTps), [historyMaxTps]);
@@ -250,7 +250,7 @@ function AnimatedTransactionCount({ info }: { info: PerformanceInfo }) {
         } else {
             // Since this is the first tx count value, estimate the previous
             // tx count in order to have a starting point for our animation
-            countUp.period = PERF_UPDATE_SEC * avgTps;
+            countUp.period = PERF_UPDATE_SEC * (avgTps != null ? avgTps : 0.0);
             countUp.start = txCount - countUp.period;
         }
         countUp.lastUpdate = Date.now();

--- a/app/providers/stats/solanaClusterStats.tsx
+++ b/app/providers/stats/solanaClusterStats.tsx
@@ -29,7 +29,7 @@ export enum ClusterStatsStatus {
 }
 
 const initialPerformanceInfo: PerformanceInfo = {
-    avgTps: 0,
+    avgTps: null,
     historyMaxTps: 0,
     perfHistory: {
         long: [],

--- a/app/providers/stats/solanaPerformanceInfo.tsx
+++ b/app/providers/stats/solanaPerformanceInfo.tsx
@@ -2,7 +2,7 @@ import { ClusterStatsStatus } from './solanaClusterStats';
 
 export type PerformanceInfo = {
     status: ClusterStatsStatus;
-    avgTps: number;
+    avgTps: number | null;
     historyMaxTps: number;
     perfHistory: {
         short: (number | null)[];
@@ -63,10 +63,10 @@ export function performanceInfoReducer(state: PerformanceInfo, action: Performan
                     return sample.numTransactions !== BigInt(0);
                 })
                 .map(sample => {
-                    return Number(sample.numTransactions / BigInt(sample.samplePeriodSecs));
+                    return Number(sample.numTransactions) / sample.samplePeriodSecs;
                 });
 
-            const avgTps = short[0];
+            const avgTps = short[0] || null;
             const medium = downsampleByFactor(short, 4);
             const long = downsampleByFactor(medium, 3);
 
@@ -94,7 +94,7 @@ export function performanceInfoReducer(state: PerformanceInfo, action: Performan
         }
 
         case PerformanceInfoActionType.SetTransactionCount: {
-            const status = state.avgTps !== 0 ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
+            const status = state.avgTps != null ? ClusterStatsStatus.Ready : ClusterStatsStatus.Loading;
 
             return {
                 ...state,


### PR DESCRIPTION
## Description

- `avgTps` falls back to `0` when `short[0]` is something falsy. This means if `avgTps` is `0`, it will fall back to `0`. Later, we check whether `avgTps` is `0` to derive a status, which means a real `0` TPS can result in `ClusterStatsStatus.Loading` when it should actually be `ClusterStatsStatus.Ready`
- We were casting `sample.samplePeriodSecs` to a `BigInt` which means that our TPS will truncate decimals. E.g., 0.3 TPS becomes 0 TPS. `sample.samplePeriodSecs` is generally not a big number (default 60 [seconds]). If we want integers, we should use ceil/floor explicitly

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

I have a network with <1 TPS. Prior to this PR, I would get errors when loading the front page

<img width="1144" height="512" alt="image" src="https://github.com/user-attachments/assets/c6488db1-0753-4c79-9aec-3e7f05358ebd" />

## Testing

Tested locally

## Related Issues

N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [ ] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `avgTps` handling and TPS calculation in Solana cluster stats to prevent incorrect status assignment.
> 
>   - **Behavior**:
>     - `avgTps` now defaults to `null` instead of `0` in `solanaClusterStats.tsx` and `solanaPerformanceInfo.tsx`.
>     - Corrects TPS calculation by dividing `numTransactions` by `samplePeriodSecs` as a float in `performanceInfoReducer()`.
>     - Status determination in `SetTransactionCount` action now checks for `avgTps != null` instead of `avgTps !== 0`.
>   - **Types**:
>     - Updates `PerformanceInfo` type to allow `avgTps` to be `number | null` in `solanaPerformanceInfo.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 9297f50841b026865e000c6c3865c3a678aa348b. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->