### PR TITLE
fix: stabilize bluprynt verification under RPC timeouts

### DIFF
--- a/app/api/verification/bluprynt/[mintAddress]/route.ts
+++ b/app/api/verification/bluprynt/[mintAddress]/route.ts
@@ -5,9 +5,9 @@ import { SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS as SAS_PROGRAM_ID } from 'sa
 
 import { Logger } from '@/app/shared/lib/logger';
 
-import { CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { CACHE_HEADERS, ERROR_CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
 
-const RPC_TIMEOUT_MS = 5_000;
+const RPC_TIMEOUT_MS = 15_000;
 
 type Params = {
     params: {
@@ -57,14 +57,14 @@ export async function GET(_request: Request, { params: { mintAddress } }: Params
             Logger.warn('[api:bluprynt] RPC request timed out', { mintAddress, sentry: true });
             return NextResponse.json(
                 { error: 'Verification request timed out' },
-                { headers: NO_STORE_HEADERS, status: 504 },
+                { headers: ERROR_CACHE_HEADERS, status: 504 },
             );
         }
 
         Logger.panic(error instanceof Error ? error : new Error('Failed to verify bluprynt data'));
         return NextResponse.json(
             { error: 'Failed to verify bluprynt data' },
-            { headers: NO_STORE_HEADERS, status: 500 },
+            { headers: ERROR_CACHE_HEADERS, status: 500 },
         );
     }
 }

--- a/app/api/verification/bluprynt/__tests__/route.test.ts
+++ b/app/api/verification/bluprynt/__tests__/route.test.ts
@@ -60,23 +60,25 @@ describe('Bluprynt API Route', () => {
         expect(await response.json()).toEqual({ verified: false });
     });
 
-    it('should return 504 when RPC request times out', async () => {
+    it('should return 504 with short negative cache when RPC request times out', async () => {
         const timeoutError = new DOMException('Signal timed out.', 'TimeoutError');
         mockGetProgramAccounts.mockRejectedValueOnce(timeoutError);
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(504);
         expect(await response.json()).toEqual({ error: 'Verification request timed out' });
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, s-maxage=30');
         expect(Logger.warn).toHaveBeenCalledWith('[api:bluprynt] RPC request timed out', {
             mintAddress: VALID_MINT,
             sentry: true,
         });
     });
 
-    it('should return 500 when RPC throws a non-timeout error', async () => {
+    it('should return 500 with short negative cache when RPC throws a non-timeout error', async () => {
         mockGetProgramAccounts.mockRejectedValueOnce(new Error('Connection refused'));
         const response = await callRoute(VALID_MINT);
         expect(response.status).toBe(500);
         expect(await response.json()).toEqual({ error: 'Failed to verify bluprynt data' });
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, s-maxage=30');
         expect(Logger.panic).toHaveBeenCalled();
     });
 });

--- a/app/api/verification/config.ts
+++ b/app/api/verification/config.ts
@@ -1,5 +1,14 @@
 export const CACHE_MAX_AGE = 14400;
+export const ERROR_CACHE_MAX_AGE = 30;
+
 export const CACHE_HEADERS = {
     'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}, stale-while-revalidate=3600`,
 };
 export const NO_STORE_HEADERS = { 'Cache-Control': 'no-store, max-age=0' };
+
+// Short negative cache for upstream/transient failures. Keeps one origin hit
+// from fanning out into a stampede when a popular mint's verification fails.
+// Not for misconfig or invalid input — those should recover instantly.
+export const ERROR_CACHE_HEADERS = {
+    'Cache-Control': `public, max-age=${ERROR_CACHE_MAX_AGE}, s-maxage=${ERROR_CACHE_MAX_AGE}`,
+};


### PR DESCRIPTION
## Description
  - Raise bluprynt verification RPC timeout from 5s → 15s; `getProgramAccounts` is routinely slower than 5s in prod, causing `[api:bluprynt] RPC request timed out` Sentry noise.                                              
  - Add `ERROR_CACHE_HEADERS` (30s public/shared cache) for transient 504/500 responses, preventing request stampedes on popular mints when the RPC hiccups.
  - Keep misconfig and invalid-input responses as `no-store` so they recover immediately after a config push. 

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix


## Testing                                                            
  - [x] Hit `/api/verification/bluprynt/<known-verified-mint>` in staging; confirm 200 + long `Cache-Control` on success.
  - [x] Simulate a slow/broken RPC (e.g. bogus `MAINNET_RPC_URL`) and verify `curl -I` shows `Cache-Control: public, max-age=30, s-maxage=30` on the 504 response.                                                             
  - [ ] Monitor Sentry after deploy: `[api:bluprynt] RPC request timed out` warnings should drop.

## Related Issues

Closes [HOO-440](https://linear.app/solana-fndn/issue/HOO-440/bluprynt-timeout-issue)
## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
