### PR TITLE
fix: prevent bare message from being misparsed as a transaction

### DIFF
--- a/app/components/common/BaseRawDetails.tsx
+++ b/app/components/common/BaseRawDetails.tsx
@@ -21,7 +21,7 @@ function RawDetailsLoader() {
  *  VersionedMessage is optional as it will be present at inspector page only.
  */
 export function BaseRawDetails({ ix }: { ix?: TransactionInstruction }) {
-    if (!ix || ix.keys.length === 0) {
+    if (!ix) {
         return <RawDetailsLoader />;
     }
     return <BaseTransactionInstructionRawDetails ix={ix} />;

--- a/app/components/common/stories/BaseRawDetails.stories.tsx
+++ b/app/components/common/stories/BaseRawDetails.stories.tsx
@@ -30,7 +30,7 @@ const createInstructionWithKeys = (): TransactionInstruction => {
             {
                 isSigner: true,
                 isWritable: true,
-                pubkey: new PublicKey('11111111111111111111111111111111'),
+                pubkey: PublicKey.default,
             },
             {
                 isSigner: false,
@@ -43,16 +43,17 @@ const createInstructionWithKeys = (): TransactionInstruction => {
                 pubkey: new PublicKey('SysvarRent111111111111111111111111111111111'),
             },
         ],
-        programId: new PublicKey('11111111111111111111111111111111'),
+        programId: PublicKey.default,
     });
 };
 
-// Create an instruction with no keys (simulates loading state)
+// Instruction with no accounts and no data (legal in Solana — e.g. a no-op-style call).
+// Inspector hits this shape via URL params with hand-crafted messages.
 const createInstructionWithNoKeys = (): TransactionInstruction => {
     return new TransactionInstruction({
         data: Buffer.from([]),
         keys: [],
-        programId: new PublicKey('11111111111111111111111111111111'),
+        programId: PublicKey.default,
     });
 };
 
@@ -81,20 +82,30 @@ export const LoadingState: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        // Should show loading message
+        // Loader (spinner + label) renders only when ix has not arrived yet
         await expect(canvas.getByText('Loading instruction data...')).toBeInTheDocument();
+        await expect(canvasElement.querySelector('.spinner-grow')).toBeInTheDocument();
+
+        // No account/data rows leak through while loading
+        await expect(canvas.queryByText('Account #1')).not.toBeInTheDocument();
+        await expect(canvas.queryByText('Instruction Data')).not.toBeInTheDocument();
     },
 };
 
-export const LoadingStateWithEmptyKeys: Story = {
+export const EmptyAccountsList: Story = {
     args: {
         ix: createInstructionWithNoKeys(),
     },
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        // Should show loading message when keys array is empty
-        await expect(canvas.getByText('Loading instruction data...')).toBeInTheDocument();
+        // Empty keys is a valid instruction shape, not a loading state
+        await expect(canvas.queryByText('Loading instruction data...')).not.toBeInTheDocument();
+        await expect(canvas.queryByText('Account #1')).not.toBeInTheDocument();
+
+        // Data row always renders; empty data falls through to HexData's "No data"
+        await expect(canvas.getByText('Instruction Data')).toBeInTheDocument();
+        await expect(canvas.getByText('No data')).toBeInTheDocument();
     },
 };
 

--- a/app/components/shared/HexData.tsx
+++ b/app/components/shared/HexData.tsx
@@ -86,7 +86,12 @@ export function HexData({
     align?: 'start' | 'end';
 }) {
     if (!raw || raw.length === 0) {
-        return <span>No data</span>;
+        // Same <pre> wrapper as the populated path so the row height matches.
+        return (
+            <span className={cn('e-inline-flex', fullContentVariants({ align }), className)}>
+                <pre className="e-mb-0 e-inline-block e-text-left">No data</pre>
+            </span>
+        );
     }
 
     const hexString = toHex(raw);

--- a/app/shared/lib/__tests__/parse-transaction-bytes.test.ts
+++ b/app/shared/lib/__tests__/parse-transaction-bytes.test.ts
@@ -114,6 +114,34 @@ describe('parseTransactionBytes', () => {
         expect(result.messageBytes).toBe(garbage);
     });
 
+    it('should fall back when bytes deserialize as a transaction but do not round-trip', () => {
+        // Hand-crafted bare legacy message (136 bytes) that VersionedTransaction.deserialize
+        // happily accepts by misreading the first 65 bytes as "1 signature". Without the
+        // round-trip check, we'd return a 69-byte fake message recovered from the second
+        // half of the input — losing the real account keys, blockhash, and instruction.
+        const bytes = buildAmbiguousBareMessage();
+
+        // Precondition: web3.js's deserializer DOES accept these bytes (this is the trap).
+        const tx = VersionedTransaction.deserialize(bytes);
+        // But re-serialization is shorter than the input — proof the parse was lossy.
+        expect(tx.serialize().length).toBeLessThan(bytes.length);
+
+        // parseTransactionBytes detects the mismatch and treats the input as a bare message.
+        const result = parseTransactionBytes(bytes);
+        expect(result.signatures).toBeUndefined();
+        expect(result.messageBytes).toBe(bytes);
+    });
+
+    it('should not fall back for a real transaction that round-trips cleanly', () => {
+        const txBytes = buildTransactionBytes(createLegacyMessageBytes(), 1);
+
+        const result = parseTransactionBytes(txBytes);
+
+        expect(result.signatures).toHaveLength(1);
+        // Sanity: the round-trip check let a genuine transaction through.
+        expect(VersionedMessage.deserialize(result.messageBytes).header.numRequiredSignatures).toBe(1);
+    });
+
     it('should return a slice (not a view) of message bytes for transactions', () => {
         const txBytes = buildTransactionBytes(createLegacyMessageBytes(), 1);
         const result = parseTransactionBytes(txBytes);
@@ -233,6 +261,38 @@ function createMultiSigMessageBytes(): Uint8Array {
         .compileToLegacyMessage()
         .serialize();
     return new Uint8Array(buf);
+}
+
+/**
+ * Bare legacy message whose bytes from offset 65 also parse as a (different)
+ * valid VersionedMessage with numRequiredSignatures=1. This is the same shape
+ * that `Keypair.generate()`-driven tests occasionally produce by accident:
+ * `VersionedTransaction.deserialize` succeeds and silently returns a fake
+ * message recovered from the back half of the input.
+ */
+function buildAmbiguousBareMessage(): Uint8Array {
+    const bytes = new Uint8Array(136);
+
+    // --- Bare-message view (the truth) ---
+    bytes[0] = 1; // header.numRequiredSignatures
+    bytes[1] = 0; // header.numReadonlySignedAccounts
+    bytes[2] = 1; // header.numReadonlyUnsignedAccounts
+    bytes[3] = 3; // 3 account keys
+    // pubkey1: 4..36, pubkey2: 36..68, pubkey3: 68..100, blockhash: 100..132
+    bytes[132] = 1; // 1 instruction
+    // empty instruction at 133..136: programIdIndex=0, accountLen=0, dataLen=0
+
+    // --- Tx misinterpretation: byte[0]=1 → "1 signature" → bytes[65..] is "message" ---
+    // Make the would-be message header valid with numRequiredSignatures=1 so
+    // VersionedTransaction.deserialize's internal sig-count check passes.
+    bytes[65] = 1; // fake numRequiredSignatures (also pubkey2[29])
+    bytes[66] = 0; // fake numReadonlySignedAccounts
+    bytes[67] = 1; // fake numReadonlyUnsignedAccounts
+    bytes[68] = 1; // fake account keys length (also pubkey3[0])
+    // The fake message consumes 69 bytes (header + 1 pubkey + blockhash + numInst=0).
+    // bytes[133]=0 already serves as the fake numInstructions.
+
+    return bytes;
 }
 
 function buildTransactionBytes(messageBytes: Uint8Array, signatureCount: number): Uint8Array {

--- a/app/shared/lib/__tests__/parse-transaction-bytes.test.ts
+++ b/app/shared/lib/__tests__/parse-transaction-bytes.test.ts
@@ -1,4 +1,10 @@
 import {
+    bytesEqual,
+    getCompiledTransactionMessageDecoder,
+    getCompiledTransactionMessageEncoder,
+    getTransactionDecoder,
+} from '@solana/kit';
+import {
     Keypair,
     PublicKey,
     SystemProgram,
@@ -121,10 +127,15 @@ describe('parseTransactionBytes', () => {
         // half of the input — losing the real account keys, blockhash, and instruction.
         const bytes = buildAmbiguousBareMessage();
 
-        // Precondition: web3.js's deserializer DOES accept these bytes (this is the trap).
-        const tx = VersionedTransaction.deserialize(bytes);
-        // But re-serialization is shorter than the input — proof the parse was lossy.
-        expect(tx.serialize().length).toBeLessThan(bytes.length);
+        // Precondition: @solana/kit's transaction decoder DOES accept these bytes — the
+        // same decoder used by parseTransactionBytes — so the round-trip branch is what
+        // the test actually exercises (not the decode-throws fallback).
+        const tx = getTransactionDecoder().decode(bytes);
+        // And re-encoding the message is lossy: the parse silently dropped trailing bytes.
+        const reEncoded = getCompiledTransactionMessageEncoder().encode(
+            getCompiledTransactionMessageDecoder().decode(tx.messageBytes),
+        );
+        expect(bytesEqual(reEncoded, tx.messageBytes)).toBe(false);
 
         // parseTransactionBytes detects the mismatch and treats the input as a bare message.
         const result = parseTransactionBytes(bytes);

--- a/app/shared/lib/parse-transaction-bytes.ts
+++ b/app/shared/lib/parse-transaction-bytes.ts
@@ -1,5 +1,10 @@
-import { VersionedTransaction } from '@solana/web3.js';
-import bs58 from 'bs58';
+import {
+    bytesEqual,
+    getBase58Decoder,
+    getCompiledTransactionMessageDecoder,
+    getCompiledTransactionMessageEncoder,
+    getTransactionDecoder,
+} from '@solana/kit';
 
 /** Minimum byte length for a valid Solana transaction message. */
 export const MIN_MESSAGE_LENGTH =
@@ -9,13 +14,18 @@ export const MIN_MESSAGE_LENGTH =
     32 + // recent blockhash
     1; // instructions length
 
+const TRANSACTION_DECODER = getTransactionDecoder();
+const MESSAGE_DECODER = getCompiledTransactionMessageDecoder();
+const MESSAGE_ENCODER = getCompiledTransactionMessageEncoder();
+const BASE58_DECODER = getBase58Decoder();
+
 /**
  * Determines whether `bytes` is a full transaction (signatures + message) or a
  * bare message, and returns the message portion either way.
  *
- * Tries `VersionedTransaction.deserialize` first. If that fails (e.g. the input
- * is a bare message with no signatures), falls back to treating the entire input
- * as a raw message.
+ * Tries to decode as a wire-format transaction first. If that fails (e.g. the
+ * input is a bare message with no signatures), falls back to treating the
+ * entire input as a raw message.
  *
  * Returns `signatures` only when the input is a full transaction.
  */
@@ -23,17 +33,37 @@ export function parseTransactionBytes(bytes: Uint8Array): {
     messageBytes: Uint8Array;
     signatures?: (string | undefined)[];
 } {
+    let tx;
     try {
-        const tx = VersionedTransaction.deserialize(bytes);
-        const messageBytes = new Uint8Array(tx.message.serialize());
-        const signatures = tx.signatures.map(sig => (sig.some(b => b !== 0) ? bs58.encode(sig) : undefined));
-        const hasSignatures = signatures.some(Boolean);
-        return {
-            messageBytes,
-            ...(hasSignatures ? { signatures } : undefined),
-        };
+        tx = TRANSACTION_DECODER.decode(bytes);
     } catch {
-        // Deserialization as a transaction failed — treat the entire input as a bare message.
         return { messageBytes: bytes };
     }
+
+    // A bare message can accidentally decode as a transaction when its first
+    // byte is a plausible compact-u16 signature count and the bytes that
+    // follow happen to satisfy the message header self-check. Re-encoding the
+    // *message* canonically catches this: an accidental match carries trailing
+    // junk that gets dropped on re-encode, while a real transaction's message
+    // is canonical and round-trips byte-for-byte.
+    let reEncodedMessage;
+    try {
+        reEncodedMessage = MESSAGE_ENCODER.encode(MESSAGE_DECODER.decode(tx.messageBytes));
+    } catch {
+        return { messageBytes: bytes };
+    }
+    if (!bytesEqual(reEncodedMessage, tx.messageBytes)) {
+        return { messageBytes: bytes };
+    }
+
+    // tx.messageBytes is a view over the input — copy so callers can mutate
+    // their input buffer without affecting our return value.
+    const messageBytes = new Uint8Array(tx.messageBytes);
+    // SignaturesMap is insertion-ordered, matching message signer order.
+    const signatures = Object.values(tx.signatures).map(sig => (sig ? BASE58_DECODER.decode(sig) : undefined));
+    const hasSignatures = signatures.some(Boolean);
+    return {
+        messageBytes,
+        ...(hasSignatures ? { signatures } : undefined),
+    };
 }

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -9,10 +9,10 @@
 | Dynamic | `/address/[address]/anchor-program` | 390 B | 1.07 MB |
 | Dynamic | `/address/[address]/attestation` | 10 kB | 1.18 MB |
 | Dynamic | `/address/[address]/attributes` | 10 kB | 1.14 MB |
-| Dynamic | `/address/[address]/blockhashes` | 10 kB | 1.13 MB |
+| Dynamic | `/address/[address]/blockhashes` | 10 kB | 1.14 MB |
 | Dynamic | `/address/[address]/compression` | 10 kB | 1.17 MB |
 | Dynamic | `/address/[address]/concurrent-merkle-tree` | 10 kB | 1.17 MB |
-| Dynamic | `/address/[address]/domains` | 10 kB | 1.15 MB |
+| Dynamic | `/address/[address]/domains` | 10 kB | 1.16 MB |
 | Dynamic | `/address/[address]/entries` | 10 kB | 1.16 MB |
 | Dynamic | `/address/[address]/feature-gate` | 380 B | 1.07 MB |
 | Dynamic | `/address/[address]/idl` | 160 kB | 1.43 MB |
@@ -31,7 +31,7 @@
 | Dynamic | `/address/[address]/vote-history` | 10 kB | 1.14 MB |
 | Dynamic | `/api/anchor` | 370 B | 190 kB |
 | Dynamic | `/api/ans-domains/[address]` | 370 B | 190 kB |
-| Dynamic | `/api/domain-info/[domain]` | 10 kB | 1.15 MB |
+| Dynamic | `/api/domain-info/[domain]` | 10 kB | 1.16 MB |
 | Dynamic | `/api/geo-location` | 370 B | 190 kB |
 | Dynamic | `/api/metadata/proxy` | 370 B | 190 kB |
 | Dynamic | `/api/ping/[network]` | 370 B | 190 kB |
@@ -46,7 +46,7 @@
 | Dynamic | `/api/verified-programs/list/[page]` | 370 B | 190 kB |
 | Dynamic | `/api/verified-programs/metadata/[programId]` | 370 B | 190 kB |
 | Dynamic | `/block/[slot]` | 10 kB | 1.23 MB |
-| Dynamic | `/block/[slot]/accounts` | 10 kB | 1.15 MB |
+| Dynamic | `/block/[slot]/accounts` | 10 kB | 1.16 MB |
 | Dynamic | `/block/[slot]/programs` | 10 kB | 1.16 MB |
 | Dynamic | `/block/[slot]/rewards` | 10 kB | 1.16 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 290 kB |
@@ -57,6 +57,6 @@
 | Static | `/supply` | 10 kB | 1.16 MB |
 | Static | `/tos` | 370 B | 190 kB |
 | Dynamic | `/tx/[signature]` | 70 kB | 1.67 MB |
-| Dynamic | `/tx/[signature]/inspect` | 610 B | 1.43 MB |
-| Static | `/tx/inspector` | 600 B | 1.43 MB |
+| Dynamic | `/tx/[signature]/inspect` | 620 B | 1.44 MB |
+| Static | `/tx/inspector` | 600 B | 1.44 MB |
 | Static | `/verified-programs` | 10 kB | 200 kB |


### PR DESCRIPTION
## Description

Fixes a flaky misparse in `parseTransactionBytes`. The function distinguishes a full transaction (signatures + message) from a bare message by trying `VersionedTransaction.deserialize` first and falling back on failure. The Solana wire format has no magic byte to disambiguate the two, so a bare message starting with `0x01` (`numRequiredSignatures = 1`) can be silently misread as `1 signature + sub-message`. The deserializer's only self-consistency check (`sigCount === numRequiredSignatures` of the parsed sub-message) sometimes passes by coincidence on random pubkey bytes — at which point the function returns 64 bytes from the front of the real message as a fake signature and a re-serialized fake message as `messageBytes`, losing real account keys, blockhash, and instructions.

The fix adds a round-trip check after deserialization: a real transaction re-serializes back to its input exactly; an accidental bare-message match drops trailing bytes on re-encode (the misparse only consumes `1 + 64 + canonicalMessageSize` bytes, dropping the bare message's trailing instruction), so the comparison fails and we correctly fall through to the bare-message branch.

## Type of change

-   [x] Bug fix

## Testing
### Manual regression test

Preview: https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/

The fix lives in `parseTransactionBytes`, which is exercised by **two** entry points:
1. The Transaction Inspector textarea (`/tx/inspector`)
2. The base64-tx fallback in the global search bar

The `?message=` URL param **bypasses** `parseTransactionBytes` (it is the post-parse render path), so URL-prefilled inspector links don't exercise the fix. All scenarios below paste bytes through one of the two real entry points.

#### Test 1 — Inspector textarea, **ambiguous bare message** (the regression case)

1. Open https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/tx/inspector?cluster=devnet
2. Paste this base64 into the input box:
   ```
   AQABAwIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAA==
   ```
3. **Expected (fixed):** Inspector renders a *message* with 3 account keys (the first being `8opHzTAnfzRpPEx21XtnrVTX28YQuCpAjcn1PczScKh`), 1 required signer, and a single instruction targeting that account as an unknown program — and **no Signatures section**.
   **Old buggy behavior:** Sometimes succeeded silently with a different (truncated) message and a fake signature derived from the front 64 bytes of the input.

#### Test 2 — Search bar, **ambiguous bare message**

1. Open https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/?cluster=devnet and paste the same base64 from Test 1 into the global search bar.
2. Click the **"Inspect Decoded Transaction"** suggestion.
3. **Expected:** Inspector loads the message-only view; the URL contains `?message=<...>` but **no `signatures=` param**.

#### Test 3 — Inspector textarea, **real signed transaction** (sanity)

A real signed transaction can be produced and broadcast on devnet via the Solana CLI, then fetched as base64 wire bytes:

```bash
SIG=$(solana transfer --url devnet --allow-unfunded-recipient --no-wait --output json \
  $(solana address) 0.0001 \
  | python3 -c 'import sys,json; print(json.load(sys.stdin)["signature"])')

# Wait a few seconds for confirmation, then fetch the raw wire bytes
curl -sS https://api.devnet.solana.com -H 'Content-Type: application/json' \
  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getTransaction\",\"params\":[\"$SIG\",{\"encoding\":\"base64\",\"maxSupportedTransactionVersion\":0}]}" \
  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["transaction"][0])'
```

A sample run produced this 183-byte signed transaction (legacy, 1 signature, System.transfer of 0.0001 SOL, signature `35n3zWCMBLcdr7eVtiWfXVaRY4wMyH17MqFmfa2Bvmm6Sj9AQ2pJjWCAC7uGwxFP39H6tAjeCSNHuPrRwQ8GGmx2`):

```
AWgnPby4al3AsxWqGLjM5/1i557SaAVUWIuunyOwBE4LJxko5OeaqtEU+S+ZdeAmmVn0W9CHXexOJ7Ktwi8Hgw8BAAECBEIM0C0asU16UDMk4RpS64roCzuJolYLUgVmFLnw6RQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACFUbczxIYLgYoNGo61m1uRXjcpMLLwfxuKhx8onwQNnAQECAAAMAgAAAKCGAQAAAAAA
```

1. Paste the base64 into https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/tx/inspector?cluster=devnet
2. **Expected:** Inspector shows the message AND a populated Signatures section with `35n3zWCMBLcdr7eVtiWfXVaRY4wMyH17MqFmfa2Bvmm6Sj9AQ2pJjWCAC7uGwxFP39H6tAjeCSNHuPrRwQ8GGmx2` as the signer's signature. Cross-reference with the on-chain view at https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/tx/35n3zWCMBLcdr7eVtiWfXVaRY4wMyH17MqFmfa2Bvmm6Sj9AQ2pJjWCAC7uGwxFP39H6tAjeCSNHuPrRwQ8GGmx2?cluster=devnet

#### Test 4 — Inspector textarea, **real bare message** (sanity)

Bare messages are produced by the Solana CLI in sign-only mode. Example for devnet:

```bash
BLOCKHASH=$(curl -sS https://api.devnet.solana.com -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"getLatestBlockhash"}' \
  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["value"]["blockhash"])')

solana transfer --url devnet --sign-only --dump-transaction-message \
  --blockhash "$BLOCKHASH" --allow-unfunded-recipient \
  $(solana address) 0.001
```

That prints `Transaction Message: <base64>`. A sample run produced this 118-byte bare message (legacy, 1 signer, single System.transfer of 0.001 SOL):

```
AQABAgRCDNAtGrFNelAzJOEaUuuK6As7iaJWC1IFZhS58OkUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0BeKhEis+w14J7/s/OFy5lEbsAC587TeXc4rYIKMTOwEBAgAADAIAAABAQg8AAAAAAA==
```

1. Paste the base64 into https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/tx/inspector?cluster=devnet
2. **Expected:** Inspector shows the message-only view (1 required signer, 1 System.transfer instruction), no Signatures section. The blockhash field will likely show as expired since the bare message is older than the cluster's blockhash window.

#### Test 5 — Real on-chain transaction page (no-regression baseline)

1. Visit https://explorer-git-fork-hoodieshq-fix-parse-3cbb86-solana-foundation.vercel.app/tx/4akAicSpP86hkTrB1TM5Mmg5j5J4qxx5gSg16rybyis41R5bUPWTENcAQZTyf2K7Q3z7dUk4uz5woigyt49PKMk3?cluster=mainnet-beta on the preview.
2. **Expected:** Renders identically to production (https://explorer.solana.com/tx/4akAicSpP86hkTrB1TM5Mmg5j5J4qxx5gSg16rybyis41R5bUPWTENcAQZTyf2K7Q3z7dUk4uz5woigyt49PKMk3?cluster=mainnet-beta), including signatures, instructions, and account-balance changes.

## Related Issues
Closes [HOO-500](https://linear.app/solana-fndn/issue/HOO-500/parsetransactionbytes-implementation-bug)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information (not applicable to this change)
-   [x] CI/CD checks pass


