### PR TITLE
fix: sanitize untrusted external metadata links

### DIFF
--- a/app/components/account/CompressedNftCard.tsx
+++ b/app/components/account/CompressedNftCard.tsx
@@ -8,6 +8,7 @@ import useAsyncEffect from 'use-async-effect';
 import { getProxiedUri } from '@/app/features/metadata';
 import { useCluster } from '@/app/providers/cluster';
 import { CompressedNft, useCompressedNft, useMetadataJsonLink } from '@/app/providers/compressed-nft';
+import { getSafeExternalUrl } from '@/app/shared/lib/safe-external-url';
 
 import { Address } from '../common/Address';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -20,6 +21,7 @@ export function CompressedNftCard({ account }: { account: Account }) {
     const { url } = useCluster();
     const compressedNft = useCompressedNft({ address: account.pubkey.toString(), url });
     if (!compressedNft) return <UnknownAccountCard account={account} />;
+    const externalUrl = getSafeExternalUrl(compressedNft.content.links.external_url);
 
     const collectionGroup = compressedNft.grouping.find(group => group.group_key === 'collection');
     const updateAuthority = compressedNft.authorities.find(authority => authority.scopes.includes('full'))?.address;
@@ -57,10 +59,14 @@ export function CompressedNftCard({ account }: { account: Account }) {
             <tr>
                 <td>Website</td>
                 <td className="text-lg-end">
-                    <a rel="noopener noreferrer" target="_blank" href={compressedNft.content.links.external_url}>
-                        {compressedNft.content.links.external_url}
-                        <ExternalLink className="align-text-top ms-2" size={13} />
-                    </a>
+                    {externalUrl ? (
+                        <a rel="noopener noreferrer" target="_blank" href={externalUrl}>
+                            {compressedNft.content.links.external_url}
+                            <ExternalLink className="align-text-top ms-2" size={13} />
+                        </a>
+                    ) : (
+                        compressedNft.content.links.external_url || '-'
+                    )}
                 </td>
             </tr>
             <tr>

--- a/app/components/account/ConfigAccountSection.tsx
+++ b/app/components/account/ConfigAccountSection.tsx
@@ -7,6 +7,8 @@ import { PublicKey } from '@solana/web3.js';
 import { ConfigAccount, StakeConfigInfoAccount, ValidatorInfoAccount } from '@validators/accounts/config';
 import React from 'react';
 
+import { getSafeExternalUrl } from '@/app/shared/lib/safe-external-url';
+
 const MAX_SLASH_PENALTY = Math.pow(2, 8);
 
 export function ConfigAccountSection({ account, configAccount }: { account: Account; configAccount: ConfigAccount }) {
@@ -56,6 +58,7 @@ function StakeConfigCard({ account, configAccount }: { account: Account; configA
 
 function ValidatorInfoCard({ account, configAccount }: { account: Account; configAccount: ValidatorInfoAccount }) {
     const refresh = useRefreshAccount();
+    const websiteUrl = getSafeExternalUrl(configAccount.info.configData.website);
     return (
         <AccountCard
             title="Validator Info"
@@ -84,9 +87,13 @@ function ValidatorInfoCard({ account, configAccount }: { account: Account; confi
                 <tr>
                     <td>Website</td>
                     <td className="text-lg-end">
-                        <a href={configAccount.info.configData.website} target="_blank" rel="noopener noreferrer">
-                            {configAccount.info.configData.website}
-                        </a>
+                        {websiteUrl ? (
+                            <a href={websiteUrl} target="_blank" rel="noopener noreferrer">
+                                {configAccount.info.configData.website}
+                            </a>
+                        ) : (
+                            configAccount.info.configData.website
+                        )}
                     </td>
                 </tr>
             )}

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -49,6 +49,7 @@ import { create } from 'superstruct';
 import useSWR from 'swr';
 
 import { Logger } from '@/app/shared/lib/logger';
+import { getSafeExternalUrl } from '@/app/shared/lib/safe-external-url';
 import { FullLegacyTokenInfo, getTokenInfo, getTokenInfoSwrKey } from '@/app/utils/token-info';
 
 import { TokenExtensionsStatusRow } from './token-extensions/TokenExtensionsStatusRow';
@@ -131,6 +132,9 @@ function FungibleTokenMintAccountCard({
 }) {
     const fetchInfo = useRefreshAccount();
 
+    const websiteUrl = getSafeExternalUrl(tokenInfo?.extensions?.website);
+    const bridgeContractUrl = getSafeExternalUrl(tokenInfo?.extensions?.bridgeContract);
+    const assetContractUrl = getSafeExternalUrl(tokenInfo?.extensions?.assetContract);
     const bridgeContractAddress = getEthAddress(tokenInfo?.extensions?.bridgeContract);
     const assetContractAddress = getEthAddress(tokenInfo?.extensions?.assetContract);
 
@@ -178,10 +182,14 @@ function FungibleTokenMintAccountCard({
                 <tr>
                     <td>Website</td>
                     <td className="text-md-end">
-                        <a rel="noopener noreferrer" target="_blank" href={tokenInfo.extensions.website}>
-                            {tokenInfo.extensions.website}
-                            <ExternalLink className="align-text-top ms-2" size={13} />
-                        </a>
+                        {websiteUrl ? (
+                            <a rel="noopener noreferrer" target="_blank" href={websiteUrl}>
+                                {tokenInfo.extensions.website}
+                                <ExternalLink className="align-text-top ms-2" size={13} />
+                            </a>
+                        ) : (
+                            tokenInfo.extensions.website
+                        )}
                     </td>
                 </tr>
             )}
@@ -216,9 +224,13 @@ function FungibleTokenMintAccountCard({
                     <td>Bridge Contract</td>
                     <td className="text-md-end">
                         <Copyable text={bridgeContractAddress}>
-                            <a href={tokenInfo.extensions.bridgeContract} target="_blank" rel="noreferrer">
-                                {bridgeContractAddress}
-                            </a>
+                            {bridgeContractUrl ? (
+                                <a href={bridgeContractUrl} target="_blank" rel="noreferrer">
+                                    {bridgeContractAddress}
+                                </a>
+                            ) : (
+                                <span>{bridgeContractAddress}</span>
+                            )}
                         </Copyable>
                     </td>
                 </tr>
@@ -228,9 +240,13 @@ function FungibleTokenMintAccountCard({
                     <td>Bridged Asset Contract</td>
                     <td className="text-md-end">
                         <Copyable text={assetContractAddress}>
-                            <a href={tokenInfo.extensions.bridgeContract} target="_blank" rel="noreferrer">
-                                {assetContractAddress}
-                            </a>
+                            {assetContractUrl ? (
+                                <a href={assetContractUrl} target="_blank" rel="noreferrer">
+                                    {assetContractAddress}
+                                </a>
+                            ) : (
+                                <span>{assetContractAddress}</span>
+                            )}
                         </Copyable>
                     </td>
                 </tr>
@@ -252,6 +268,7 @@ function NonFungibleTokenMintAccountCard({
     mintInfo: MintAccountInfo;
 }) {
     const fetchInfo = useRefreshAccount();
+    const externalUrl = getSafeExternalUrl(nftData?.json?.external_url);
 
     const collectionOpt = nftData.metadata.collection;
     const collection = collectionOpt && isSome(collectionOpt) ? collectionOpt.value : null;
@@ -329,10 +346,14 @@ function NonFungibleTokenMintAccountCard({
                 <tr>
                     <td>Website</td>
                     <td className="text-md-end">
-                        <a rel="noopener noreferrer" target="_blank" href={nftData.json.external_url}>
-                            {nftData.json.external_url}
-                            <ExternalLink className="align-text-top ms-2" size={13} />
-                        </a>
+                        {externalUrl ? (
+                            <a rel="noopener noreferrer" target="_blank" href={externalUrl}>
+                                {nftData.json.external_url}
+                                <ExternalLink className="align-text-top ms-2" size={13} />
+                            </a>
+                        ) : (
+                            nftData.json.external_url
+                        )}
                     </td>
                 </tr>
             )}
@@ -953,6 +974,7 @@ export function TokenExtensionRow(
         }
         case 'tokenMetadata': {
             const extension = create(tokenExtension.state, TokenMetadata);
+            const uri = getSafeExternalUrl(extension.uri);
             return (
                 <>
                     {headerStyle === 'header' ? <HHeader name="Metadata" /> : null}
@@ -981,8 +1003,8 @@ export function TokenExtensionRow(
                     <tr>
                         <td>URI</td>
                         <td className="text-md-end">
-                            {extension.uri.startsWith('http') ? (
-                                <a rel="noopener noreferrer" target="_blank" href={extension.uri}>
+                            {uri ? (
+                                <a rel="noopener noreferrer" target="_blank" href={uri}>
                                     {extension.uri}
                                     <ExternalLink className="align-text-top ms-2" size={13} />
                                 </a>

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -6,6 +6,7 @@ import { PublicKey } from '@solana/web3.js';
 import Link from 'next/link';
 import { ExternalLink } from 'react-feather';
 
+import { getSafeExternalUrl } from '@/app/shared/lib/safe-external-url';
 import { OsecRegistryInfo, useVerifiedProgram, VerificationStatus } from '@/app/utils/verified-builds';
 
 import { Address } from '../common/Address';
@@ -190,11 +191,12 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
                 </td>
             );
         case DisplayType.URL:
-            if (isValidLink(value as string)) {
+            const safeUrl = getSafeExternalUrl(value);
+            if (safeUrl) {
                 return (
                     <td className="text-lg-end">
                         <span className="font-monospace">
-                            <a rel="noopener noreferrer" target="_blank" href={value as string}>
+                            <a rel="noopener noreferrer" target="_blank" href={safeUrl}>
                                 {value}
                                 <ExternalLink className="align-text-top ms-2" size={13} />
                             </a>
@@ -223,13 +225,4 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
             break;
     }
     return <></>;
-}
-
-function isValidLink(value: string) {
-    try {
-        const url = new URL(value);
-        return ['http:', 'https:'].includes(url.protocol);
-    } catch (_err) {
-        return false;
-    }
 }

--- a/app/components/account/__tests__/TokenAccountSection.spec.tsx
+++ b/app/components/account/__tests__/TokenAccountSection.spec.tsx
@@ -1,0 +1,120 @@
+import { PublicKey } from '@solana/web3.js';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TokenAccountSection } from '../TokenAccountSection';
+
+vi.mock('@components/account/token-extensions/ScaledUiAmountMultiplierTooltip', () => ({
+    default: () => null,
+}));
+
+vi.mock('@components/common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: PublicKey }) => <span>{pubkey.toBase58()}</span>,
+}));
+
+vi.mock('@components/common/Copyable', () => ({
+    Copyable: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@entities/account', () => ({
+    useRefreshAccount: () => vi.fn(),
+}));
+
+vi.mock('@entities/nft', () => ({
+    isMetaplexNFT: () => false,
+}));
+
+vi.mock('@features/account', () => ({
+    AccountCard: ({ children }: { children: React.ReactNode }) => (
+        <table>
+            <tbody>{children}</tbody>
+        </table>
+    ),
+}));
+
+vi.mock('@providers/cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('@providers/cluster')>();
+    return {
+        ...actual,
+        useCluster: () => ({ cluster: 'mainnet-beta' }),
+    };
+});
+
+vi.mock('../UnknownAccountCard', () => ({
+    UnknownAccountCard: () => <div>Unknown account</div>,
+}));
+
+vi.mock('../token-extensions/TokenExtensionsStatusRow', () => ({
+    TokenExtensionsStatusRow: () => null,
+}));
+
+const mintAuthority = PublicKey.default;
+const mintAccount = {
+    data: {
+        parsed: {
+            nftData: undefined,
+            parsed: {},
+            program: 'spl-token',
+        },
+    },
+    executable: false,
+    lamports: 0,
+    owner: mintAuthority,
+    pubkey: mintAuthority,
+};
+
+const mintTokenAccount = {
+    info: {
+        decimals: 6,
+        freezeAuthority: null,
+        isInitialized: true,
+        mintAuthority: null,
+        supply: '1000000',
+    },
+    type: 'mint',
+} as const;
+
+describe('TokenAccountSection', () => {
+    it('does not render unsafe website values as clickable links', () => {
+        render(
+            <TokenAccountSection
+                account={mintAccount as any}
+                tokenAccount={mintTokenAccount as any}
+                tokenInfo={
+                    {
+                        extensions: {
+                            website: 'javascript:alert(1)',
+                        },
+                    } as any
+                }
+            />,
+        );
+
+        expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'javascript:alert(1)' })).not.toBeInTheDocument();
+    });
+
+    it('uses the asset contract URL for the bridged asset row', () => {
+        const bridgeContractUrl = 'https://etherscan.io/address/0x1111111111111111111111111111111111111111';
+        const assetContractUrl = 'https://arbiscan.io/token/0x2222222222222222222222222222222222222222';
+        const assetContractAddress = '0x2222222222222222222222222222222222222222';
+
+        render(
+            <TokenAccountSection
+                account={mintAccount as any}
+                tokenAccount={mintTokenAccount as any}
+                tokenInfo={
+                    {
+                        extensions: {
+                            assetContract: assetContractUrl,
+                            bridgeContract: bridgeContractUrl,
+                        },
+                    } as any
+                }
+            />,
+        );
+
+        expect(screen.getByRole('link', { name: assetContractAddress })).toHaveAttribute('href', assetContractUrl);
+    });
+});

--- a/app/components/common/NFTArt.tsx
+++ b/app/components/common/NFTArt.tsx
@@ -11,23 +11,36 @@ import { InfoTooltip } from './InfoTooltip';
 const isDisplayEnabled = isEnvEnabled(process.env.NEXT_PUBLIC_VIEW_ORIGINAL_DISPLAY_ENABLED);
 
 export const MAX_TIME_LOADING_IMAGE = 5000; /* 5 seconds */
+const UNSUPPORTED_EXTERNAL_RESOURCE_TOOLTIP =
+    'Original asset links are only enabled for http and https URLs. Unsupported URI schemes are shown as disabled.';
 
 const ViewOriginalArtContentLink = ({ src }: { src: string }) => {
     const safeSrc = getSafeExternalUrl(src);
 
-    if (!safeSrc) {
+    if (!isDisplayEnabled) {
         return null;
     }
 
     return (
         <h6 className="header-pretitle d-flex mt-2 justify-content-center">
-            {!isDisplayEnabled ? null : (
+            {safeSrc ? (
                 <a href={safeSrc} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
                     <div>VIEW ORIGINAL</div>
                     <div className="d-flex">
                         <InfoTooltip right text="Clicking this link will open an external resource" />
                     </div>
                 </a>
+            ) : (
+                <span
+                    aria-disabled="true"
+                    className="d-flex align-items-center text-muted"
+                    data-testid="view-original-disabled"
+                >
+                    <div>VIEW ORIGINAL</div>
+                    <div className="d-flex">
+                        <InfoTooltip right text={UNSUPPORTED_EXTERNAL_RESOURCE_TOOLTIP} />
+                    </div>
+                </span>
             )}
         </h6>
     );

--- a/app/components/common/NFTArt.tsx
+++ b/app/components/common/NFTArt.tsx
@@ -1,9 +1,9 @@
 import type { NftJson } from '@entities/nft';
 import lowContrastSolanalogo from '@img/logos-solana/low-contrast-solana-logo.svg';
 import { PublicKey } from '@solana/web3.js';
-import Link from 'next/link';
 
 import { getProxiedUri } from '@/app/features/metadata/utils';
+import { getSafeExternalUrl } from '@/app/shared/lib/safe-external-url';
 import { isEnvEnabled } from '@/app/utils/env';
 
 import { InfoTooltip } from './InfoTooltip';
@@ -13,19 +13,21 @@ const isDisplayEnabled = isEnvEnabled(process.env.NEXT_PUBLIC_VIEW_ORIGINAL_DISP
 export const MAX_TIME_LOADING_IMAGE = 5000; /* 5 seconds */
 
 const ViewOriginalArtContentLink = ({ src }: { src: string }) => {
-    if (!src) {
+    const safeSrc = getSafeExternalUrl(src);
+
+    if (!safeSrc) {
         return null;
     }
 
     return (
         <h6 className="header-pretitle d-flex mt-2 justify-content-center">
             {!isDisplayEnabled ? null : (
-                <Link href={src} target="_blank" className="d-flex align-items-center">
+                <a href={safeSrc} target="_blank" rel="noopener noreferrer" className="d-flex align-items-center">
                     <div>VIEW ORIGINAL</div>
                     <div className="d-flex">
                         <InfoTooltip right text="Clicking this link will open an external resource" />
                     </div>
-                </Link>
+                </a>
             )}
         </h6>
     );

--- a/app/components/common/__tests__/NFTArt.spec.tsx
+++ b/app/components/common/__tests__/NFTArt.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../InfoTooltip', () => ({
+    InfoTooltip: ({ text }: { text?: string }) => <span>{text}</span>,
+}));
+
+describe('NFTArt', () => {
+    afterEach(() => {
+        vi.resetModules();
+        vi.unstubAllEnvs();
+    });
+
+    it('renders a disabled VIEW ORIGINAL label for unsupported URI schemes', async () => {
+        vi.stubEnv('NEXT_PUBLIC_VIEW_ORIGINAL_DISPLAY_ENABLED', 'true');
+        const { NFTImageContent } = await import('../NFTArt');
+
+        render(<NFTImageContent uri="ipfs://QmTestHash" />);
+
+        expect(screen.getByText('VIEW ORIGINAL')).toBeInTheDocument();
+        expect(screen.getByTestId('view-original-disabled')).toHaveAttribute('aria-disabled', 'true');
+        expect(screen.queryByRole('link', { name: 'VIEW ORIGINAL' })).not.toBeInTheDocument();
+    });
+});

--- a/app/shared/lib/__tests__/safe-external-url.spec.ts
+++ b/app/shared/lib/__tests__/safe-external-url.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeExternalUrl, isSafeExternalUrl } from '../safe-external-url';
+
+describe('safe external URLs', () => {
+    it('accepts trimmed http and https URLs', () => {
+        expect(getSafeExternalUrl(' https://solana.com ')).toBe('https://solana.com');
+        expect(getSafeExternalUrl('http://localhost:3000/test')).toBe('http://localhost:3000/test');
+    });
+
+    it('rejects non-http protocols and malformed values', () => {
+        expect(getSafeExternalUrl('javascript:alert(1)')).toBeNull();
+        expect(getSafeExternalUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==')).toBeNull();
+        expect(getSafeExternalUrl('mailto:security@example.com')).toBeNull();
+        expect(getSafeExternalUrl('/relative/path')).toBeNull();
+        expect(getSafeExternalUrl('')).toBeNull();
+        expect(getSafeExternalUrl(undefined)).toBeNull();
+    });
+
+    it('exposes the same validation via the type guard', () => {
+        expect(isSafeExternalUrl('https://solana.com')).toBe(true);
+        expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+    });
+});

--- a/app/shared/lib/__tests__/safe-external-url.spec.ts
+++ b/app/shared/lib/__tests__/safe-external-url.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { getSafeExternalUrl, isSafeExternalUrl } from '../safe-external-url';
 
 describe('safe external URLs', () => {
-    it('accepts trimmed http and https URLs', () => {
-        expect(getSafeExternalUrl(' https://solana.com ')).toBe('https://solana.com');
+    it('accepts trimmed http and https URLs and returns normalized hrefs', () => {
+        expect(getSafeExternalUrl(' HTTPS://Example.COM/Path ')).toBe('https://example.com/Path');
         expect(getSafeExternalUrl('http://localhost:3000/test')).toBe('http://localhost:3000/test');
     });
 

--- a/app/shared/lib/safe-external-url.ts
+++ b/app/shared/lib/safe-external-url.ts
@@ -1,0 +1,21 @@
+export function getSafeExternalUrl(value: unknown): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return null;
+    }
+
+    try {
+        const url = new URL(trimmedValue);
+        return ['http:', 'https:'].includes(url.protocol) ? trimmedValue : null;
+    } catch {
+        return null;
+    }
+}
+
+export function isSafeExternalUrl(value: unknown): value is string {
+    return getSafeExternalUrl(value) !== null;
+}

--- a/app/shared/lib/safe-external-url.ts
+++ b/app/shared/lib/safe-external-url.ts
@@ -10,7 +10,7 @@ export function getSafeExternalUrl(value: unknown): string | null {
 
     try {
         const url = new URL(trimmedValue);
-        return ['http:', 'https:'].includes(url.protocol) ? trimmedValue : null;
+        return ['http:', 'https:'].includes(url.protocol) ? url.href : null;
     } catch {
         return null;
     }


### PR DESCRIPTION
## Description

Sanitize untrusted external URLs before rendering them as clickable links in account and NFT views.

This change fixes a user-facing security issue where third-party metadata values such as token websites, NFT `external_url`, token metadata URIs, compressed NFT links, validator config websites, and verified-build repository URLs could be rendered directly into `href` attributes. Unsafe or malformed values now render as plain text instead of clickable links.

It also fixes a separate bug in the token mint overview where the "Bridged Asset Contract" row incorrectly linked to the bridge contract URL instead of the asset contract URL.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

N/A — no layout or visual design changes.

## Testing

-   Added unit tests for the shared external URL sanitizer
-   Added regression tests covering:
    - unsafe `javascript:` website values not rendering as clickable links
    - bridged asset contract rows using the correct asset contract URL
-   Ran:
    - `pnpm exec eslint app/shared/lib/safe-external-url.ts app/shared/lib/__tests__/safe-external-url.spec.ts app/components/account/__tests__/TokenAccountSection.spec.tsx app/components/account/TokenAccountSection.tsx app/components/account/CompressedNftCard.tsx app/components/account/ConfigAccountSection.tsx app/components/common/NFTArt.tsx app/components/account/VerifiedBuildCard.tsx`
    - `pnpm exec vitest --project specs run app/shared/lib/__tests__/safe-external-url.spec.ts app/components/account/__tests__/TokenAccountSection.spec.tsx`

## Related Issues

No matching public issue found.
No overlapping open PR found for this fix in the fork or the upstream repository during triage.

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [ ] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

-   This is a defensive hardening change for metadata-driven external links.
-   No protocol-specific behavior was changed beyond preventing unsafe URLs from becoming clickable.
-   Focused local tests passed. Vitest still emits an existing Next.js SWC lockfile warning in the current local environment, but the targeted test run completed successfully.
