### PR TITLE
feat: Hide unverified badge for trusted programs

### DIFF
--- a/app/components/account/__tests__/AccountHeader.spec.tsx
+++ b/app/components/account/__tests__/AccountHeader.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { vi } from 'vitest';
 
 import { AccountHeader } from '@/app/components/account/AccountHeader';
+import { PROGRAMS_SKIP_UNVERIFIED_BADGE } from '@/app/components/shared/account/ProgramHeader';
 import { useSecurityTxt } from '@/app/features/security-txt';
 import { createNeodymeSecurityTxt, createPmpSecurityTxt } from '@/app/features/security-txt/ui/__tests__/helpers';
 import type { Account, UpgradeableLoaderAccountData } from '@/app/providers/accounts';
@@ -156,6 +157,45 @@ describe('AccountHeader', () => {
             );
 
             expect(screen.getByText('Unverified')).toBeInTheDocument();
+        });
+
+        describe('unverified badge for trusted programs', () => {
+            it.each([...PROGRAMS_SKIP_UNVERIFIED_BADGE].map(([address, name]) => ({ address, name })))(
+                'should not show unverified badge for $name even with securityTxt',
+                ({ address }) => {
+                    const pmpSecurityTxt = createPmpSecurityTxt();
+                    vi.mocked(useSecurityTxt).mockReturnValue(pmpSecurityTxt);
+
+                    const account = setup().account;
+                    render(
+                        <AccountHeader
+                            address={address}
+                            account={account}
+                            tokenInfo={undefined}
+                            isTokenInfoLoading={false}
+                        />
+                    );
+
+                    expect(screen.queryByText('Unverified')).not.toBeInTheDocument();
+                }
+            );
+
+            it('should show unverified badge for non-trusted programs with securityTxt', () => {
+                const pmpSecurityTxt = createPmpSecurityTxt();
+                vi.mocked(useSecurityTxt).mockReturnValue(pmpSecurityTxt);
+
+                const { account, mockAddress } = setup();
+                render(
+                    <AccountHeader
+                        address={mockAddress}
+                        account={account}
+                        tokenInfo={undefined}
+                        isTokenInfoLoading={false}
+                    />
+                );
+
+                expect(screen.getByText('Unverified')).toBeInTheDocument();
+            });
         });
     });
 });

--- a/app/components/shared/account/ProgramHeader.tsx
+++ b/app/components/shared/account/ProgramHeader.tsx
@@ -13,6 +13,16 @@ import { Badge } from '../ui/badge';
 
 const IDENTICON_WIDTH = 64;
 
+// The "unverified" badge indicates that the securityTxt metadata (name, logo, etc.)
+// is self-reported by the program author and may not be accurate. However, we trust
+// official Solana programs (e.g. spl-token, token-2022, associated token) even if they
+// have securityTxt, so we skip showing the badge for these trusted programs.
+export const PROGRAMS_SKIP_UNVERIFIED_BADGE = new Map([
+    ['TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', 'Token Program'],
+    ['TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb', 'Token-2022 Program'],
+    ['ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL', 'Associated Token Program'],
+]);
+
 export function ProgramHeader({ address, parsedData }: { address: string; parsedData: UpgradeableLoaderAccountData }) {
     const securityTxt = useSecurityTxt(address, parsedData);
 
@@ -28,17 +38,20 @@ export function ProgramHeader({ address, parsedData }: { address: string; parsed
                 unverified: undefined,
             };
         }
+
+        const shouldSkipUnverifiedBadge = PROGRAMS_SKIP_UNVERIFIED_BADGE.has(address);
+
         if (isPmpSecurityTXT(securityTxt)) {
             return {
                 logo: getProxiedUri(securityTxt.logo),
                 programName: securityTxt.name,
-                unverified: true,
+                unverified: shouldSkipUnverifiedBadge ? false : true,
                 version: securityTxt.version,
             };
         }
         return {
             programName: securityTxt.name,
-            unverified: true,
+            unverified: shouldSkipUnverifiedBadge ? false : true,
         };
     })();
 


### PR DESCRIPTION
## Description
Removed "unverified" badge for trusted programs.


## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<img width="1195" height="315" alt="localhost_3000_address_TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" src="https://github.com/user-attachments/assets/149c6f2f-c10b-44d4-9bcb-f01a6e81b98e" />


## Testing
- Visit http://localhost:3000/address/TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
- See no "unverified" badge

## Related Issues
N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hide "unverified" badge for trusted Solana programs in `ProgramHeader.tsx` and add tests in `AccountHeader.spec.tsx`.
> 
>   - **Behavior**:
>     - Hides "unverified" badge for trusted programs in `ProgramHeader.tsx` using `PROGRAMS_SKIP_UNVERIFIED_BADGE`.
>     - Trusted programs include 'Token Program', 'Token-2022 Program', and 'Associated Token Program'.
>     - Badge still shown for non-trusted programs.
>   - **Tests**:
>     - Added tests in `AccountHeader.spec.tsx` to verify badge is hidden for trusted programs and shown for others.
>     - Utilizes `PROGRAMS_SKIP_UNVERIFIED_BADGE` for test cases.
>   - **Misc**:
>     - Added `PROGRAMS_SKIP_UNVERIFIED_BADGE` constant to `ProgramHeader.tsx` to manage trusted programs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for c49091470447009288592870ac8ad0782b35a33c. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->