### PR TITLE
fix: Ping endpoint e.body.tee is not a function

### DIFF
--- a/app/api/ping/[network]/route.ts
+++ b/app/api/ping/[network]/route.ts
@@ -52,8 +52,9 @@ export async function GET(_request: Request, { params: { network } }: Params) {
 
         return NextResponse.json(data, { headers: CACHE_HEADERS });
     } catch (error) {
-        Logger.error(new Error('Ping API error', { cause: error }));
-        Sentry.captureException(error);
+        const wrappedError = new Error('Ping API error', { cause: error });
+        Logger.error(wrappedError);
+        Sentry.captureException(wrappedError);
         return NextResponse.json(
             { error: 'Failed to fetch ping data' },
             { headers: { 'Cache-Control': 'no-store, max-age=0' }, status: 500 }


### PR DESCRIPTION
## Description
- fixing "e.body.tee is not a function" error for ping endpoint
- adding logging

## Type of change
-   [x] Bug fix

## Testing
1. open http://localhost:3000/api/ping/mainnet
2. should work with no errors

## Related Issues
[HOO-349](https://linear.app/solana-fndn/issue/HOO-349/improve-the-ping-endpoint-to-handle-tee-error)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass