### PR TITLE
fix: Handle empty security txt names

### DIFF
--- a/app/components/account/__tests__/AccountHeader.spec.tsx
+++ b/app/components/account/__tests__/AccountHeader.spec.tsx
@@ -212,6 +212,24 @@ describe('AccountHeader', () => {
             expect(screen.queryByAltText('Program logo')).not.toBeInTheDocument();
         });
 
+        it('should render with empty name when securityTxt is present but name is empty string for non-trusted program', () => {
+            const pmpSecurityTxt = createPmpSecurityTxt({ name: '' });
+            vi.mocked(useSecurityTxt).mockReturnValue(pmpSecurityTxt);
+
+            const nonTrustedAddress = '11111111111111111111111111111112';
+            const { account } = setup(nonTrustedAddress);
+            render(
+                <AccountHeader
+                    address={nonTrustedAddress}
+                    account={account}
+                    tokenInfo={undefined}
+                    isTokenInfoLoading={false}
+                />
+            );
+
+            expect(screen.getByRole('heading', { name: 'Program Account' })).toBeInTheDocument();
+        });
+
         it('should render with self-reported warning icon', () => {
             vi.stubEnv('NEXT_PUBLIC_METADATA_ENABLED', 'true');
             const pmpSecurityTxt = createPmpSecurityTxt();

--- a/app/components/shared/account/ProgramHeader.tsx
+++ b/app/components/shared/account/ProgramHeader.tsx
@@ -36,10 +36,13 @@ export function ProgramHeader({
         const programInfo = PROGRAM_INFO_BY_ID[address];
         const isTrustedProgram = programInfo && programInfo.deployments.includes(cluster);
         const trustedProgramName = isTrustedProgram ? programInfo.name : undefined;
+        const namePlaceholder = 'Program Account';
+
+        let programName = trustedProgramName ?? namePlaceholder;
 
         if (!securityTxt) {
             return {
-                programName: trustedProgramName || 'Program Account',
+                programName,
                 selfReported: false,
             };
         }
@@ -47,16 +50,19 @@ export function ProgramHeader({
         // Only show warning if we're actually using self-reported data
         const usingSelfReportedName = !trustedProgramName;
 
+        // Handle empty name in security.txt
+        programName = (trustedProgramName ?? securityTxt.name) || namePlaceholder;
+
         if (isPmpSecurityTXT(securityTxt)) {
             return {
                 logo: getProxiedUri(securityTxt.logo),
-                programName: trustedProgramName ?? securityTxt.name,
+                programName,
                 selfReported: usingSelfReportedName,
                 version: securityTxt.version,
             };
         }
         return {
-            programName: trustedProgramName ?? securityTxt.name,
+            programName,
             selfReported: usingSelfReportedName,
         };
     })();
@@ -83,7 +89,7 @@ export function ProgramHeader({
 
     return (
         <div className="e-inline-flex e-items-center e-gap-2">
-            <div className="">
+            <div>
                 <div className="e-relative e-h-10 e-w-10 e-flex-shrink-0 e-overflow-hidden e-rounded sm:e-h-16 sm:e-w-16">
                     {logo ? (
                         // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
## Description

Fixed handling empty security txt names.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Testing
- Visit any program page that contains security txt, but the name is an empty string
- Tests should pass
<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

## Related Issues
N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix handling of empty security.txt names in `ProgramHeader.tsx` by using a default placeholder and add a corresponding test.
> 
>   - **Behavior**:
>     - In `ProgramHeader.tsx`, handle empty `securityTxt.name` by using 'Program Account' as a placeholder.
>     - Ensure `programName` is set to a default if `securityTxt.name` is empty.
>   - **Testing**:
>     - Add test in `AccountHeader.spec.tsx` to verify rendering with empty `securityTxt.name` for non-trusted programs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fexplorer&utm_source=github&utm_medium=referral)<sup> for d2c3b998a80b7622c0997ff3baa3dcf8cc5950a6. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->