### PR TITLE
fix: send RPC errors from the endpoints to Sentry

### DIFF
--- a/app/api/anchor/route.ts
+++ b/app/api/anchor/route.ts
@@ -55,7 +55,9 @@ export async function GET(request: Request) {
         }
 
         // RPC failure means the request fundamentally failed — escalate to Sentry.
-        Logger.panic(new Error('[api:anchor] Failed to fetch IDL', { cause: error }));
+        Logger.panic(new Error('[api:anchor] Failed to fetch IDL', { cause: error }), {
+            sentryExtras: { cluster: clusterProp, programAddress },
+        });
         return NextResponse.json({ error: 'Failed to fetch IDL' }, { status: 502 });
     }
 }

--- a/app/api/anchor/route.ts
+++ b/app/api/anchor/route.ts
@@ -54,7 +54,8 @@ export async function GET(request: Request) {
             return NextResponse.json({ idl: null }, { headers: CACHE_HEADERS, status: 200 });
         }
 
-        Logger.error(new Error('[api:anchor] Failed to fetch IDL', { cause: error }));
+        // RPC failure means the request fundamentally failed — escalate to Sentry.
+        Logger.panic(new Error('[api:anchor] Failed to fetch IDL', { cause: error }));
         return NextResponse.json({ error: 'Failed to fetch IDL' }, { status: 502 });
     }
 }

--- a/app/api/ans-domains/[address]/__tests__/route.spec.ts
+++ b/app/api/ans-domains/[address]/__tests__/route.spec.ts
@@ -72,13 +72,19 @@ describe('GET /api/ans-domains/[address]', () => {
             expect(data.domains).toEqual([]);
         });
 
-        it('should log the error on fetch failure', async () => {
+        it('should escalate on fetch failure', async () => {
             const error = new Error('Connection failed');
             vi.mocked(fetchAnsDomains).mockRejectedValueOnce(error);
 
             await GET(mockRequest, { params: { address: VALID_ADDRESS } });
 
-            expect(Logger.error).toHaveBeenCalledWith(error, { address: VALID_ADDRESS });
+            expect(Logger.panic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    cause: error,
+                    message: '[api:ans-domains] Failed to fetch ANS domains',
+                }),
+                { sentryExtras: { address: VALID_ADDRESS } },
+            );
         });
 
         it('should not cache error responses', async () => {

--- a/app/api/ans-domains/[address]/route.ts
+++ b/app/api/ans-domains/[address]/route.ts
@@ -24,7 +24,9 @@ export async function GET(_request: Request, { params: { address } }: Params) {
         return NextResponse.json({ domains }, { headers: CACHE_HEADERS });
     } catch (error) {
         // RPC failure means the request fundamentally failed — escalate to Sentry.
-        Logger.panic(new Error('[api:ans-domains] Failed to fetch ANS domains', { cause: error }), { address });
+        Logger.panic(new Error('[api:ans-domains] Failed to fetch ANS domains', { cause: error }), {
+            sentryExtras: { address },
+        });
         return NextResponse.json({ domains: [] }, { headers: { 'Cache-Control': 'no-store' }, status: 500 });
     }
 }

--- a/app/api/ans-domains/[address]/route.ts
+++ b/app/api/ans-domains/[address]/route.ts
@@ -23,7 +23,8 @@ export async function GET(_request: Request, { params: { address } }: Params) {
         const domains = await fetchAnsDomains(address);
         return NextResponse.json({ domains }, { headers: CACHE_HEADERS });
     } catch (error) {
-        Logger.error(error, { address });
+        // RPC failure means the request fundamentally failed — escalate to Sentry.
+        Logger.panic(new Error('[api:ans-domains] Failed to fetch ANS domains', { cause: error }), { address });
         return NextResponse.json({ domains: [] }, { headers: { 'Cache-Control': 'no-store' }, status: 500 });
     }
 }

--- a/app/api/domain-info/[domain]/__tests__/route.spec.ts
+++ b/app/api/domain-info/[domain]/__tests__/route.spec.ts
@@ -73,13 +73,19 @@ describe('GET /api/domain-info/[domain]', () => {
         expect(response.headers.get('Cache-Control')).toBe('no-store');
     });
 
-    it('should log the error on unexpected failure', async () => {
+    it('should escalate on unexpected failure', async () => {
         const error = new Error('Unexpected failure');
         vi.mocked(resolveDomain).mockRejectedValueOnce(error);
 
         await GET(mockRequest, { params: { domain: 'test.sol' } });
 
-        expect(Logger.error).toHaveBeenCalledWith(error, { domain: 'test.sol' });
+        expect(Logger.panic).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cause: error,
+                message: '[api:domain-info] Failed to resolve domain',
+            }),
+            { sentryExtras: { domain: 'test.sol' } },
+        );
     });
 
     describe('invalid domain input', () => {

--- a/app/api/domain-info/[domain]/route.ts
+++ b/app/api/domain-info/[domain]/route.ts
@@ -25,7 +25,8 @@ export async function GET(_request: Request, { params: { domain } }: Params) {
 
         return NextResponse.json(domainInfo, { headers: CACHE_HEADERS });
     } catch (error) {
-        Logger.error(error, { domain });
+        // RPC failure means the request fundamentally failed — escalate to Sentry.
+        Logger.panic(new Error('[api:domain-info] Failed to resolve domain', { cause: error }), { domain });
         return NextResponse.json(null, { headers: NO_CACHE_HEADERS, status: 500 });
     }
 }

--- a/app/api/domain-info/[domain]/route.ts
+++ b/app/api/domain-info/[domain]/route.ts
@@ -26,7 +26,9 @@ export async function GET(_request: Request, { params: { domain } }: Params) {
         return NextResponse.json(domainInfo, { headers: CACHE_HEADERS });
     } catch (error) {
         // RPC failure means the request fundamentally failed — escalate to Sentry.
-        Logger.panic(new Error('[api:domain-info] Failed to resolve domain', { cause: error }), { domain });
+        Logger.panic(new Error('[api:domain-info] Failed to resolve domain', { cause: error }), {
+            sentryExtras: { domain },
+        });
         return NextResponse.json(null, { headers: NO_CACHE_HEADERS, status: 500 });
     }
 }

--- a/app/api/program-metadata-idl/route.ts
+++ b/app/api/program-metadata-idl/route.ts
@@ -57,7 +57,9 @@ export async function GET(request: Request) {
         }
 
         // RPC failure means the request fundamentally failed — escalate to Sentry.
-        Logger.panic(new Error('[api:program-metadata-idl] Request failed', { cause: error }));
+        Logger.panic(new Error('[api:program-metadata-idl] Request failed', { cause: error }), {
+            sentryExtras: { cluster: clusterProp, programAddress, seed },
+        });
         return NextResponse.json({ error: errors[500] }, { status: 502 });
     }
 }

--- a/app/api/program-metadata-idl/route.ts
+++ b/app/api/program-metadata-idl/route.ts
@@ -56,7 +56,8 @@ export async function GET(request: Request) {
             );
         }
 
-        Logger.error(new Error('[api:program-metadata-idl] Request failed', { cause: error }));
+        // RPC failure means the request fundamentally failed — escalate to Sentry.
+        Logger.panic(new Error('[api:program-metadata-idl] Request failed', { cause: error }));
         return NextResponse.json({ error: errors[500] }, { status: 502 });
     }
 }


### PR DESCRIPTION
## Description

Promote upstream-RPC failures in 4 server routes from console-only `Logger.error` to `Logger.panic`, so they reach Sentry at fatal severity.

Affected routes (all server-side Solana RPC callers):

-   `app/api/anchor/route.ts` — `Program.fetchIdl` (`getAccountInfo`)
-   `app/api/program-metadata-idl/route.ts` — `getProgramCanonicalMetadata` (`@solana/kit` `getAccountInfo`)
-   `app/api/ans-domains/[address]/route.ts` — `fetchAnsDomains` (web3.js `Connection`)
-   `app/api/domain-info/[domain]/route.ts` — `resolveDomain` (web3.js `Connection`)

## Type of change

-   [x] Other (please describe): Observability — surface silent server-side RPC failures to Sentry

## Screenshots

n/a

## Testing

- `pnpm tsc --noEmit` passes (exit 0).
- https://explorer.solana.com/api/anchor?programAddress=ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES&cluster=2 should return error from the anchor endpoint, but the error is registered at the Sentry
OR the link to the address page https://explorer.solana.com/address/ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES/idl?cluster=devnet

## Related Issues

[HOO-478](https://linear.app/solana-fndn/issue/HOO-478)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass