### PR TITLE
Make tx cost consistent across block page and transaction signature page

### DIFF
--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -118,7 +118,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
 
             let costUnits: number | undefined = undefined;
             try {
-                costUnits = tx.meta?.costUnits ?? 0;
+                costUnits = tx.meta?.costUnits;
             } catch (err) {
                 // ignore parsing errors because some old logs aren't parsable
             }
@@ -172,7 +172,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
         if (sortMode === 'compute' && showComputeUnits) {
             filteredTxs.sort((a, b) => b.computeUnits! - a.computeUnits!);
         } else if (sortMode === 'txnCost') {
-            filteredTxs.sort((a, b) => b.costUnits! - a.costUnits!);
+            filteredTxs.sort((a, b) => (b.costUnits ?? 0) - (a.costUnits ?? 0));
         } else if (sortMode === 'fee') {
             filteredTxs.sort((a, b) => (b.meta?.fee || 0) - (a.meta?.fee || 0));
         } else if (sortMode === 'reservedCUs') {
@@ -345,7 +345,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
                                         <td>
                                             {tx.costUnits !== undefined
                                                 ? new Intl.NumberFormat('en-US').format(tx.costUnits)
-                                                : 'Unknown'}
+                                                : 'Not Supported Slot'}
                                         </td>
                                         <td>
                                             {tx.invocations.size === 0

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -346,12 +346,12 @@ function StatusCard({ signature, autoRefresh }: SignatureProps & AutoRefreshProp
                     </tr>
                 )}
 
-                {costUnits !== undefined && (
-                    <tr>
-                        <td>Transaction cost</td>
-                        <td className="text-lg-end">{costUnits.toLocaleString('en-US')}</td>
-                    </tr>
-                )}
+                <tr>
+                    <td>Transaction cost</td>
+                    <td className="text-lg-end">
+                        {costUnits !== undefined ? costUnits.toLocaleString('en-US') : 'Not Supported Slot'}
+                    </td>
+                </tr>
 
                 {reservedCUs !== undefined && (
                     <tr>


### PR DESCRIPTION
## Description
Make tx costUnits consistent across block page and transaction signature page (show `Not Supported Slot` instead of showing 0 value or making the component disappear).

<!-- Provide a brief description of the changes in this PR -->

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots
<img width="1168" height="112" alt="Screenshot 2025-11-25 at 7 10 57 AM" src="https://github.com/user-attachments/assets/bdeeb40c-ce3e-4a46-9ae7-6c833912f068" />
<img width="1161" height="81" alt="Screenshot 2025-11-25 at 7 10 47 AM" src="https://github.com/user-attachments/assets/521392f5-5853-4a24-90ed-54702ca85942" />

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->
Fixes https://github.com/solana-foundation/explorer/issues/662

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix transaction cost display to show 'Not Supported Slot' for undefined cost units in block and transaction signature pages.
> 
>   - **Behavior**:
>     - Display 'Not Supported Slot' for undefined `costUnits` in `BlockHistoryCard.tsx` and `page-client.tsx` instead of 0 or hiding the component.
>   - **Sorting**:
>     - Update sorting logic in `BlockHistoryCard.tsx` to handle undefined `costUnits` by treating them as 0.
>   - **UI**:
>     - Consistent display of transaction cost across block and transaction signature pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 289636584490ad39562b22500f3e4ebd7b27eef7. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->