### PR TITLE
fix: treat rugcheck 'invalid token mint' response as no-data

### DIFF
--- a/app/api/verification/rugcheck/[mintAddress]/route.ts
+++ b/app/api/verification/rugcheck/[mintAddress]/route.ts
@@ -85,6 +85,7 @@ export async function GET(_request: Request, { params: { mintAddress } }: Params
 type NoDataStatusCode = 404 | 422;
 
 const RUGCHECK_NO_DATA_ERRORS: Partial<Record<string, NoDataStatusCode>> = {
+    'invalid token mint': 404,
     'not found': 404,
     'unable to generate report': 422,
 };

--- a/app/api/verification/rugcheck/__tests__/route.test.ts
+++ b/app/api/verification/rugcheck/__tests__/route.test.ts
@@ -56,6 +56,14 @@ describe('Rugcheck API Route', () => {
         expect(await response.json()).toEqual({ error: 'No rugcheck data available' });
     });
 
+    it('should return 404 when rugcheck responds with 400 (invalid token mint)', async () => {
+        mockFetchResponse(400, { error: 'invalid token mint' });
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({ error: 'No rugcheck data available' });
+        expect(Logger.panic).not.toHaveBeenCalled();
+    });
+
     it('should return 400 and report to sentry when rugcheck responds with 400 and unexpected body', async () => {
         mockFetchResponse(400, { error: 'bad request' });
         const response = await callRoute(VALID_MINT);


### PR DESCRIPTION
## Description

Rugcheck's premium API returns `HTTP 400 {"error":"invalid token mint"}` for mints it doesn't recognize (example: `HJx4HRAT3RiFq7cy9fSrvP92usAmJ7bJgPccQTyroT2r`).

`app/api/verification/rugcheck/[mintAddress]/route.ts` maps two 400-body error messages to a "no data" status (`'not found'` → 404, `'unable to generate report'` → 422). Anything else — including `'invalid token mint'` — falls through to `Logger.panic(...)` and returns `400 {"error":"Failed to fetch rugcheck data"}`, which:

1. Spams Sentry with a `panic` for what is actually a benign "rugcheck has no report for this token" case.
2. Makes the client (`useRugCheckVerification`) render a generic `FetchFailed` UI state instead of a clean "no data" state (since the non-429 error branch in `fetchRugCheckVerification` treats it the same as a real API failure).

This PR adds `'invalid token mint' → 404` to the `RUGCHECK_NO_DATA_ERRORS` map so the case is handled like the other "no report" responses.

## Type of change

-   [x] Bug fix

## Testing

- Added a unit test in `app/api/verification/rugcheck/__tests__/route.test.ts` covering the new mapping and asserting `Logger.panic` is not called.
- All 11 tests in the suite pass (`pnpm vitest run app/api/verification/rugcheck/__tests__/route.test.ts`).
- Manually verified end-to-end against the dev server:
  - Before: `GET /api/verification/rugcheck/HJx4HRAT3RiFq7cy9fSrvP92usAmJ7bJgPccQTyroT2r` → `400 {"error":"Failed to fetch rugcheck data"}` + Sentry panic.
  - After: same request → `404 {"error":"No rugcheck data available"}`, no Sentry event.

## Related Issues

N/A

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally

## Additional Notes

The `RUGCHECK_NO_DATA_ERRORS` comment already points to https://api.rugcheck.xyz/swagger/index.html — `'invalid token mint'` is another undocumented-but-observed 400-body error string that should be treated the same way.