### PR TITLE
fix: remove tokenLabelInfo from token account address

### DIFF
--- a/app/components/account/OwnedTokensCard.tsx
+++ b/app/components/account/OwnedTokensCard.tsx
@@ -261,7 +261,7 @@ function TokenRow({ mintAddress, token, showLogo, showAccountAddress }: TokenRow
             )}
             {showAccountAddress && token.pubkey && (
                 <td>
-                    <Address pubkey={new PublicKey(token.pubkey)} link tokenLabelInfo={token} />
+                    <Address pubkey={new PublicKey(token.pubkey)} link />
                 </td>
             )}
             <td>


### PR DESCRIPTION
## Description

the detail page prefer shows token information instead of the actual token address.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots


current:

<img width="1168" height="324" alt="Screenshot 2026-04-08 at 20 07 26" src="https://github.com/user-attachments/assets/26f52f42-5af7-4ce6-8afd-5bda9c245347" />

this PR:
<img width="1154" height="321" alt="Screenshot 2026-04-08 at 20 07 36" src="https://github.com/user-attachments/assets/be3657eb-6162-4082-b2f9-9a28048ed9ad" />
