### PR TITLE
Try multiple signer seeds when resolving the Otter Verify build-params PDA

### DIFF
--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -42,11 +42,20 @@ export type OsecInfo = {
     is_frozen: boolean;
 };
 
+function parsePublicKey(value: string | undefined): PublicKey | null {
+    if (!value) return null;
+    try {
+        return new PublicKey(value);
+    } catch {
+        return null;
+    }
+}
+
 const TRUSTED_SIGNERS: Record<string, string> = {
     '11111111111111111111111111111111': 'Explorer',
     '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r': 'Foundation',
     '9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU': 'OtterSecurity',
-    CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn: 'Explorer',
+    'CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn': 'Explorer',
 };
 
 export function useVerifiedProgramRegistry({
@@ -172,7 +181,7 @@ export function useVerifiedProgram({
     // Get the first verified entry
     const verifiedData = orderedVerifiedEntries?.find(entry => entry.is_verified);
 
-    return useEnrichedOsecInfo({ options, osecInfo: verifiedData, programId });
+    return useEnrichedOsecInfo({ options, osecInfo: verifiedData, programAuthority, programId });
 }
 
 // Internal method to enrich the osec info with the verify command (requires fetching the on-chain PDA)
@@ -180,15 +189,24 @@ function useEnrichedOsecInfo({
     programId,
     osecInfo,
     options,
+    programAuthority,
 }: {
     programId: PublicKey;
     osecInfo: OsecInfo | undefined;
     options?: { suspense: boolean };
+    programAuthority: PublicKey | null;
 }) {
     const { url: clusterUrl, cluster: cluster } = useCluster();
     const connection = new Connection(clusterUrl);
 
     const { program: accountAnchorProgram } = useAnchorProgram(VERIFY_PROGRAM_ID, connection.rpcEndpoint);
+    const signerAuthorities = Array.from(
+        new Map(
+            [programAuthority, parsePublicKey(osecInfo?.signer), ...Object.keys(TRUSTED_SIGNERS).map(parsePublicKey)]
+                .filter((key): key is PublicKey => key !== null)
+                .map(key => [key.toBase58(), key]),
+        ).values(),
+    );
 
     // Fetch the PDA derived from the program upgrade authority
     const {
@@ -196,27 +214,29 @@ function useEnrichedOsecInfo({
         error: pdaError,
         isLoading: isPdaLoading,
     } = useSWRImmutable(
-        accountAnchorProgram ? `pda-${programId.toBase58()}-${osecInfo?.signer}` : null,
+        accountAnchorProgram && osecInfo && signerAuthorities.length > 0
+            ? `pda-${programId.toBase58()}-${signerAuthorities.map(x => x.toBase58()).join(',')}`
+            : null,
         async () => {
             if (!osecInfo || !accountAnchorProgram) {
                 return null;
             }
 
-            try {
+            for (const pdaSeedAuthority of signerAuthorities) {
                 const [pda] = PublicKey.findProgramAddressSync(
-                    [fromUtf8('otter_verify'), new PublicKey(osecInfo.signer).toBytes(), programId.toBytes()],
+                    [fromUtf8('otter_verify'), pdaSeedAuthority.toBytes(), programId.toBytes()],
                     new PublicKey(VERIFY_PROGRAM_ID),
                 );
-
-                const pdaAccountInfo = await (accountAnchorProgram.account as any).buildParams.fetch(pda);
-                if (!pdaAccountInfo) {
-                    return null;
+                try {
+                    const pdaAccountInfo = await (accountAnchorProgram.account as any).buildParams.fetch(pda);
+                    if (pdaAccountInfo) {
+                        return pdaAccountInfo;
+                    }
+                } catch (error) {
+                    Logger.error(error);
                 }
-                return pdaAccountInfo;
-            } catch (error) {
-                Logger.error(error);
-                return null;
             }
+            return null;
         },
         { suspense: options?.suspense },
     );

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -1,6 +1,7 @@
 import { useAnchorProgram } from '@entities/idl';
 import { sha256 } from '@noble/hashes/sha256';
 import { Connection, PublicKey } from '@solana/web3.js';
+import { useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import { fromBase64, fromUtf8, toHex } from '@/app/shared/lib/bytes';
@@ -9,7 +10,6 @@ import { Logger } from '@/app/shared/lib/logger';
 import { useCluster } from '../providers/cluster';
 import { ProgramDataAccountInfo } from '../validators/accounts/upgradeable-program';
 import { Cluster } from './cluster';
-import { useMemo } from 'react';
 
 const OSEC_REGISTRY_URL = 'https://verify.osec.io';
 const VERIFY_PROGRAM_ID = 'verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC';
@@ -53,10 +53,10 @@ function parsePublicKey(value: string | undefined): PublicKey | null {
 }
 
 const TRUSTED_SIGNERS: Record<string, string> = {
+    '11111111111111111111111111111111': 'Explorer',
     '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r': 'Foundation',
     '9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU': 'OtterSecurity',
     CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn: 'Explorer',
-    '11111111111111111111111111111111': 'Explorer',
 };
 
 export function useVerifiedProgramRegistry({

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -200,12 +200,16 @@ function useEnrichedOsecInfo({
     const connection = new Connection(clusterUrl);
 
     const { program: accountAnchorProgram } = useAnchorProgram(VERIFY_PROGRAM_ID, connection.rpcEndpoint);
-    const signerAuthorities = Array.from(
-        new Map(
-            [programAuthority, parsePublicKey(osecInfo?.signer), ...Object.keys(TRUSTED_SIGNERS).map(parsePublicKey)]
-                .filter((key): key is PublicKey => key !== null)
-                .map(key => [key.toBase58(), key]),
-        ).values(),
+    const signerAuthorities = useMemo(
+        () =>
+            Array.from(
+                new Map(
+                    [programAuthority, parsePublicKey(osecInfo?.signer), ...Object.keys(TRUSTED_SIGNERS).map(parsePublicKey)]
+                        .filter((key): key is PublicKey => key !== null)
+                        .map(key => [key.toBase58(), key]),
+                ).values(),
+            ),
+        [programAuthority, osecInfo?.signer],
     );
 
     // Fetch the PDA derived from the program upgrade authority

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -9,6 +9,7 @@ import { Logger } from '@/app/shared/lib/logger';
 import { useCluster } from '../providers/cluster';
 import { ProgramDataAccountInfo } from '../validators/accounts/upgradeable-program';
 import { Cluster } from './cluster';
+import { useMemo } from 'react';
 
 const OSEC_REGISTRY_URL = 'https://verify.osec.io';
 const VERIFY_PROGRAM_ID = 'verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC';
@@ -54,7 +55,7 @@ function parsePublicKey(value: string | undefined): PublicKey | null {
 const TRUSTED_SIGNERS: Record<string, string> = {
     '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r': 'Foundation',
     '9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU': 'OtterSecurity',
-    'CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn': 'Explorer',
+    CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn: 'Explorer',
     '11111111111111111111111111111111': 'Explorer',
 };
 
@@ -204,7 +205,11 @@ function useEnrichedOsecInfo({
         () =>
             Array.from(
                 new Map(
-                    [programAuthority, parsePublicKey(osecInfo?.signer), ...Object.keys(TRUSTED_SIGNERS).map(parsePublicKey)]
+                    [
+                        programAuthority,
+                        parsePublicKey(osecInfo?.signer),
+                        ...Object.keys(TRUSTED_SIGNERS).map(parsePublicKey),
+                    ]
                         .filter((key): key is PublicKey => key !== null)
                         .map(key => [key.toBase58(), key]),
                 ).values(),
@@ -238,7 +243,9 @@ function useEnrichedOsecInfo({
                     }
                 } catch (error: unknown) {
                     // Expected: most signer candidates won't have a matching PDA
-                    Logger.debug(error);
+                    Logger.debug('[utils:verified-builds] No matching PDA for signer candidate', {
+                        error,
+                    });
                 }
             }
             return null;

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -52,10 +52,10 @@ function parsePublicKey(value: string | undefined): PublicKey | null {
 }
 
 const TRUSTED_SIGNERS: Record<string, string> = {
-    '11111111111111111111111111111111': 'Explorer',
     '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r': 'Foundation',
     '9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU': 'OtterSecurity',
     'CyJj5ejJAUveDXnLduJbkvwjxcmWJNqCuB9DR7AExrHn': 'Explorer',
+    '11111111111111111111111111111111': 'Explorer',
 };
 
 export function useVerifiedProgramRegistry({

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -232,8 +232,9 @@ function useEnrichedOsecInfo({
                     if (pdaAccountInfo) {
                         return pdaAccountInfo;
                     }
-                } catch (error) {
-                    Logger.error(error);
+                } catch (error: unknown) {
+                    // Expected: most signer candidates won't have a matching PDA
+                    Logger.debug(error);
                 }
             }
             return null;


### PR DESCRIPTION
## Description

We were only trying one pubkey to derive the Otter Verify PDA. That works only when it matches whoever actually uploaded the build on-chain. In practice, Signer can be a placeholder (111…), or the PDA might have been created under a trusted uploader key that isn’t the program’s current upgrade authority, so we’d miss the account even when it exists.

This change passes the program upgrade authority into enrichment and tries a small list: authority first, then the registry signer if it’s valid, then the known trusted keys. We walk that list, derive the PDA for each, and use the first buildParams fetch that succeeds, closer to how solana-verify scans for a program’s PDAs.

Should fix Verified Build showing “not yet uploaded” when on-chain data is actually there.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

