### PR TITLE
feat: Changing pre-filled value for interact tab

### DIFF
--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
@@ -65,8 +65,6 @@ const INSTRUCTION_WITH_TWO_SIGNERS: InstructionData = {
     name: 'testInstruction',
 };
 
-const makeRef = (val?: string): { current: string | undefined } => ({ current: val });
-
 describe('createWalletPrefillDependency', () => {
     it('should fill signer accounts with wallet address', () => {
         const { result } = renderHook(() =>
@@ -78,13 +76,9 @@ describe('createWalletPrefillDependency', () => {
         const { form, fieldNames } = result.current;
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_SIGNER_AND_NON_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER_AND_NON_SIGNER, null, {
+            account: fieldNames.account,
+        });
 
         const walletAddress = walletPublicKey.toBase58();
         dependency.onValueChange(walletPublicKey, form);
@@ -102,13 +96,9 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
+            account: fieldNames.account,
+        });
 
         const setValueSpy = vi.spyOn(form, 'setValue');
         dependency.onValueChange(null, form);
@@ -126,13 +116,9 @@ describe('createWalletPrefillDependency', () => {
         const { form, fieldNames } = result.current;
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_NESTED_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_NESTED_SIGNER, null, {
+            account: fieldNames.account,
+        });
 
         const walletAddress = walletPublicKey.toBase58();
         dependency.onValueChange(walletPublicKey, form);
@@ -149,13 +135,9 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
+            account: fieldNames.account,
+        });
 
         const setValueSpy = vi.spyOn(form, 'setValue');
         dependency.onValueChange('not-a-public-key', form);
@@ -165,7 +147,7 @@ describe('createWalletPrefillDependency', () => {
         expect(setValueSpy).not.toHaveBeenCalled();
     });
 
-    it('should not overwrite existing values', () => {
+    it('should not overwrite user-typed values', () => {
         const { result } = renderHook(() =>
             useInstructionForm({
                 instruction: INSTRUCTION_WITH_SIGNER,
@@ -174,16 +156,12 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        form.setValue('accounts.testInstruction.signer', PREFILLED_ADDRESS);
+        form.setValue('accounts.testInstruction.signer', PREFILLED_ADDRESS, { shouldDirty: true });
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
+            account: fieldNames.account,
+        });
 
         dependency.onValueChange(walletPublicKey, form);
 
@@ -202,22 +180,17 @@ describe('createWalletPrefillDependency', () => {
         const walletAAddress = Keypair.generate().publicKey.toBase58();
         const walletB = Keypair.generate().publicKey;
 
-        form.setValue('accounts.testInstruction.signer', walletAAddress);
-        const ref = makeRef(walletAAddress);
+        form.setValue('accounts.testInstruction.signer', walletAAddress, { shouldDirty: false });
 
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_SIGNER,
-            {
-                account: fieldNames.account,
-            },
-            ref,
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
+            account: fieldNames.account,
+        });
         dependency.onValueChange(walletB, form);
 
         expect(form.getValues('accounts.testInstruction.signer')).toBe(walletB.toBase58());
     });
 
-    it('should fill only empty signer fields when some are already filled', () => {
+    it('should fill only non-dirty signer fields when some are already user-typed', () => {
         const { result } = renderHook(() =>
             useInstructionForm({
                 instruction: INSTRUCTION_WITH_TWO_SIGNERS,
@@ -226,17 +199,14 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        form.setValue('accounts.testInstruction.signer1', PREFILLED_ADDRESS);
+        // Simulate user typing into signer1
+        form.setValue('accounts.testInstruction.signer1', PREFILLED_ADDRESS, { shouldDirty: true });
 
         const walletPublicKey = PublicKey.default;
         const walletAddress = walletPublicKey.toBase58();
-        const dependency = createWalletPrefillDependency(
-            INSTRUCTION_WITH_TWO_SIGNERS,
-            {
-                account: fieldNames.account,
-            },
-            makeRef(),
-        );
+        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_TWO_SIGNERS, null, {
+            account: fieldNames.account,
+        });
 
         dependency.onValueChange(walletPublicKey, form);
 

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
@@ -65,6 +65,13 @@ const INSTRUCTION_WITH_TWO_SIGNERS: InstructionData = {
     name: 'testInstruction',
 };
 
+const EMPTY_INSTRUCTION: InstructionData = {
+    accounts: [],
+    args: [],
+    docs: [],
+    name: 'testInstruction',
+};
+
 describe('createWalletPrefillDependency', () => {
     it('should fill signer accounts with wallet address', () => {
         const { result } = renderHook(() =>
@@ -124,6 +131,45 @@ describe('createWalletPrefillDependency', () => {
         dependency.onValueChange(walletPublicKey, form);
 
         expect(form.getValues('accounts.testInstruction.group.nestedSigner')).toBe(walletAddress);
+    });
+
+    it('should return correct dependency id and getValue', () => {
+        const walletPublicKey = PublicKey.default;
+        const dependency = createWalletPrefillDependency(EMPTY_INSTRUCTION, walletPublicKey, {
+            account: () => 'accounts.testInstruction.test' as any,
+        });
+
+        expect(dependency.id).toBe('wallet');
+        expect(dependency.getValue()).toBe(walletPublicKey);
+    });
+
+    it('should update signer fields when wallet changes', () => {
+        const { result } = renderHook(() =>
+            useInstructionForm({
+                instruction: INSTRUCTION_WITH_SIGNER,
+                onSubmit: vi.fn(),
+            }),
+        );
+        const { form, fieldNames } = result.current;
+
+        const walletA = Keypair.generate().publicKey;
+        const walletB = Keypair.generate().publicKey;
+
+        // Simulate wallet connecting: create dependency with walletA, trigger fill
+        const depA = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, walletA, {
+            account: fieldNames.account,
+        });
+        expect(depA.getValue()).toBe(walletA);
+        depA.onValueChange(depA.getValue(), form);
+        expect(form.getValues('accounts.testInstruction.signer')).toBe(walletA.toBase58());
+
+        // Simulate wallet change: new dependency with walletB, field was not dirty so it updates
+        const depB = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, walletB, {
+            account: fieldNames.account,
+        });
+        expect(depB.getValue()).toBe(walletB);
+        depB.onValueChange(depB.getValue(), form);
+        expect(form.getValues('accounts.testInstruction.signer')).toBe(walletB.toBase58());
     });
 
     it('should ignore non-PublicKey values in onValueChange', () => {

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
@@ -190,6 +190,33 @@ describe('createWalletPrefillDependency', () => {
         expect(form.getValues('accounts.testInstruction.signer')).toBe(PREFILLED_ADDRESS);
     });
 
+    it('should overwrite a signer field that still contains the previous wallet address', () => {
+        const { result } = renderHook(() =>
+            useInstructionForm({
+                instruction: INSTRUCTION_WITH_SIGNER,
+                onSubmit: vi.fn(),
+            }),
+        );
+        const { form, fieldNames } = result.current;
+
+        const walletAAddress = Keypair.generate().publicKey.toBase58();
+        const walletB = Keypair.generate().publicKey;
+
+        form.setValue('accounts.testInstruction.signer', walletAAddress);
+        const ref = makeRef(walletAAddress);
+
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            ref,
+        );
+        dependency.onValueChange(walletB, form);
+
+        expect(form.getValues('accounts.testInstruction.signer')).toBe(walletB.toBase58());
+    });
+
     it('should fill only empty signer fields when some are already filled', () => {
         const { result } = renderHook(() =>
             useInstructionForm({

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/wallet-prefill-provider.spec.ts
@@ -65,12 +65,7 @@ const INSTRUCTION_WITH_TWO_SIGNERS: InstructionData = {
     name: 'testInstruction',
 };
 
-const EMPTY_INSTRUCTION: InstructionData = {
-    accounts: [],
-    args: [],
-    docs: [],
-    name: 'testInstruction',
-};
+const makeRef = (val?: string): { current: string | undefined } => ({ current: val });
 
 describe('createWalletPrefillDependency', () => {
     it('should fill signer accounts with wallet address', () => {
@@ -83,9 +78,13 @@ describe('createWalletPrefillDependency', () => {
         const { form, fieldNames } = result.current;
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER_AND_NON_SIGNER, walletPublicKey, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_SIGNER_AND_NON_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         const walletAddress = walletPublicKey.toBase58();
         dependency.onValueChange(walletPublicKey, form);
@@ -103,9 +102,13 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         const setValueSpy = vi.spyOn(form, 'setValue');
         dependency.onValueChange(null, form);
@@ -123,24 +126,18 @@ describe('createWalletPrefillDependency', () => {
         const { form, fieldNames } = result.current;
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_NESTED_SIGNER, walletPublicKey, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_NESTED_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         const walletAddress = walletPublicKey.toBase58();
         dependency.onValueChange(walletPublicKey, form);
 
         expect(form.getValues('accounts.testInstruction.group.nestedSigner')).toBe(walletAddress);
-    });
-
-    it('should return correct dependency id and getValue', () => {
-        const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(EMPTY_INSTRUCTION, walletPublicKey, {
-            account: () => 'accounts.testInstruction.test' as any,
-        });
-
-        expect(dependency.id).toBe('wallet');
-        expect(dependency.getValue()).toBe(walletPublicKey);
     });
 
     it('should ignore non-PublicKey values in onValueChange', () => {
@@ -152,9 +149,13 @@ describe('createWalletPrefillDependency', () => {
         );
         const { form, fieldNames } = result.current;
 
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, null, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         const setValueSpy = vi.spyOn(form, 'setValue');
         dependency.onValueChange('not-a-public-key', form);
@@ -176,9 +177,13 @@ describe('createWalletPrefillDependency', () => {
         form.setValue('accounts.testInstruction.signer', PREFILLED_ADDRESS);
 
         const walletPublicKey = PublicKey.default;
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_SIGNER, walletPublicKey, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_SIGNER,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         dependency.onValueChange(walletPublicKey, form);
 
@@ -198,9 +203,13 @@ describe('createWalletPrefillDependency', () => {
 
         const walletPublicKey = PublicKey.default;
         const walletAddress = walletPublicKey.toBase58();
-        const dependency = createWalletPrefillDependency(INSTRUCTION_WITH_TWO_SIGNERS, walletPublicKey, {
-            account: fieldNames.account,
-        });
+        const dependency = createWalletPrefillDependency(
+            INSTRUCTION_WITH_TWO_SIGNERS,
+            {
+                account: fieldNames.account,
+            },
+            makeRef(),
+        );
 
         dependency.onValueChange(walletPublicKey, form);
 

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/wallet-prefill-provider.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/wallet-prefill-provider.ts
@@ -1,10 +1,10 @@
 import type { InstructionData } from '@entities/idl';
 import { PublicKey } from '@solana/web3.js';
-import type { MutableRefObject } from 'react';
-import type { FieldPath, UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 
 import type { FormValue, InstructionFormData, InstructionFormFieldNames } from '../../use-instruction-form';
 import { isPrefilledAccount, WALLET_ACCOUNT_PATTERNS } from '../const';
+import type { ExternalDependency } from '../types';
 import { traverseInstructionAccounts } from './traverse-accounts';
 
 /**
@@ -13,10 +13,10 @@ import { traverseInstructionAccounts } from './traverse-accounts';
  */
 export function createWalletPrefillDependency(
     instruction: InstructionData,
+    publicKey: PublicKey | null,
     fieldNames: Pick<InstructionFormFieldNames, 'account'>,
-    lastPrefillAddressRef: MutableRefObject<string | undefined>,
-): { onValueChange: (value: unknown, form: UseFormReturn<InstructionFormData>) => void } {
-    const signerPaths: FieldPath<InstructionFormData>[] = [];
+): ExternalDependency<PublicKey> {
+    const signerPaths: ReturnType<InstructionFormFieldNames['account']>[] = [];
 
     traverseInstructionAccounts(instruction, (account, parentGroup) => {
         // Skip accounts that have known addresses (e.g., system program, token program)
@@ -43,26 +43,20 @@ export function createWalletPrefillDependency(
     });
 
     return {
+        getValue: () => publicKey,
+        id: 'wallet',
         onValueChange: (value: unknown, form: UseFormReturn<InstructionFormData>) => {
             if (!value || !(value instanceof PublicKey)) return;
 
             const walletAddress = value.toBase58();
-            const lastPrefillAddress = lastPrefillAddressRef.current;
 
             for (const path of signerPaths) {
-                const currentValue = String(form.getValues(path) ?? '').trim();
-                const isEmpty = currentValue === '';
-                const hasPreviousWallet = lastPrefillAddress !== undefined && currentValue === lastPrefillAddress;
-
-                if (isEmpty || hasPreviousWallet) {
-                    form.setValue(path, walletAddress as unknown as FormValue, {
-                        shouldDirty: false,
-                        shouldValidate: false,
-                    });
-                }
+                if (form.getFieldState(path).isDirty) continue;
+                form.setValue(path, walletAddress as unknown as FormValue, {
+                    shouldDirty: false,
+                    shouldValidate: false,
+                });
             }
-
-            lastPrefillAddressRef.current = walletAddress;
         },
     };
 }

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/wallet-prefill-provider.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/wallet-prefill-provider.ts
@@ -1,10 +1,10 @@
 import type { InstructionData } from '@entities/idl';
 import { PublicKey } from '@solana/web3.js';
+import type { MutableRefObject } from 'react';
 import type { FieldPath, UseFormReturn } from 'react-hook-form';
 
 import type { FormValue, InstructionFormData, InstructionFormFieldNames } from '../../use-instruction-form';
 import { isPrefilledAccount, WALLET_ACCOUNT_PATTERNS } from '../const';
-import type { ExternalDependency } from '../types';
 import { traverseInstructionAccounts } from './traverse-accounts';
 
 /**
@@ -13,9 +13,9 @@ import { traverseInstructionAccounts } from './traverse-accounts';
  */
 export function createWalletPrefillDependency(
     instruction: InstructionData,
-    publicKey: PublicKey | null,
     fieldNames: Pick<InstructionFormFieldNames, 'account'>,
-): ExternalDependency<PublicKey> {
+    lastPrefillAddressRef: MutableRefObject<string | undefined>,
+): { onValueChange: (value: unknown, form: UseFormReturn<InstructionFormData>) => void } {
     const signerPaths: FieldPath<InstructionFormData>[] = [];
 
     traverseInstructionAccounts(instruction, (account, parentGroup) => {
@@ -43,22 +43,26 @@ export function createWalletPrefillDependency(
     });
 
     return {
-        getValue: () => publicKey,
-        id: 'wallet',
         onValueChange: (value: unknown, form: UseFormReturn<InstructionFormData>) => {
             if (!value || !(value instanceof PublicKey)) return;
 
             const walletAddress = value.toBase58();
+            const lastPrefillAddress = lastPrefillAddressRef.current;
 
             for (const path of signerPaths) {
-                const currentValue = form.getValues(path);
-                if (!currentValue || String(currentValue).trim() === '') {
+                const currentValue = String(form.getValues(path) ?? '').trim();
+                const isEmpty = currentValue === '';
+                const hasPreviousWallet = lastPrefillAddress !== undefined && currentValue === lastPrefillAddress;
+
+                if (isEmpty || hasPreviousWallet) {
                     form.setValue(path, walletAddress as unknown as FormValue, {
                         shouldDirty: false,
                         shouldValidate: false,
                     });
                 }
             }
+
+            lastPrefillAddressRef.current = walletAddress;
         },
     };
 }

--- a/app/features/idl/interactive-idl/ui/InteractInstruction.tsx
+++ b/app/features/idl/interactive-idl/ui/InteractInstruction.tsx
@@ -8,6 +8,7 @@ import { Button } from '@shared/ui/button';
 import { Card } from '@shared/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/ui/tooltip';
 import { useWallet } from '@solana/wallet-adapter-react';
+import { useEffect, useRef } from 'react';
 import { Loader, Send } from 'react-feather';
 import { Control, Controller, FieldPath } from 'react-hook-form';
 
@@ -50,12 +51,18 @@ export function InteractInstruction({
     const pdas = usePdas({ form, idl, instruction });
     const getAutocompleteItems = createGetAutocompleteItems({ pdas, publicKey });
 
-    const walletPrefillDependency = createWalletPrefillDependency(instruction, publicKey, fieldNames);
+    const lastPrefillAddressRef = useRef<string | undefined>(undefined);
+    useEffect(() => {
+        createWalletPrefillDependency(instruction, fieldNames, lastPrefillAddressRef).onValueChange(publicKey, form);
+        // instruction and fieldNames are stable for the lifetime of this component instance
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [publicKey, form]);
+
     const knownAccountsPrefillDependency = createKnownAccountsPrefillDependency(instruction, fieldNames);
     const pdaPrefillDependency = createPdaPrefillDependency(idl, instruction, fieldNames);
     useFormPrefill({
         config: {
-            externalDependencies: [walletPrefillDependency, knownAccountsPrefillDependency, pdaPrefillDependency],
+            externalDependencies: [knownAccountsPrefillDependency, pdaPrefillDependency],
         },
         form,
     });

--- a/app/features/idl/interactive-idl/ui/InteractInstruction.tsx
+++ b/app/features/idl/interactive-idl/ui/InteractInstruction.tsx
@@ -8,7 +8,6 @@ import { Button } from '@shared/ui/button';
 import { Card } from '@shared/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/ui/tooltip';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { useEffect, useRef } from 'react';
 import { Loader, Send } from 'react-feather';
 import { Control, Controller, FieldPath } from 'react-hook-form';
 
@@ -51,18 +50,12 @@ export function InteractInstruction({
     const pdas = usePdas({ form, idl, instruction });
     const getAutocompleteItems = createGetAutocompleteItems({ pdas, publicKey });
 
-    const lastPrefillAddressRef = useRef<string | undefined>(undefined);
-    useEffect(() => {
-        createWalletPrefillDependency(instruction, fieldNames, lastPrefillAddressRef).onValueChange(publicKey, form);
-        // instruction and fieldNames are stable for the lifetime of this component instance
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [publicKey, form]);
-
+    const walletPrefillDependency = createWalletPrefillDependency(instruction, publicKey, fieldNames);
     const knownAccountsPrefillDependency = createKnownAccountsPrefillDependency(instruction, fieldNames);
     const pdaPrefillDependency = createPdaPrefillDependency(idl, instruction, fieldNames);
     useFormPrefill({
         config: {
-            externalDependencies: [knownAccountsPrefillDependency, pdaPrefillDependency],
+            externalDependencies: [walletPrefillDependency, knownAccountsPrefillDependency, pdaPrefillDependency],
         },
         form,
     });

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -18,7 +18,7 @@
 | Dynamic | `/address/[address]/idl` | 130 kB | 1.27 MB |
 | Dynamic | `/address/[address]/instructions` | 10 kB | 1.13 MB |
 | Dynamic | `/address/[address]/metadata` | 10 kB | 1.03 MB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 10 kB | 1.10 MB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 10 kB | 1.08 MB |
 | Dynamic | `/address/[address]/program-multisig` | 10 kB | 1.08 MB |
 | Dynamic | `/address/[address]/rewards` | 10 kB | 1.02 MB |
 | Dynamic | `/address/[address]/security` | 10 kB | 1.08 MB |


### PR DESCRIPTION
## Description
- updating wallet id value for fields in interact tab 

## Type of change
-   [x] New feature

## Screenshots
https://github.com/user-attachments/assets/878bc5a9-5689-4f5c-8a62-ac8959d07e7e

## Testing
1. open [program](https://explorer-git-fork-hoodieshq-feat-prefi-0580d7-solana-foundation.vercel.app/address/whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc/idl) 
2. go to interact tab
3. connect 2 wallet account
4. change them and see how values are changing

## Related Issues
[HOO-263](https://linear.app/solana-fndn/issue/HOO-263/update-interact-idl-prefilled-wallet-when-connection-changes)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
