### PR TITLE
Add label for RipRip pack purchase program

### DIFF
--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -75,6 +75,7 @@ export enum PROGRAM_NAMES {
     RAYDIUM_LP_1 = 'Raydium Liquidity Pool Program v1',
     RAYDIUM_LP_2 = 'Raydium Liquidity Pool Program v2',
     RAYDIUM_STAKING = 'Raydium Staking Program',
+    RIPRIP_PACK_PURCHASE = 'RipRip: Pack Purchase Program',
     SABER_ROUTER = 'Saber Router Program',
     SABER_SWAP = 'Saber Stable Swap Program',
     SERUM_1 = 'Serum Dex Program v1',
@@ -365,6 +366,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     RVKd61ztZW9GUwhRbbLoYVRE5Xf1B2tVscKqwZqXgEr: {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.RAYDIUM_LP_1,
+    },
+    RipRdCXEbJUmeR9kjGV4XCwQxyLKruJp4h4a2EgocBK: {
+        deployments: [Cluster.MainnetBeta],
+        name: PROGRAM_NAMES.RIPRIP_PACK_PURCHASE,
     },
     SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy: {
         deployments: LIVE_CLUSTERS,


### PR DESCRIPTION
Adds a label for the RipRip pack purchase program (`RipRdCXEbJUmeR9kjGV4XCwQxyLKruJp4h4a2EgocBK`).

RipRip is a virtual card pack opening platform on Solana. The program is stateless and emits `OrderPaidV1` events for off-chain indexers to settle pack openings via a provably-fair commit-reveal RNG protocol.

- Website: https://www.riprip.io
- Address ownership manifest: https://www.riprip.io/.well-known/solana-addresses.json
- Anchor IDL is available on-chain alongside the program; mainnet activity is observable from launch onward.

The change adds `RIPRIP_PACK_PURCHASE` to the `PROGRAM_NAMES` enum (alphabetical insertion between `RAYDIUM_STAKING` and `SABER_ROUTER`) and a corresponding entry in `PROGRAM_INFO_BY_ID` (sorted between `RVKd61z…` and `SPoo1Ku…` per the existing ASCII order). `deployments: [Cluster.MainnetBeta]`.