### PR TITLE
Show cNFT Images in the Explorer

### DIFF
--- a/app/components/common/NFTArt.tsx
+++ b/app/components/common/NFTArt.tsx
@@ -3,6 +3,7 @@ import { MetadataJson } from '@metaplex/js';
 import { PublicKey } from '@solana/web3.js';
 import Link from 'next/link';
 
+import { getProxiedUri } from '@/app/features/metadata/utils';
 import { isEnvEnabled } from '@/app/utils/env';
 
 import { InfoTooltip } from './InfoTooltip';
@@ -35,7 +36,7 @@ export const NFTImageContent = ({ uri }: { uri?: string }) => {
         <div style={{ maxHeight: 200, width: 150 }}>
             <div className="rounded mx-auto d-block" style={{ overflow: 'hidden' }}>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img alt="nft" src={uri ?? lowContrastSolanalogo.src} width="100%" />
+                <img alt="nft" src={uri ? getProxiedUri(uri) : lowContrastSolanalogo.src} width="100%" />
             </div>
             {uri && <ViewOriginalArtContentLink src={uri} />}
         </div>


### PR DESCRIPTION
## Description

Previously NFTs did not show the actual NFT images but just the Solana logo. This PR fixes this by using the passed in image URI when available.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots
After:
<img width="754" height="323" alt="Screenshot 2025-11-11 at 9 21 34 AM" src="https://github.com/user-attachments/assets/cfa28c3c-0b53-4d58-a83c-18b61795d940" />
Before:
<img width="740" height="326" alt="Screenshot 2025-11-11 at 9 21 52 AM" src="https://github.com/user-attachments/assets/e9dec929-4aec-4669-8e88-10a5af34c61b" />


## Testing

Tested the change locally with this nft EaFvTPHcMB3eLXEkG2UWhV5FFQjxcnsNhQYu97xxGBsz

## Related Issues

N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `NFTImageContent` now displays NFT images using `uri` if available, improving UI by replacing default logo.
> 
>   - **Behavior**:
>     - `NFTImageContent` in `NFTArt.tsx` now displays NFT image using `uri` if available, falling back to `lowContrastSolanalogo` otherwise.
>     - `ViewOriginalArtContentLink` displays a link to the original art if `uri` is provided.
>   - **Misc**:
>     - Fixes minor indentation issue in `ViewOriginalArtContentLink`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for e219689657390901cbf347a75439bf05df68c51c. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->