### PR TITLE
fix: Preserve custom RPC URL on reload when cluster=custom is selected

### DIFF
--- a/app/providers/cluster.tsx
+++ b/app/providers/cluster.tsx
@@ -95,6 +95,7 @@ export function ClusterProvider({ children }: ClusterProviderProps) {
     const searchParams = useSearchParams();
     const cluster = parseQuery(searchParams);
     const enableCustomUrl =
+        cluster === Cluster.Custom ||
         (localStorageIsAvailable() && localStorage.getItem('enableCustomUrl') !== null) ||
         isWhitelistedRpc(state.customUrl);
     const customUrl = (enableCustomUrl && searchParams?.get('customUrl')) || state.customUrl;


### PR DESCRIPTION
## Description

Preserve custom RPC URL on reload when cluster=custom is selected

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

No UI changes

## Testing

Tested locally

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ClusterProvider` to preserve custom RPC URL on reload when `cluster=custom` is selected.
> 
>   - **Behavior**:
>     - Fixes bug in `ClusterProvider` to preserve custom RPC URL on reload when `cluster=custom` is selected.
>     - Modifies `enableCustomUrl` logic to include `cluster === Cluster.Custom` check in `cluster.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for 068e804e3dfa5c99c2b859751e12c8f0ee38db7d. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->