### PR TITLE
chore: forbid `!` non-null assertions across the project

### DIFF
--- a/.storybook/__mocks__/MockAccountsProvider.tsx
+++ b/.storybook/__mocks__/MockAccountsProvider.tsx
@@ -4,11 +4,13 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import React from 'react';
 
 import { FetchStatus } from '@/app/providers/cache';
+import { assert } from '@/app/shared/lib/assert';
 import { MAINNET_BETA_URL } from '@/app/utils/cluster';
 import { LOADER_IDS } from '@/app/utils/programs';
 
 // BPF Loader 2 program ID - using key from LOADER_IDS
-const BPF_LOADER_2_KEY = Object.keys(LOADER_IDS).find(key => LOADER_IDS[key] === 'BPF Loader 2')!;
+const BPF_LOADER_2_KEY = Object.keys(LOADER_IDS).find(key => LOADER_IDS[key] === 'BPF Loader 2');
+assert(BPF_LOADER_2_KEY, 'BPF Loader 2 program ID not found in LOADER_IDS');
 const BPF_LOADER_2 = new PublicKey(BPF_LOADER_2_KEY);
 
 // Mock account data for programs

--- a/.storybook/__mocks__/MockAccountsProvider.tsx
+++ b/.storybook/__mocks__/MockAccountsProvider.tsx
@@ -4,13 +4,13 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import React from 'react';
 
 import { FetchStatus } from '@/app/providers/cache';
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 import { MAINNET_BETA_URL } from '@/app/utils/cluster';
 import { LOADER_IDS } from '@/app/utils/programs';
 
 // BPF Loader 2 program ID - using key from LOADER_IDS
 const BPF_LOADER_2_KEY = Object.keys(LOADER_IDS).find(key => LOADER_IDS[key] === 'BPF Loader 2');
-assert(BPF_LOADER_2_KEY, 'BPF Loader 2 program ID not found in LOADER_IDS');
+invariant(BPF_LOADER_2_KEY, 'BPF Loader 2 program ID not found in LOADER_IDS');
 const BPF_LOADER_2 = new PublicKey(BPF_LOADER_2_KEY);
 
 // Mock account data for programs

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -48,7 +48,7 @@ import { ExternalLink } from 'react-feather';
 import { create } from 'superstruct';
 import useSWR from 'swr';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 import { Logger } from '@/app/shared/lib/logger';
 import { FullLegacyTokenInfo, getTokenInfo, getTokenInfoSwrKey } from '@/app/utils/token-info';
 
@@ -92,7 +92,7 @@ export function TokenAccountSection({
 
                 const parsedData = account.data.parsed;
                 if (isMetaplexNFT(parsedData, mintInfo)) {
-                    assert(parsedData.nftData, 'isMetaplexNFT returned true but nftData is missing');
+                    invariant(parsedData.nftData, 'isMetaplexNFT returned true but nftData is missing');
                     return (
                         <NonFungibleTokenMintAccountCard
                             account={account}

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -5,7 +5,7 @@ import { useRefreshAccount } from '@entities/account';
 import { isMetaplexNFT } from '@entities/nft';
 import { AccountCard } from '@features/account';
 import { isSome } from '@metaplex-foundation/umi';
-import { Account, NFTData, TokenProgramData } from '@providers/accounts';
+import { Account, NFTData } from '@providers/accounts';
 import { TOKEN_2022_PROGRAM_ID, useScaledUiAmountForMint } from '@providers/accounts/tokens';
 import { useCluster } from '@providers/cluster';
 import { PublicKey } from '@solana/web3.js';
@@ -48,6 +48,7 @@ import { ExternalLink } from 'react-feather';
 import { create } from 'superstruct';
 import useSWR from 'swr';
 
+import { assert } from '@/app/shared/lib/assert';
 import { Logger } from '@/app/shared/lib/logger';
 import { FullLegacyTokenInfo, getTokenInfo, getTokenInfoSwrKey } from '@/app/utils/token-info';
 
@@ -89,11 +90,13 @@ export function TokenAccountSection({
             case 'mint': {
                 const mintInfo = create(tokenAccount.info, MintAccountInfo);
 
-                if (isMetaplexNFT(account.data.parsed, mintInfo)) {
+                const parsedData = account.data.parsed;
+                if (isMetaplexNFT(parsedData, mintInfo)) {
+                    assert(parsedData.nftData, 'isMetaplexNFT returned true but nftData is missing');
                     return (
                         <NonFungibleTokenMintAccountCard
                             account={account}
-                            nftData={(account.data.parsed as TokenProgramData).nftData!}
+                            nftData={parsedData.nftData}
                             mintInfo={mintInfo}
                         />
                     );

--- a/app/components/account/nftoken/__tests__/isNFTokenAccount-test.ts
+++ b/app/components/account/nftoken/__tests__/isNFTokenAccount-test.ts
@@ -2,7 +2,7 @@ import { parseNFTokenNFTAccount } from '@components/account/nftoken/isNFTokenAcc
 import { NFTOKEN_ADDRESS } from '@components/account/nftoken/nftoken';
 import { PublicKey } from '@solana/web3.js';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 describe('parseNFTokenAccounts', () => {
     it('parses an NFT', () => {
@@ -26,7 +26,7 @@ describe('parseNFTokenAccounts', () => {
             pubkey: new PublicKey('FagABcRBhZH27JDtu6A1Jo9woXyoznP28QujLkxkN9Hj'),
             space: buffer.length,
         });
-        assert(nftAccount, 'expected parseNFTokenNFTAccount to return an NFT account');
+        invariant(nftAccount, 'expected parseNFTokenNFTAccount to return an NFT account');
         expect(nftAccount.metadata_url).toBe('https://cdn.glow.app/n/88/78ef17c1-2b5a-468e-ae8f-7403856e9f00.json');
     });
 });

--- a/app/components/account/nftoken/__tests__/isNFTokenAccount-test.ts
+++ b/app/components/account/nftoken/__tests__/isNFTokenAccount-test.ts
@@ -2,6 +2,8 @@ import { parseNFTokenNFTAccount } from '@components/account/nftoken/isNFTokenAcc
 import { NFTOKEN_ADDRESS } from '@components/account/nftoken/nftoken';
 import { PublicKey } from '@solana/web3.js';
 
+import { assert } from '@/app/shared/lib/assert';
+
 describe('parseNFTokenAccounts', () => {
     it('parses an NFT', () => {
         const buffer = new Uint8Array([
@@ -24,6 +26,7 @@ describe('parseNFTokenAccounts', () => {
             pubkey: new PublicKey('FagABcRBhZH27JDtu6A1Jo9woXyoznP28QujLkxkN9Hj'),
             space: buffer.length,
         });
-        expect(nftAccount!.metadata_url).toBe('https://cdn.glow.app/n/88/78ef17c1-2b5a-468e-ae8f-7403856e9f00.json');
+        assert(nftAccount, 'expected parseNFTokenNFTAccount to return an NFT account');
+        expect(nftAccount.metadata_url).toBe('https://cdn.glow.app/n/88/78ef17c1-2b5a-468e-ae8f-7403856e9f00.json');
     });
 });

--- a/app/components/account/nftoken/isNFTokenAccount.ts
+++ b/app/components/account/nftoken/isNFTokenAccount.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 
-import { assert } from '@/app/shared/lib/assert';
 import { toBase64 } from '@/app/shared/lib/bytes';
+import { invariant } from '@/app/shared/lib/invariant';
 import { Logger } from '@/app/shared/lib/logger';
 
 import { Account } from '../../../providers/accounts';
@@ -20,7 +20,7 @@ export const parseNFTokenNFTAccount = (account: Account): NftokenTypes.NftAccoun
     }
 
     try {
-        assert(account.data.raw, 'isNFTokenAccount guarantees raw account data');
+        invariant(account.data.raw, 'isNFTokenAccount guarantees raw account data');
         const parsed = NftokenTypes.nftAccountLayout.decode(account.data.raw);
 
         if (!parsed) {
@@ -56,7 +56,7 @@ export const parseNFTokenCollectionAccount = (account: Account): NftokenTypes.Co
     }
 
     try {
-        assert(account.data.raw, 'isNFTokenAccount guarantees raw account data');
+        invariant(account.data.raw, 'isNFTokenAccount guarantees raw account data');
         const parsed = NftokenTypes.collectionAccountLayout.decode(account.data.raw);
 
         if (!parsed) {

--- a/app/components/account/nftoken/isNFTokenAccount.ts
+++ b/app/components/account/nftoken/isNFTokenAccount.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 
+import { assert } from '@/app/shared/lib/assert';
 import { toBase64 } from '@/app/shared/lib/bytes';
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -19,13 +20,14 @@ export const parseNFTokenNFTAccount = (account: Account): NftokenTypes.NftAccoun
     }
 
     try {
-        const parsed = NftokenTypes.nftAccountLayout.decode(account.data.raw!);
+        assert(account.data.raw, 'isNFTokenAccount guarantees raw account data');
+        const parsed = NftokenTypes.nftAccountLayout.decode(account.data.raw);
 
         if (!parsed) {
             return null;
         }
 
-        if (toBase64(new Uint8Array(parsed!.discriminator)) !== nftokenAccountDisc) {
+        if (toBase64(new Uint8Array(parsed.discriminator)) !== nftokenAccountDisc) {
             return null;
         }
 
@@ -54,7 +56,8 @@ export const parseNFTokenCollectionAccount = (account: Account): NftokenTypes.Co
     }
 
     try {
-        const parsed = NftokenTypes.collectionAccountLayout.decode(account.data.raw!);
+        assert(account.data.raw, 'isNFTokenAccount guarantees raw account data');
+        const parsed = NftokenTypes.collectionAccountLayout.decode(account.data.raw);
 
         if (!parsed) {
             return null;

--- a/app/components/account/nftoken/nftoken-hooks.tsx
+++ b/app/components/account/nftoken/nftoken-hooks.tsx
@@ -1,7 +1,7 @@
 import { useCluster } from '@providers/cluster';
 import useSWR, { SWRResponse } from 'swr';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { NftokenFetcher } from './nftoken';
 import { NftokenTypes } from './nftoken-types';
@@ -30,7 +30,7 @@ export const useCollectionNfts = ({
     const { data, error, mutate } = useSWR(swrKey, getCollectionNftsFetcher, {
         suspense: true,
     });
-    assert(data, 'SWR suspense guarantees data is non-null');
+    invariant(data, 'SWR suspense guarantees data is non-null');
     return { data, error, mutate };
 };
 
@@ -49,6 +49,6 @@ export const useNftokenMetadata = (
     const { data, error, mutate } = useSWR(swrKey, getMetadataFetcher, {
         suspense: true,
     });
-    assert(data !== undefined, 'SWR suspense guarantees data is defined');
+    invariant(data !== undefined, 'SWR suspense guarantees data is defined');
     return { data, error, mutate };
 };

--- a/app/components/account/nftoken/nftoken-hooks.tsx
+++ b/app/components/account/nftoken/nftoken-hooks.tsx
@@ -1,6 +1,8 @@
 import { useCluster } from '@providers/cluster';
 import useSWR, { SWRResponse } from 'swr';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { NftokenFetcher } from './nftoken';
 import { NftokenTypes } from './nftoken-types';
 
@@ -28,8 +30,8 @@ export const useCollectionNfts = ({
     const { data, error, mutate } = useSWR(swrKey, getCollectionNftsFetcher, {
         suspense: true,
     });
-    // Not nullable since we use suspense
-    return { data: data!, error, mutate };
+    assert(data, 'SWR suspense guarantees data is non-null');
+    return { data, error, mutate };
 };
 
 const getMetadataFetcher = async (metadataUrl: string) => {
@@ -47,6 +49,6 @@ export const useNftokenMetadata = (
     const { data, error, mutate } = useSWR(swrKey, getMetadataFetcher, {
         suspense: true,
     });
-    // Not nullable since we use suspense
-    return { data: data!, error, mutate };
+    assert(data !== undefined, 'SWR suspense guarantees data is defined');
+    return { data, error, mutate };
 };

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -4,6 +4,8 @@ import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React from 'react';
 
+import { assert } from '@/app/shared/lib/assert';
+
 type AccountStats = {
     reads: number;
     writes: number;
@@ -25,7 +27,9 @@ export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockR
             });
             message.compiledInstructions.forEach(ix => {
                 ix.accountKeyIndexes.forEach(index => {
-                    const address = accountKeys.get(index)!.toBase58();
+                    const accountKey = accountKeys.get(index);
+                    assert(accountKey, `account key index ${index} out of range`);
+                    const address = accountKey.toBase58();
                     txSet.set(address, message.isAccountWritable(index));
                 });
             });

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -4,7 +4,7 @@ import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
 import React from 'react';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 type AccountStats = {
     reads: number;
@@ -28,7 +28,7 @@ export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockR
             message.compiledInstructions.forEach(ix => {
                 ix.accountKeyIndexes.forEach(index => {
                     const accountKey = accountKeys.get(index);
-                    assert(accountKey, `account key index ${index} out of range`);
+                    invariant(accountKey, `account key index ${index} out of range`);
                     const address = accountKey.toBase58();
                     txSet.set(address, message.isAccountWritable(index));
                 });

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -21,6 +21,8 @@ import React, { createRef, useMemo } from 'react';
 import { ChevronDown } from 'react-feather';
 import useAsyncEffect from 'use-async-effect';
 
+import { assert } from '@/app/shared/lib/assert';
+
 const PAGE_SIZE = 25;
 
 const useQueryProgramFilter = (query: ReadonlyURLSearchParams): string => {
@@ -99,7 +101,9 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
                 accountKeysFromLookups: tx.meta?.loadedAddresses,
             });
             indexMap.forEach((count, i) => {
-                const programId = accountKeys.get(i)!.toBase58();
+                const accountKey = accountKeys.get(i);
+                assert(accountKey, `account key index ${i} out of range`);
+                const programId = accountKey.toBase58();
                 invocations.set(programId, count);
                 const programTransactionCount = invokedPrograms.get(programId) || 0;
                 invokedPrograms.set(programId, programTransactionCount + 1);
@@ -170,9 +174,9 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
         const showComputeUnits = filteredTxs.every(tx => tx.computeUnits !== undefined);
 
         if (sortMode === 'compute' && showComputeUnits) {
-            filteredTxs.sort((a, b) => b.computeUnits! - a.computeUnits!);
+            filteredTxs.sort((a, b) => (b.computeUnits ?? 0) - (a.computeUnits ?? 0));
         } else if (sortMode === 'txnCost') {
-            filteredTxs.sort((a, b) => b.costUnits! - a.costUnits!);
+            filteredTxs.sort((a, b) => (b.costUnits ?? 0) - (a.costUnits ?? 0));
         } else if (sortMode === 'fee') {
             filteredTxs.sort((a, b) => (b.meta?.fee || 0) - (a.meta?.fee || 0));
         } else if (sortMode === 'reservedCUs') {

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -21,7 +21,7 @@ import React, { createRef, useMemo } from 'react';
 import { ChevronDown } from 'react-feather';
 import useAsyncEffect from 'use-async-effect';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 const PAGE_SIZE = 25;
 
@@ -102,7 +102,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
             });
             indexMap.forEach((count, i) => {
                 const accountKey = accountKeys.get(i);
-                assert(accountKey, `account key index ${i} out of range`);
+                invariant(accountKey, `account key index ${i} out of range`);
                 const programId = accountKey.toBase58();
                 invocations.set(programId, count);
                 const programTransactionCount = invokedPrograms.get(programId) || 0;

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -3,7 +3,7 @@ import { TableCardBody } from '@components/common/TableCardBody';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import React from 'react';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) {
     const totalTransactions = block.transactions.length;
@@ -22,7 +22,7 @@ export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) 
         const trackProgram = (index: number) => {
             if (index >= accountKeys.length) return;
             const programId = accountKeys.get(index);
-            assert(programId, `account key index ${index} out of range`);
+            invariant(programId, `account key index ${index} out of range`);
             const programAddress = programId.toBase58();
             programUsed.add(programAddress);
             const frequency = ixFrequency.get(programAddress);

--- a/app/components/block/BlockProgramsCard.tsx
+++ b/app/components/block/BlockProgramsCard.tsx
@@ -3,6 +3,8 @@ import { TableCardBody } from '@components/common/TableCardBody';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import React from 'react';
 
+import { assert } from '@/app/shared/lib/assert';
+
 export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) {
     const totalTransactions = block.transactions.length;
     const txSuccesses = new Map<string, number>();
@@ -19,7 +21,8 @@ export function BlockProgramsCard({ block }: { block: VersionedBlockResponse }) 
         });
         const trackProgram = (index: number) => {
             if (index >= accountKeys.length) return;
-            const programId = accountKeys.get(index)!;
+            const programId = accountKeys.get(index);
+            assert(programId, `account key index ${index} out of range`);
             const programAddress = programId.toBase58();
             programUsed.add(programAddress);
             const frequency = ixFrequency.get(programAddress);

--- a/app/components/inspector/instruction-parsers/__tests__/system-program.parser.spec.ts
+++ b/app/components/inspector/instruction-parsers/__tests__/system-program.parser.spec.ts
@@ -3,6 +3,8 @@ import { PublicKey, SystemProgram, TransactionInstruction } from '@solana/web3.j
 import { getCreateAccountWithSeedInstructionDataEncoder } from '@solana-program/system';
 import { describe, expect, test } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { parseSystemProgramInstruction } from '../system-program.parser';
 
 /** Helper to encode CreateAccountWithSeed instruction data using @solana-program/system */
@@ -54,15 +56,15 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            expect(result).not.toBeNull();
-            expect(result!.type).toBe('createAccountWithSeed');
-            expect(result!.info.source.equals(payer)).toBe(true);
-            expect(result!.info.newAccount.equals(newAccount)).toBe(true);
-            expect(result!.info.base.equals(baseAccount)).toBe(true);
-            expect(result!.info.seed).toBe(seed);
-            expect(result!.info.lamports).toBe(lamports);
-            expect(result!.info.space).toBe(space);
-            expect(result!.info.owner.equals(tokenProgram)).toBe(true);
+            assert(result, 'expected parser to return an instruction for a valid CreateAccountWithSeed payload');
+            expect(result.type).toBe('createAccountWithSeed');
+            expect(result.info.source.equals(payer)).toBe(true);
+            expect(result.info.newAccount.equals(newAccount)).toBe(true);
+            expect(result.info.base.equals(baseAccount)).toBe(true);
+            expect(result.info.seed).toBe(seed);
+            expect(result.info.lamports).toBe(lamports);
+            expect(result.info.space).toBe(space);
+            expect(result.info.owner.equals(tokenProgram)).toBe(true);
         });
 
         test('parses 2-account variant (payer === baseAccount)', () => {
@@ -88,16 +90,19 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            expect(result).not.toBeNull();
-            expect(result!.type).toBe('createAccountWithSeed');
-            expect(result!.info.source.equals(payer)).toBe(true);
-            expect(result!.info.newAccount.equals(newAccount)).toBe(true);
+            assert(
+                result,
+                'expected parser to return an instruction for a valid 2-account CreateAccountWithSeed payload',
+            );
+            expect(result.type).toBe('createAccountWithSeed');
+            expect(result.info.source.equals(payer)).toBe(true);
+            expect(result.info.newAccount.equals(newAccount)).toBe(true);
             // Base should be extracted from instruction data, not accounts
-            expect(result!.info.base.equals(payer)).toBe(true);
-            expect(result!.info.seed).toBe(seed);
-            expect(result!.info.lamports).toBe(lamports);
-            expect(result!.info.space).toBe(space);
-            expect(result!.info.owner.equals(tokenProgram)).toBe(true);
+            expect(result.info.base.equals(payer)).toBe(true);
+            expect(result.info.seed).toBe(seed);
+            expect(result.info.lamports).toBe(lamports);
+            expect(result.info.space).toBe(space);
+            expect(result.info.owner.equals(tokenProgram)).toBe(true);
         });
 
         test('handles different seed lengths correctly', () => {
@@ -120,8 +125,8 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            expect(result).not.toBeNull();
-            expect(result!.info.seed).toBe(longSeed);
+            assert(result, 'expected parser to return an instruction when seed is long');
+            expect(result.info.seed).toBe(longSeed);
         });
 
         test('returns null for non-System Program instructions', () => {

--- a/app/components/inspector/instruction-parsers/__tests__/system-program.parser.spec.ts
+++ b/app/components/inspector/instruction-parsers/__tests__/system-program.parser.spec.ts
@@ -3,7 +3,7 @@ import { PublicKey, SystemProgram, TransactionInstruction } from '@solana/web3.j
 import { getCreateAccountWithSeedInstructionDataEncoder } from '@solana-program/system';
 import { describe, expect, test } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { parseSystemProgramInstruction } from '../system-program.parser';
 
@@ -56,7 +56,7 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            assert(result, 'expected parser to return an instruction for a valid CreateAccountWithSeed payload');
+            invariant(result, 'expected parser to return an instruction for a valid CreateAccountWithSeed payload');
             expect(result.type).toBe('createAccountWithSeed');
             expect(result.info.source.equals(payer)).toBe(true);
             expect(result.info.newAccount.equals(newAccount)).toBe(true);
@@ -90,7 +90,7 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            assert(
+            invariant(
                 result,
                 'expected parser to return an instruction for a valid 2-account CreateAccountWithSeed payload',
             );
@@ -125,7 +125,7 @@ describe('parseSystemProgramInstruction', () => {
 
             const result = parseSystemProgramInstruction(instruction);
 
-            assert(result, 'expected parser to return an instruction when seed is long');
+            invariant(result, 'expected parser to return an instruction when seed is long');
             expect(result.info.seed).toBe(longSeed);
         });
 

--- a/app/components/instruction/AnchorDetailsCard.tsx
+++ b/app/components/instruction/AnchorDetailsCard.tsx
@@ -18,8 +18,8 @@ import { extractEventsFromLogs } from '@utils/program-logs';
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, CornerDownRight } from 'react-feather';
 
-import { assert } from '@/app/shared/lib/assert';
 import { toBase64 } from '@/app/shared/lib/bytes';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { InstructionCard } from './InstructionCard';
 import { ProgramEventsCard } from './ProgramEventsCard';
@@ -246,7 +246,7 @@ function AnchorDetails({ ix, anchorProgram }: { ix: TransactionInstruction; anch
                     let accountInfo: FlattenedIdlAccount | null = null;
                     if (accountMap.has(keyIndex) && ixAccounts) {
                         const mappedIndex = accountMap.get(keyIndex);
-                        assert(mappedIndex !== undefined, 'accountMap.has(keyIndex) guarantees the mapped index');
+                        invariant(mappedIndex !== undefined, 'accountMap.has(keyIndex) guarantees the mapped index');
                         accountInfo = ixAccounts[mappedIndex];
                     }
 

--- a/app/components/instruction/AnchorDetailsCard.tsx
+++ b/app/components/instruction/AnchorDetailsCard.tsx
@@ -18,6 +18,7 @@ import { extractEventsFromLogs } from '@utils/program-logs';
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, CornerDownRight } from 'react-feather';
 
+import { assert } from '@/app/shared/lib/assert';
 import { toBase64 } from '@/app/shared/lib/bytes';
 
 import { InstructionCard } from './InstructionCard';
@@ -242,8 +243,12 @@ function AnchorDetails({ ix, anchorProgram }: { ix: TransactionInstruction; anch
                     }
 
                     // Get the account info for this actual account
-                    const accountInfo =
-                        accountMap.has(keyIndex) && ixAccounts ? ixAccounts[accountMap.get(keyIndex)!] : null;
+                    let accountInfo: FlattenedIdlAccount | null = null;
+                    if (accountMap.has(keyIndex) && ixAccounts) {
+                        const mappedIndex = accountMap.get(keyIndex);
+                        assert(mappedIndex !== undefined, 'accountMap.has(keyIndex) guarantees the mapped index');
+                        accountInfo = ixAccounts[mappedIndex];
+                    }
 
                     // Skip nested accounts if parent group is collapsed
                     if (

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -2,7 +2,17 @@ import { PublicKey } from '@solana/web3.js';
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
+
+function nextSibling(el: Element | null): Element {
+    assert(el, 'expected current element to be non-null');
+    // eslint-disable-next-line testing-library/no-node-access -- tests walk the DOM by sibling index
+    const sibling = el.nextElementSibling;
+    assert(sibling, 'expected nextElementSibling to exist');
+    return sibling;
+}
 
 vi.mock('react-feather', () => ({
     CornerDownRight: () => <div data-testid="corner-down-right" />,
@@ -548,48 +558,40 @@ describe('LighthouseDetailsCard', () => {
             expect(ixArgs1a).toHaveTextContent('#0');
             expect(ixArgs1a).toHaveTextContent('Lamports');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1aChild0 = ixArgs1a!.nextElementSibling;
+            const ixArgs1aChild0 = nextSibling(ixArgs1a);
             expect(ixArgs1aChild0).toHaveTextContent('value');
             expect(ixArgs1aChild0).toHaveTextContent('bignum');
             expect(ixArgs1aChild0).toHaveTextContent('40305008');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1aChild1 = ixArgs1aChild0!.nextElementSibling;
+            const ixArgs1aChild1 = nextSibling(ixArgs1aChild0);
             expect(ixArgs1aChild1).toHaveTextContent('operator');
             expect(ixArgs1aChild1).toHaveTextContent('string');
             expect(ixArgs1aChild1).toHaveTextContent('>=');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1b = ixArgs1aChild1!.nextElementSibling;
+            const ixArgs1b = nextSibling(ixArgs1aChild1);
             expect(ixArgs1b).toHaveTextContent('#1');
             expect(ixArgs1b).toHaveTextContent('Lamports');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1bChild0 = ixArgs1b!.nextElementSibling;
+            const ixArgs1bChild0 = nextSibling(ixArgs1b);
             expect(ixArgs1bChild0).toHaveTextContent('value');
             expect(ixArgs1bChild0).toHaveTextContent('bignum');
             expect(ixArgs1bChild0).toHaveTextContent('67175012');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1bChild1 = ixArgs1bChild0!.nextElementSibling;
+            const ixArgs1bChild1 = nextSibling(ixArgs1bChild0);
             expect(ixArgs1bChild1).toHaveTextContent('operator');
             expect(ixArgs1bChild1).toHaveTextContent('string');
             expect(ixArgs1bChild1).toHaveTextContent('<=');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1c = ixArgs1bChild1!.nextElementSibling;
+            const ixArgs1c = nextSibling(ixArgs1bChild1);
             expect(ixArgs1c).toHaveTextContent('#2');
             expect(ixArgs1c).toHaveTextContent('KnownOwner');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1cChild0 = ixArgs1c!.nextElementSibling;
+            const ixArgs1cChild0 = nextSibling(ixArgs1c);
             expect(ixArgs1cChild0).toHaveTextContent('value');
             expect(ixArgs1cChild0).toHaveTextContent('number');
             expect(ixArgs1cChild0).toHaveTextContent('0');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            const ixArgs1cChild1 = ixArgs1cChild0!.nextElementSibling;
+            const ixArgs1cChild1 = nextSibling(ixArgs1cChild0);
             expect(ixArgs1cChild1).toHaveTextContent('operator');
             expect(ixArgs1cChild1).toHaveTextContent('string');
             expect(ixArgs1cChild1).toHaveTextContent('=');
@@ -640,80 +642,68 @@ describe('LighthouseDetailsCard', () => {
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('MetaAssertion');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('AuthorizedWithdrawer');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('pubkey');
             expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('=');
 
             // 2nd assertion
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+
+            next = nextSibling(next);
             expect(next).toHaveTextContent('#1');
             expect(next).toHaveTextContent('MetaAssertion');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('AuthorizedStaker');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('pubkey');
             expect(next).toHaveTextContent('FZLY576gVwyD6rEosP72pRUC9TAe7LhgvoSepk3F63PY');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('=');
 
             // 3rd assertion
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+
+            next = nextSibling(next);
             expect(next).toHaveTextContent('#2');
             expect(next).toHaveTextContent('StakeAssertion');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('fields');
             expect(next).toHaveTextContent('Array[1]');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('#0');
             expect(next).toHaveTextContent('DelegationStake');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('value');
             expect(next).toHaveTextContent('bignum');
             expect(next).toHaveTextContent('2200000');
 
-            // eslint-disable-next-line testing-library/no-node-access
-            next = next!.nextElementSibling;
+            next = nextSibling(next);
             expect(next).toHaveTextContent('operator');
             expect(next).toHaveTextContent('string');
             expect(next).toHaveTextContent('>=');

--- a/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
+++ b/app/components/instruction/lighthouse/__tests__/LighthouseDetailsCard.test.tsx
@@ -2,15 +2,15 @@ import { PublicKey } from '@solana/web3.js';
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { LighthouseDetailsCard } from '../LighthouseDetailsCard';
 
 function nextSibling(el: Element | null): Element {
-    assert(el, 'expected current element to be non-null');
+    invariant(el, 'expected current element to be non-null');
     // eslint-disable-next-line testing-library/no-node-access -- tests walk the DOM by sibling index
     const sibling = el.nextElementSibling;
-    assert(sibling, 'expected nextElementSibling to exist');
+    invariant(sibling, 'expected nextElementSibling to exist');
     return sibling;
 }
 

--- a/app/components/transaction/ProgramLogSection.tsx
+++ b/app/components/transaction/ProgramLogSection.tsx
@@ -40,9 +40,9 @@ export function ProgramLogSection({ signature }: SignatureProps) {
                         <Code className="me-2" size={13} /> Raw
                     </button>
                 </div>
-                {prettyLogs !== null ? (
+                {prettyLogs !== null && logMessages !== null ? (
                     showRaw ? (
-                        <RawProgramLogs raw={logMessages!} />
+                        <RawProgramLogs raw={logMessages} />
                     ) : (
                         <ProgramLogsCardBody message={message} logs={prettyLogs} cluster={cluster} url={url} />
                     )

--- a/app/entities/idl/lib/utils.ts
+++ b/app/entities/idl/lib/utils.ts
@@ -1,8 +1,6 @@
 import { is, string } from 'superstruct';
 
-function invariant(cond: any, message?: string): asserts cond is NonNullable<unknown> {
-    if (cond === undefined) throw new Error(message ?? 'invariant violated');
-}
+import { invariant } from '@/app/shared/lib/invariant';
 
 const Address = string();
 

--- a/app/entities/idl/model/__tests__/use-format-codama-idl.spec.ts
+++ b/app/entities/idl/model/__tests__/use-format-codama-idl.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 // simplified versions of codama IDLs
 import minimalMock from '../../mocks/codama/simplified/minimalMock';
@@ -127,7 +127,7 @@ describe('useFormatCodamaIdl', () => {
 
         const types = result.current?.types;
         expect(types?.length).toEqual(3);
-        assert(types, 'expected formatted IDL to contain types');
+        invariant(types, 'expected formatted IDL to contain types');
 
         const type1 = types[0];
 

--- a/app/entities/idl/model/__tests__/use-format-codama-idl.spec.ts
+++ b/app/entities/idl/model/__tests__/use-format-codama-idl.spec.ts
@@ -1,5 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
+import { assert } from '@/app/shared/lib/assert';
+
 // simplified versions of codama IDLs
 import minimalMock from '../../mocks/codama/simplified/minimalMock';
 import programMock1 from '../../mocks/codama/simplified/programMock1';
@@ -125,8 +127,9 @@ describe('useFormatCodamaIdl', () => {
 
         const types = result.current?.types;
         expect(types?.length).toEqual(3);
+        assert(types, 'expected formatted IDL to contain types');
 
-        const type1 = types![0];
+        const type1 = types[0];
 
         expect(type1.name).toEqual('whirlpoolRewardInfo');
         expect(type1.fieldType?.kind).toEqual('struct');
@@ -152,7 +155,7 @@ describe('useFormatCodamaIdl', () => {
         expect(type1Field5?.name).toEqual('growthGlobalX64');
         expect(type1Field5?.type).toEqual('u128');
 
-        const type2 = types![1];
+        const type2 = types[1];
 
         expect(type2.name).toEqual('remainingAccountsInfo');
         expect(type2.fieldType?.kind).toEqual('struct');
@@ -166,7 +169,7 @@ describe('useFormatCodamaIdl', () => {
         expect(type2Field2?.name).toEqual('optionalAccounts');
         expect(type2Field2?.type).toEqual('option(array(bool, 3))');
 
-        const type3 = types![2];
+        const type3 = types[2];
 
         expect(type3.name).toEqual('accountsType');
         expect(type3.fieldType?.kind).toEqual('enum');

--- a/app/features/idl/formatted-idl/lib/invariant.ts
+++ b/app/features/idl/formatted-idl/lib/invariant.ts
@@ -1,3 +1,0 @@
-export function invariant(cond: unknown, message?: string): asserts cond is NonNullable<unknown> {
-    if (cond === undefined) throw new Error(message ?? 'invariant violated');
-}

--- a/app/features/idl/formatted-idl/ui/AnchorFormattedIdl.tsx
+++ b/app/features/idl/formatted-idl/ui/AnchorFormattedIdl.tsx
@@ -1,7 +1,8 @@
 import type { AnchorIdl } from '@entities/idl';
 import { formatDisplayIdl, getFormattedIdl, useFormatAnchorIdl } from '@entities/idl';
 
-import { invariant } from '../lib/invariant';
+import { invariant } from '@/app/shared/lib/invariant';
+
 import { useSearchIdl } from '../model/search';
 import { BaseFormattedIdl } from './BaseFormattedIdl';
 import type { StandardFormattedIdlProps } from './types';

--- a/app/features/idl/formatted-idl/ui/CodamaFormattedIdl.tsx
+++ b/app/features/idl/formatted-idl/ui/CodamaFormattedIdl.tsx
@@ -1,7 +1,8 @@
 import type { CodamaIdl } from '@entities/idl';
 import { useFormatCodamaIdl } from '@entities/idl';
 
-import { invariant } from '../lib/invariant';
+import { invariant } from '@/app/shared/lib/invariant';
+
 import { useSearchIdl } from '../model/search';
 import { BaseFormattedIdl } from './BaseFormattedIdl';
 import type { StandardFormattedIdlProps } from './types';

--- a/app/features/idl/interactive-idl/model/__tests__/use-pdas.spec.ts
+++ b/app/features/idl/interactive-idl/model/__tests__/use-pdas.spec.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { describe, expect, it } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import votingIdl029 from '../__mocks__/anchor/anchor-0.29.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import votingIdl030 from '../__mocks__/anchor/anchor-0.30.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
@@ -328,7 +328,7 @@ describe('usePdas', () => {
 function setup(idl: unknown, instructionName: string) {
     const mockIdl = idl as SupportedIdl;
     const mockInstruction = findInstruction(idl, instructionName);
-    assert(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
+    invariant(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
 
     const createMockForm = () => {
         return renderHook(() =>

--- a/app/features/idl/interactive-idl/model/__tests__/use-pdas.spec.ts
+++ b/app/features/idl/interactive-idl/model/__tests__/use-pdas.spec.ts
@@ -4,6 +4,8 @@ import { renderHook } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
 import { describe, expect, it } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import votingIdl029 from '../__mocks__/anchor/anchor-0.29.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import votingIdl030 from '../__mocks__/anchor/anchor-0.30.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import votingIdl030Variations from '../__mocks__/anchor/anchor-0.30.0-voting-variations-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
@@ -325,7 +327,8 @@ describe('usePdas', () => {
 
 function setup(idl: unknown, instructionName: string) {
     const mockIdl = idl as SupportedIdl;
-    const mockInstruction = findInstruction(idl, instructionName)!;
+    const mockInstruction = findInstruction(idl, instructionName);
+    assert(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
 
     const createMockForm = () => {
         return renderHook(() =>

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/pda-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/pda-prefill-provider.spec.ts
@@ -2,7 +2,7 @@ import type { SupportedIdl } from '@entities/idl';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import votingIdl030 from '../../../__mocks__/anchor/anchor-0.30.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import votingIdl030Variations from '../../../__mocks__/anchor/anchor-0.30.0-voting-variations-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
@@ -150,7 +150,7 @@ describe('createPdaPrefillDependency', () => {
 function setup(idl: unknown, instructionName: string) {
     const mockIdl = idl as SupportedIdl;
     const mockInstruction = findInstruction(idl, instructionName);
-    assert(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
+    invariant(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
 
     const createForm = () => {
         return renderHook(() =>

--- a/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/pda-prefill-provider.spec.ts
+++ b/app/features/idl/interactive-idl/model/form-prefill/providers/__tests__/pda-prefill-provider.spec.ts
@@ -2,6 +2,8 @@ import type { SupportedIdl } from '@entities/idl';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import votingIdl030 from '../../../__mocks__/anchor/anchor-0.30.0-voting-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import votingIdl030Variations from '../../../__mocks__/anchor/anchor-0.30.0-voting-variations-AXcxp15oz1L4YYtqZo6Qt6EkUj1jtLR6wXYqaJvn4oye.json';
 import { findInstruction } from '../../../__tests__/utils';
@@ -147,7 +149,8 @@ describe('createPdaPrefillDependency', () => {
 
 function setup(idl: unknown, instructionName: string) {
     const mockIdl = idl as SupportedIdl;
-    const mockInstruction = findInstruction(idl, instructionName)!;
+    const mockInstruction = findInstruction(idl, instructionName);
+    assert(mockInstruction, `instruction ${instructionName} not found in IDL fixture`);
 
     const createForm = () => {
         return renderHook(() =>

--- a/app/features/idl/interactive-idl/model/pda-generator/__tests__/seed-builder.test.ts
+++ b/app/features/idl/interactive-idl/model/pda-generator/__tests__/seed-builder.test.ts
@@ -1,6 +1,8 @@
 import { PublicKey } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { buildSeedsWithInfo } from '../seed-builder';
 import type { IdlSeed, PdaArgument, PdaInstruction } from '../types';
 
@@ -62,8 +64,8 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, {}, {}, EMPTY_INSTRUCTION);
 
-                    expect(result.buffers).not.toBeNull();
-                    expect(Array.from(result.buffers![0])).toEqual(value);
+                    assert(result.buffers, 'expected buffers for valid const seed');
+                    expect(Array.from(result.buffers[0])).toEqual(value);
                     expect(result.info[0].name).toBe(expectedHex);
                     expect(result.info[0].value).toBe(expectedHex);
                 },
@@ -93,8 +95,8 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, { value: input }, {}, instruction);
 
-                    expect(result.buffers).not.toBeNull();
-                    expect(Array.from(result.buffers![0])).toEqual(expected);
+                    assert(result.buffers, 'expected buffers for valid integer arg seed');
+                    expect(Array.from(result.buffers[0])).toEqual(expected);
                 },
             );
 
@@ -110,8 +112,8 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, { value: input }, {}, instruction);
 
-                    expect(result.buffers).not.toBeNull();
-                    expect(result.buffers![0].length).toBe(expectedLength);
+                    assert(result.buffers, 'expected buffers for valid signed integer arg seed');
+                    expect(result.buffers[0].length).toBe(expectedLength);
                 },
             );
 
@@ -125,8 +127,8 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { values: '[1,256,1000]' }, {}, instruction);
 
-                expect(result.buffers).not.toBeNull();
-                expect(Array.from(result.buffers![0])).toEqual([1, 0, 0, 1, 232, 3]);
+                assert(result.buffers, 'expected buffers for valid integer array seed');
+                expect(Array.from(result.buffers[0])).toEqual([1, 0, 0, 1, 232, 3]);
             });
         });
 
@@ -141,8 +143,8 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { data: input }, {}, instruction);
 
-                expect(result.buffers).not.toBeNull();
-                expect(Array.from(result.buffers![0])).toEqual(UTF8_TEST_CASES[input]);
+                assert(result.buffers, 'expected buffers for valid string/bytes arg seed');
+                expect(Array.from(result.buffers[0])).toEqual(UTF8_TEST_CASES[input]);
             });
         });
 
@@ -152,8 +154,8 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, {}, { owner: DEFAULT_PUBKEY }, EMPTY_INSTRUCTION);
 
-                expect(result.buffers).not.toBeNull();
-                expect(result.buffers![0].length).toBe(32);
+                assert(result.buffers, 'expected buffers for valid account seed');
+                expect(result.buffers[0].length).toBe(32);
                 expect(result.info[0].name).toBe('owner');
                 expect(result.info[0].value).toBe(DEFAULT_PUBKEY);
             });
@@ -194,11 +196,11 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { index: '5' }, { user: DEFAULT_PUBKEY }, instruction);
 
-                expect(result.buffers).not.toBeNull();
-                expect(result.buffers!.length).toBe(3);
-                expect(Array.from(result.buffers![0])).toEqual([0x01, 0x02]);
-                expect(Array.from(result.buffers![1])).toEqual([5]);
-                expect(result.buffers![2].length).toBe(32);
+                assert(result.buffers, 'expected buffers for valid mixed seeds');
+                expect(result.buffers.length).toBe(3);
+                expect(Array.from(result.buffers[0])).toEqual([0x01, 0x02]);
+                expect(Array.from(result.buffers[1])).toEqual([5]);
+                expect(result.buffers[2].length).toBe(32);
             });
 
             it('should return null buffers if any seed fails', () => {
@@ -248,8 +250,8 @@ describe('seed-builder', () => {
             it('should handle empty seeds array', () => {
                 const result = buildSeedsWithInfo([], {}, {}, EMPTY_INSTRUCTION);
 
-                expect(result.buffers).not.toBeNull();
-                expect(result.buffers!.length).toBe(0);
+                assert(result.buffers, 'expected empty buffers array for empty seeds input');
+                expect(result.buffers.length).toBe(0);
                 expect(result.info.length).toBe(0);
             });
 

--- a/app/features/idl/interactive-idl/model/pda-generator/__tests__/seed-builder.test.ts
+++ b/app/features/idl/interactive-idl/model/pda-generator/__tests__/seed-builder.test.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { buildSeedsWithInfo } from '../seed-builder';
 import type { IdlSeed, PdaArgument, PdaInstruction } from '../types';
@@ -64,7 +64,7 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, {}, {}, EMPTY_INSTRUCTION);
 
-                    assert(result.buffers, 'expected buffers for valid const seed');
+                    invariant(result.buffers, 'expected buffers for valid const seed');
                     expect(Array.from(result.buffers[0])).toEqual(value);
                     expect(result.info[0].name).toBe(expectedHex);
                     expect(result.info[0].value).toBe(expectedHex);
@@ -95,7 +95,7 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, { value: input }, {}, instruction);
 
-                    assert(result.buffers, 'expected buffers for valid integer arg seed');
+                    invariant(result.buffers, 'expected buffers for valid integer arg seed');
                     expect(Array.from(result.buffers[0])).toEqual(expected);
                 },
             );
@@ -112,7 +112,7 @@ describe('seed-builder', () => {
 
                     const result = buildSeedsWithInfo(seeds, { value: input }, {}, instruction);
 
-                    assert(result.buffers, 'expected buffers for valid signed integer arg seed');
+                    invariant(result.buffers, 'expected buffers for valid signed integer arg seed');
                     expect(result.buffers[0].length).toBe(expectedLength);
                 },
             );
@@ -127,7 +127,7 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { values: '[1,256,1000]' }, {}, instruction);
 
-                assert(result.buffers, 'expected buffers for valid integer array seed');
+                invariant(result.buffers, 'expected buffers for valid integer array seed');
                 expect(Array.from(result.buffers[0])).toEqual([1, 0, 0, 1, 232, 3]);
             });
         });
@@ -143,7 +143,7 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { data: input }, {}, instruction);
 
-                assert(result.buffers, 'expected buffers for valid string/bytes arg seed');
+                invariant(result.buffers, 'expected buffers for valid string/bytes arg seed');
                 expect(Array.from(result.buffers[0])).toEqual(UTF8_TEST_CASES[input]);
             });
         });
@@ -154,7 +154,7 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, {}, { owner: DEFAULT_PUBKEY }, EMPTY_INSTRUCTION);
 
-                assert(result.buffers, 'expected buffers for valid account seed');
+                invariant(result.buffers, 'expected buffers for valid account seed');
                 expect(result.buffers[0].length).toBe(32);
                 expect(result.info[0].name).toBe('owner');
                 expect(result.info[0].value).toBe(DEFAULT_PUBKEY);
@@ -196,7 +196,7 @@ describe('seed-builder', () => {
 
                 const result = buildSeedsWithInfo(seeds, { index: '5' }, { user: DEFAULT_PUBKEY }, instruction);
 
-                assert(result.buffers, 'expected buffers for valid mixed seeds');
+                invariant(result.buffers, 'expected buffers for valid mixed seeds');
                 expect(result.buffers.length).toBe(3);
                 expect(Array.from(result.buffers[0])).toEqual([0x01, 0x02]);
                 expect(Array.from(result.buffers[1])).toEqual([5]);
@@ -250,7 +250,7 @@ describe('seed-builder', () => {
             it('should handle empty seeds array', () => {
                 const result = buildSeedsWithInfo([], {}, {}, EMPTY_INSTRUCTION);
 
-                assert(result.buffers, 'expected empty buffers array for empty seeds input');
+                invariant(result.buffers, 'expected empty buffers array for empty seeds input');
                 expect(result.buffers.length).toBe(0);
                 expect(result.info.length).toBe(0);
             });

--- a/app/features/idl/ui/__tests__/IdlCard.spec.tsx
+++ b/app/features/idl/ui/__tests__/IdlCard.spec.tsx
@@ -9,7 +9,7 @@ import { vi } from 'vitest';
 import { GENESIS_HASHES } from '@/app/entities/chain-id';
 import * as programMetadataIdlModule from '@/app/entities/program-metadata';
 import { ClusterProvider } from '@/app/providers/cluster';
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 import { Cluster, clusterSlug } from '@/app/utils/cluster';
 
 import { IdlCard } from '../IdlCard';
@@ -141,7 +141,7 @@ describe('IdlCard', () => {
 
         expect(windowOpenSpy).toHaveBeenCalledTimes(1);
         const firstCall = windowOpenSpy.mock.calls[0];
-        assert(firstCall, 'expected window.open to have been called');
+        invariant(firstCall, 'expected window.open to have been called');
         const [openedUrl, target, features] = firstCall;
         const castawayUrl = new URL(openedUrl as string);
         expect(castawayUrl.origin).toBe('https://www.castaway.lol');
@@ -189,7 +189,7 @@ describe('IdlCard', () => {
 
         expect(windowOpenSpy).toHaveBeenCalledTimes(1);
         const firstCall = windowOpenSpy.mock.calls[0];
-        assert(firstCall, 'expected window.open to have been called');
+        invariant(firstCall, 'expected window.open to have been called');
         const [openedUrl, target, features] = firstCall;
         const castawayUrl = new URL(openedUrl as string);
         expect(castawayUrl.origin).toBe('https://www.castaway.lol');

--- a/app/features/idl/ui/__tests__/IdlCard.spec.tsx
+++ b/app/features/idl/ui/__tests__/IdlCard.spec.tsx
@@ -9,6 +9,7 @@ import { vi } from 'vitest';
 import { GENESIS_HASHES } from '@/app/entities/chain-id';
 import * as programMetadataIdlModule from '@/app/entities/program-metadata';
 import { ClusterProvider } from '@/app/providers/cluster';
+import { assert } from '@/app/shared/lib/assert';
 import { Cluster, clusterSlug } from '@/app/utils/cluster';
 
 import { IdlCard } from '../IdlCard';
@@ -139,7 +140,9 @@ describe('IdlCard', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
         expect(windowOpenSpy).toHaveBeenCalledTimes(1);
-        const [openedUrl, target, features] = windowOpenSpy.mock.calls[0]!;
+        const firstCall = windowOpenSpy.mock.calls[0];
+        assert(firstCall, 'expected window.open to have been called');
+        const [openedUrl, target, features] = firstCall;
         const castawayUrl = new URL(openedUrl as string);
         expect(castawayUrl.origin).toBe('https://www.castaway.lol');
         expect(castawayUrl.pathname).toBe('/');
@@ -185,7 +188,9 @@ describe('IdlCard', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
         expect(windowOpenSpy).toHaveBeenCalledTimes(1);
-        const [openedUrl, target, features] = windowOpenSpy.mock.calls[0]!;
+        const firstCall = windowOpenSpy.mock.calls[0];
+        assert(firstCall, 'expected window.open to have been called');
+        const [openedUrl, target, features] = firstCall;
         const castawayUrl = new URL(openedUrl as string);
         expect(castawayUrl.origin).toBe('https://www.castaway.lol');
         expect(castawayUrl.pathname).toBe('/');

--- a/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
+++ b/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
@@ -1,7 +1,7 @@
 import { Keypair, PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { base64TxSearchProvider } from '../base64-tx-search-provider';
 import { createSearchContext } from './provider-test-utils';
@@ -31,7 +31,7 @@ describe('base64TxSearchProvider', () => {
         const results = await base64TxSearchProvider.search(b64, ctx);
         const params = extractParams(results[0].options[0].pathname);
         const messageParam = params.get('message');
-        assert(messageParam, 'expected message param in inspector URL');
+        invariant(messageParam, 'expected message param in inspector URL');
         const decodedMessage = new Uint8Array(Buffer.from(messageParam, 'base64'));
 
         expect(decodedMessage).toEqual(messageBytes);
@@ -85,7 +85,7 @@ describe('base64TxSearchProvider', () => {
         const results = await base64TxSearchProvider.search(b64, ctx);
         const params = extractParams(results[0].options[0].pathname);
         const message = params.get('message');
-        assert(message, 'expected message param in inspector URL');
+        invariant(message, 'expected message param in inspector URL');
 
         // A double-encoded value would contain '%25' (the encoding of '%')
         expect(message).not.toContain('%25');

--- a/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
+++ b/app/features/search/model/__tests__/base64-tx-search-provider.test.ts
@@ -1,6 +1,8 @@
 import { Keypair, PublicKey, SystemProgram, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { base64TxSearchProvider } from '../base64-tx-search-provider';
 import { createSearchContext } from './provider-test-utils';
 
@@ -28,7 +30,9 @@ describe('base64TxSearchProvider', () => {
         const b64 = Buffer.from(messageBytes).toString('base64');
         const results = await base64TxSearchProvider.search(b64, ctx);
         const params = extractParams(results[0].options[0].pathname);
-        const decodedMessage = new Uint8Array(Buffer.from(params.get('message')!, 'base64'));
+        const messageParam = params.get('message');
+        assert(messageParam, 'expected message param in inspector URL');
+        const decodedMessage = new Uint8Array(Buffer.from(messageParam, 'base64'));
 
         expect(decodedMessage).toEqual(messageBytes);
     });
@@ -80,7 +84,8 @@ describe('base64TxSearchProvider', () => {
         const b64 = createBase64Transaction();
         const results = await base64TxSearchProvider.search(b64, ctx);
         const params = extractParams(results[0].options[0].pathname);
-        const message = params.get('message')!;
+        const message = params.get('message');
+        assert(message, 'expected message param in inspector URL');
 
         // A double-encoded value would contain '%25' (the encoding of '%')
         expect(message).not.toContain('%25');

--- a/app/features/verified-programs/ui/__tests__/VerifiedProgramsCard.test.tsx
+++ b/app/features/verified-programs/ui/__tests__/VerifiedProgramsCard.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
+import { assert } from '@/app/shared/lib/assert';
+
 import { fetchProgramsPage } from '../../api';
 import type { VerifiedProgramInfo } from '../../types';
 import { VerifiedProgramsCard } from '../VerifiedProgramsCard';
@@ -239,7 +241,7 @@ describe('VerifiedProgramsCard', () => {
         expect(screen.getByText('Load More')).toBeInTheDocument();
 
         // Use a promise we can control to ensure loading state is visible
-        let resolveLoadMore: (value: any) => void;
+        let resolveLoadMore: ((value: any) => void) | undefined;
         const loadMorePromise = new Promise(resolve => {
             resolveLoadMore = resolve;
         });
@@ -253,7 +255,8 @@ describe('VerifiedProgramsCard', () => {
         });
 
         // Now resolve the promise
-        resolveLoadMore!({
+        assert(resolveLoadMore, 'Promise executor should have assigned resolveLoadMore synchronously');
+        resolveLoadMore({
             currentPage: 2,
             programs: [mockPrograms[1], mockPrograms[2]],
             totalCount: 3,

--- a/app/features/verified-programs/ui/__tests__/VerifiedProgramsCard.test.tsx
+++ b/app/features/verified-programs/ui/__tests__/VerifiedProgramsCard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
-import { assert } from '@/app/shared/lib/assert';
+import { invariant } from '@/app/shared/lib/invariant';
 
 import { fetchProgramsPage } from '../../api';
 import type { VerifiedProgramInfo } from '../../types';
@@ -255,7 +255,7 @@ describe('VerifiedProgramsCard', () => {
         });
 
         // Now resolve the promise
-        assert(resolveLoadMore, 'Promise executor should have assigned resolveLoadMore synchronously');
+        invariant(resolveLoadMore, 'Promise executor should have assigned resolveLoadMore synchronously');
         resolveLoadMore({
             currentPage: 2,
             programs: [mockPrograms[1], mockPrograms[2]],

--- a/app/providers/accounts/utils/stake.ts
+++ b/app/providers/accounts/utils/stake.ts
@@ -2,8 +2,8 @@
 // Temporary fix, copied from: https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/rpc.ts
 import { AccountInfo, Connection, ParsedAccountData, PublicKey, RpcResponseAndContext } from '@solana/web3.js';
 
-import { assert } from '@/app/shared/lib/assert';
 import { isBuffer } from '@/app/shared/lib/bytes';
+import { invariant } from '@/app/shared/lib/invariant';
 
 interface StakeActivation {
     status: string;
@@ -239,7 +239,7 @@ export async function getStakeActivation(connection: Connection, stakeAddress: P
     } else {
         status = 'inactive';
     }
-    assert(stakeAccountParsed.value, 'stake account value is checked above');
+    invariant(stakeAccountParsed.value, 'stake account value is checked above');
     const inactive = BigInt(stakeAccountParsed.value.lamports) - effective - stakeAccount.meta.rentExemptReserve;
 
     return {

--- a/app/providers/accounts/utils/stake.ts
+++ b/app/providers/accounts/utils/stake.ts
@@ -2,6 +2,7 @@
 // Temporary fix, copied from: https://github.com/solana-developers/solana-rpc-get-stake-activation/blob/main/web3js-1.0/src/rpc.ts
 import { AccountInfo, Connection, ParsedAccountData, PublicKey, RpcResponseAndContext } from '@solana/web3.js';
 
+import { assert } from '@/app/shared/lib/assert';
 import { isBuffer } from '@/app/shared/lib/bytes';
 
 interface StakeActivation {
@@ -238,7 +239,8 @@ export async function getStakeActivation(connection: Connection, stakeAddress: P
     } else {
         status = 'inactive';
     }
-    const inactive = BigInt(stakeAccountParsed.value!.lamports) - effective - stakeAccount.meta.rentExemptReserve;
+    assert(stakeAccountParsed.value, 'stake account value is checked above');
+    const inactive = BigInt(stakeAccountParsed.value.lamports) - effective - stakeAccount.meta.rentExemptReserve;
 
     return {
         active: effective,

--- a/app/shared/lib/assert.ts
+++ b/app/shared/lib/assert.ts
@@ -1,3 +1,0 @@
-export function assert(condition: unknown, message: string): asserts condition {
-    if (!condition) throw new Error(message);
-}

--- a/app/shared/lib/assert.ts
+++ b/app/shared/lib/assert.ts
@@ -1,0 +1,3 @@
+export function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) throw new Error(message);
+}

--- a/app/shared/lib/invariant.ts
+++ b/app/shared/lib/invariant.ts
@@ -1,0 +1,3 @@
+export function invariant(condition: unknown, message: string): asserts condition {
+    if (!condition) throw new Error(message);
+}

--- a/app/utils/anchor.tsx
+++ b/app/utils/anchor.tsx
@@ -490,7 +490,8 @@ function mapField(key: string, value: any, type: IdlType, idl: Idl, keySuffix?: 
                 val => val.name.toLocaleLowerCase() === enumVariantName.toLocaleLowerCase(),
             );
 
-            return variant && variant.fields ? (
+            const variantFields = variant?.fields;
+            return variant && variantFields ? (
                 <ExpandableRow
                     fieldName={itemKey}
                     fieldType={typeDisplayName({ enum: enumVariantName })}
@@ -499,7 +500,7 @@ function mapField(key: string, value: any, type: IdlType, idl: Idl, keySuffix?: 
                 >
                     <Fragment key={keySuffix ? `${key}-${keySuffix}` : key}>
                         {Object.entries(value[enumVariantName]).map(([innerKey, innerValue]: [string, any], index) => {
-                            const innerFieldType = variant.fields![index];
+                            const innerFieldType = variantFields[index];
                             if (!innerFieldType) {
                                 throw Error(
                                     `Could not type definition for ${innerKey} field in user-defined struct ${fieldType.name}`,

--- a/app/utils/url.ts
+++ b/app/utils/url.ts
@@ -57,15 +57,16 @@ export function pickClusterParams(
 
     if (additionalParams) {
         nextSearchParams ||= new URLSearchParams();
+        const params = nextSearchParams;
         const additionalParamsObj = new URLSearchParams(additionalParams.toString());
         additionalParamsObj.forEach((value, key) => {
             // Skip mainnet-beta cluster as it's the default
             if (key === 'cluster' && value === MAINNET_MONIKER) {
                 // Remove it if it was added from current params
-                nextSearchParams!.delete('cluster');
+                params.delete('cluster');
                 return;
             }
-            nextSearchParams!.set(key, value); // Override current with additional
+            params.set(key, value); // Override current with additional
         });
     }
     const queryString = nextSearchParams?.toString();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,7 +48,7 @@ export default tseslint.config(
             semi: ['error', 'always'],
             '@typescript-eslint/no-explicit-any': 'off',
             'object-curly-spacing': ['error', 'always'],
-            '@typescript-eslint/no-non-null-assertion': 'off',
+            '@typescript-eslint/no-non-null-assertion': 'error',
             '@typescript-eslint/no-unused-vars': [
                 'error',
                 {


### PR DESCRIPTION
## Description

- Turn on `@typescript-eslint/no-non-null-assertion` and clean up the 81 existing sites so the ban is enforced going forward.
- Add `app/shared/lib/assert.ts` — a tiny `assert(cond, msg)` helper that narrows and throws a clear message, and is now the preferred replacement for `!`.
- Minor knock-on behavior fix in `BlockHistoryCard` sort comparators: undefined `costUnits` now sort to 0 instead of producing `NaN` (was unreachable for `computeUnits` thanks to the existing `showComputeUnits` guard).

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Other (please describe): Code quality

## Testing

- [x] Spot-check UI: open a block [page](https://explorer-git-fork-hoodieshq-chore-forb-13446d-solana-foundation.vercel.app/block/8000?filter=all&sort=fee) and sort by "Txn Cost" / "Compute" / "Fee" / "Reserved CUs" — ordering unchanged vs. master
- [x] Spot-check UI: open an NFT mint [account](https://explorer-git-fork-hoodieshq-chore-forb-13446d-solana-foundation.vercel.app/address/BdzRDerQJcdWEsU6xaAEACnd1j25HwSTjPV4Y7aPmZNz) and confirm the Non-Fungible card still renders
- [x] Spot-check UI: open a [transaction](https://explorer-git-fork-hoodieshq-chore-forb-13446d-solana-foundation.vercel.app/tx/iKXdGRzw4Rngdb8TRwvU5cS8a1cju1NtLWEghEjViRezB9v2WzPmRLCjYsgnhfDBenu1WEqjYMTEomhFgHexFsP) with program logs and toggle the Raw button


## Related Issues

N/A

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass
