### PR TITLE
fix: opt verification routes out of Next dedupe-fetch

### DIFF
--- a/app/api/verification/coingecko/[address]/route.ts
+++ b/app/api/verification/coingecko/[address]/route.ts
@@ -5,7 +5,8 @@ import { is, number, type } from 'superstruct';
 import { CoinGeckoInfoSchema } from '@/app/features/token-verification-badge/server';
 import { Logger } from '@/app/shared/lib/logger';
 
-import { CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { CACHE_HEADERS, ERROR_CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { fetchUpstream, isTimeoutError } from '../../upstream';
 
 const COINGECKO_QUERY = [
     'community_data=false',
@@ -42,7 +43,7 @@ export async function GET(_request: Request, props: Params) {
     const { baseUrl, headers } = getCoingeckoConfig();
 
     try {
-        const response = await fetch(`${baseUrl}/coins/solana/contract/${address}?${COINGECKO_QUERY}`, {
+        const response = await fetchUpstream(`${baseUrl}/coins/solana/contract/${address}?${COINGECKO_QUERY}`, {
             headers,
         });
 
@@ -91,6 +92,13 @@ export async function GET(_request: Request, props: Params) {
             { headers: CACHE_HEADERS },
         );
     } catch (error) {
+        if (isTimeoutError(error)) {
+            Logger.warn('[api:coingecko] Upstream request timed out', { address, sentry: true });
+            return NextResponse.json(
+                { error: 'Upstream request timed out' },
+                { headers: ERROR_CACHE_HEADERS, status: 504 },
+            );
+        }
         Logger.panic(error instanceof Error ? error : new Error('Failed to fetch coingecko data'));
         return NextResponse.json(
             { error: 'Failed to fetch coingecko data' },

--- a/app/api/verification/coingecko/__tests__/route.test.ts
+++ b/app/api/verification/coingecko/__tests__/route.test.ts
@@ -145,6 +145,20 @@ describe('CoinGecko API Route', () => {
         expect(Logger.panic).toHaveBeenCalled();
     });
 
+    it('should return 504 with short negative cache when upstream request times out', async () => {
+        const timeoutError = new DOMException('Signal timed out.', 'TimeoutError');
+        fetchMock.mockRejectedValueOnce(timeoutError);
+        const response = await callRoute(VALID_ADDRESS);
+        expect(response.status).toBe(504);
+        expect(await response.json()).toEqual({ error: 'Upstream request timed out' });
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, s-maxage=30');
+        expect(Logger.warn).toHaveBeenCalledWith('[api:coingecko] Upstream request timed out', {
+            address: VALID_ADDRESS,
+            sentry: true,
+        });
+        expect(Logger.panic).not.toHaveBeenCalled();
+    });
+
     it('should use public API when COINGECKO_API_KEY is not set', async () => {
         delete process.env.COINGECKO_API_KEY;
         mockFetchResponse(200, { market_data: {} });

--- a/app/api/verification/jupiter/[mintAddress]/route.ts
+++ b/app/api/verification/jupiter/[mintAddress]/route.ts
@@ -4,7 +4,8 @@ import { array, boolean, is, optional, string, type } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-import { CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { CACHE_HEADERS, ERROR_CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { fetchUpstream, isTimeoutError } from '../../upstream';
 
 const JupiterTokenSchema = type({
     id: string(),
@@ -35,7 +36,7 @@ export async function GET(_request: Request, props: Params) {
     }
 
     try {
-        const response = await fetch(`https://api.jup.ag/tokens/v2/search?query=${mintAddress}`, {
+        const response = await fetchUpstream(`https://api.jup.ag/tokens/v2/search?query=${mintAddress}`, {
             headers: {
                 'Content-Type': 'application/json',
                 'x-api-key': JUPITER_API_KEY,
@@ -63,6 +64,13 @@ export async function GET(_request: Request, props: Params) {
         const token = data.find(t => t.id === mintAddress);
         return NextResponse.json({ verified: token?.isVerified === true }, { headers: CACHE_HEADERS });
     } catch (error) {
+        if (isTimeoutError(error)) {
+            Logger.warn('[api:jupiter] Upstream request timed out', { mintAddress, sentry: true });
+            return NextResponse.json(
+                { error: 'Upstream request timed out' },
+                { headers: ERROR_CACHE_HEADERS, status: 504 },
+            );
+        }
         Logger.panic(error instanceof Error ? error : new Error('Failed to fetch jupiter data'));
         return NextResponse.json({ error: 'Failed to fetch jupiter data' }, { headers: NO_STORE_HEADERS, status: 500 });
     }

--- a/app/api/verification/jupiter/__tests__/route.test.ts
+++ b/app/api/verification/jupiter/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+import { vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+// The route reads JUPITER_API_KEY into a module-level const, so the env must
+// be set before the route module is imported. vi.hoisted runs above the
+// `import { GET }` below in the transformed output.
+vi.hoisted(() => {
+    process.env.JUPITER_API_KEY = 'test-key';
+});
+
+import { GET } from '../[mintAddress]/route';
+
+const VALID_MINT = 'B61SyRxF2b8JwSLZHgEUF6rtn6NUikkrK1EMEgP6nhXW';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+describe('Jupiter API Route', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return 400 for an invalid mint address', async () => {
+        const response = await callRoute('not-a-valid-key');
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Invalid mint address' });
+    });
+
+    it('should call the Jupiter search endpoint with the API key header', async () => {
+        mockFetchResponse(200, [{ id: VALID_MINT, isVerified: true }]);
+        await callRoute(VALID_MINT);
+
+        const [url, options] = fetchMock.mock.calls[0];
+        expect(url).toBe(`https://api.jup.ag/tokens/v2/search?query=${VALID_MINT}`);
+        expect((options?.headers as Record<string, string>)?.['x-api-key']).toBe('test-key');
+    });
+
+    it('should return verified: true when the token is verified by Jupiter', async () => {
+        mockFetchResponse(200, [{ id: VALID_MINT, isVerified: true }]);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ verified: true });
+    });
+
+    it('should return verified: false when the token has isVerified: false', async () => {
+        mockFetchResponse(200, [{ id: VALID_MINT, isVerified: false }]);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ verified: false });
+    });
+
+    it('should return verified: false when isVerified is missing', async () => {
+        mockFetchResponse(200, [{ id: VALID_MINT }]);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ verified: false });
+    });
+
+    it('should return verified: false when the mint is not in the response array', async () => {
+        mockFetchResponse(200, [{ id: 'OtherMint11111111111111111111111111111111111', isVerified: true }]);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ verified: false });
+    });
+
+    it('should return verified: false when the response shape is unexpected', async () => {
+        mockFetchResponse(200, { unexpected: 'shape' });
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ verified: false });
+    });
+
+    it('should return 404 silently when Jupiter responds with 404', async () => {
+        mockFetchResponse(404);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch jupiter data' });
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.panic).not.toHaveBeenCalled();
+    });
+
+    it('should return 429 and log to sentry when rate limited', async () => {
+        mockFetchResponse(429);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(429);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch jupiter data' });
+        expect(Logger.warn).toHaveBeenCalledWith('[api:jupiter] Rate limit exceeded', { sentry: true });
+    });
+
+    it('should return upstream status and log panic for other error codes', async () => {
+        mockFetchResponse(503);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(503);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch jupiter data' });
+        expect(Logger.panic).toHaveBeenCalled();
+    });
+
+    it('should return 500 when fetch throws', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('Network error'));
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: 'Failed to fetch jupiter data' });
+        expect(Logger.panic).toHaveBeenCalled();
+    });
+
+    it('should return 504 with short negative cache when upstream request times out', async () => {
+        const timeoutError = new DOMException('Signal timed out.', 'TimeoutError');
+        fetchMock.mockRejectedValueOnce(timeoutError);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(504);
+        expect(await response.json()).toEqual({ error: 'Upstream request timed out' });
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, s-maxage=30');
+        expect(Logger.warn).toHaveBeenCalledWith('[api:jupiter] Upstream request timed out', {
+            mintAddress: VALID_MINT,
+            sentry: true,
+        });
+        expect(Logger.panic).not.toHaveBeenCalled();
+    });
+});
+
+function mockFetchResponse(status: number, body: unknown = []) {
+    const ok = status >= 200 && status < 300;
+    // Cast: tests only stub the surface of Response that the route touches.
+    fetchMock.mockResolvedValueOnce({
+        json: async () => body,
+        ok,
+        status,
+    } as Response);
+}
+
+function callRoute(mintAddress: string) {
+    const request = new Request(`http://localhost:3000/api/verification/jupiter/${mintAddress}`);
+    return GET(request, { params: Promise.resolve({ mintAddress }) });
+}

--- a/app/api/verification/rugcheck/[mintAddress]/route.ts
+++ b/app/api/verification/rugcheck/[mintAddress]/route.ts
@@ -4,7 +4,8 @@ import { is, number, type } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-import { CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { CACHE_HEADERS, ERROR_CACHE_HEADERS, NO_STORE_HEADERS } from '../../config';
+import { fetchUpstream, isTimeoutError } from '../../upstream';
 
 const RugCheckResponseSchema = type({
     score_normalised: number(),
@@ -35,7 +36,7 @@ export async function GET(_request: Request, props: Params) {
     }
 
     try {
-        const response = await fetch(`https://premium.rugcheck.xyz/v1/tokens/${mintAddress}/report`, {
+        const response = await fetchUpstream(`https://premium.rugcheck.xyz/v1/tokens/${mintAddress}/report`, {
             headers: {
                 'Content-Type': 'application/json',
                 'x-api-key': apiKey,
@@ -73,6 +74,13 @@ export async function GET(_request: Request, props: Params) {
 
         return NextResponse.json({ score: data.score_normalised }, { headers: CACHE_HEADERS });
     } catch (error) {
+        if (isTimeoutError(error)) {
+            Logger.warn('[api:rugcheck] Upstream request timed out', { mintAddress, sentry: true });
+            return NextResponse.json(
+                { error: 'Upstream request timed out' },
+                { headers: ERROR_CACHE_HEADERS, status: 504 },
+            );
+        }
         Logger.panic(error instanceof Error ? error : new Error('Failed to fetch rugcheck data'));
         return NextResponse.json(
             { error: 'Failed to fetch rugcheck data' },

--- a/app/api/verification/rugcheck/__tests__/route.test.ts
+++ b/app/api/verification/rugcheck/__tests__/route.test.ts
@@ -97,6 +97,20 @@ describe('Rugcheck API Route', () => {
         expect(response.status).toBe(500);
         expect(await response.json()).toEqual({ error: 'Failed to fetch rugcheck data' });
     });
+
+    it('should return 504 with short negative cache when upstream request times out', async () => {
+        const timeoutError = new DOMException('Signal timed out.', 'TimeoutError');
+        fetchMock.mockRejectedValueOnce(timeoutError);
+        const response = await callRoute(VALID_MINT);
+        expect(response.status).toBe(504);
+        expect(await response.json()).toEqual({ error: 'Upstream request timed out' });
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30, s-maxage=30');
+        expect(Logger.warn).toHaveBeenCalledWith('[api:rugcheck] Upstream request timed out', {
+            mintAddress: VALID_MINT,
+            sentry: true,
+        });
+        expect(Logger.panic).not.toHaveBeenCalled();
+    });
 });
 
 function mockFetchResponse(status: number, body: Record<string, unknown> = {}) {

--- a/app/api/verification/upstream.ts
+++ b/app/api/verification/upstream.ts
@@ -1,0 +1,17 @@
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
+// Passing a signal opts out of Next.js's dedupe-fetch wrapper (calls
+// response.body.tee() on every GET). Some upstream gzip/chunked bodies yield
+// a body undici can't tee — throws "body.tee is not a function".
+export function fetchUpstream(url: string, init?: RequestInit): Promise<Response> {
+    return fetch(url, {
+        ...init,
+        signal: init?.signal ?? AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+}
+
+// AbortSignal.timeout rejects with a DOMException named 'TimeoutError'.
+// https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static#exceptions
+export function isTimeoutError(error: unknown): boolean {
+    return error instanceof DOMException && error.name === 'TimeoutError';
+}

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -12,8 +12,8 @@
 | Dynamic | `/address/[address]/blockhashes` | 10 kB | 1.14 MB |
 | Dynamic | `/address/[address]/compression` | 10 kB | 1.17 MB |
 | Dynamic | `/address/[address]/concurrent-merkle-tree` | 10 kB | 1.17 MB |
-| Dynamic | `/address/[address]/domains` | 10 kB | 1.16 MB |
-| Dynamic | `/address/[address]/entries` | 10 kB | 1.16 MB |
+| Dynamic | `/address/[address]/domains` | 10 kB | 1.15 MB |
+| Dynamic | `/address/[address]/entries` | 10 kB | 1.15 MB |
 | Dynamic | `/address/[address]/feature-gate` | 380 B | 1.07 MB |
 | Dynamic | `/address/[address]/idl` | 160 kB | 1.43 MB |
 | Dynamic | `/address/[address]/instructions` | 10 kB | 1.25 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -12,8 +12,8 @@
 | Dynamic | `/address/[address]/blockhashes` | 10 kB | 1.14 MB |
 | Dynamic | `/address/[address]/compression` | 10 kB | 1.17 MB |
 | Dynamic | `/address/[address]/concurrent-merkle-tree` | 10 kB | 1.17 MB |
-| Dynamic | `/address/[address]/domains` | 10 kB | 1.15 MB |
-| Dynamic | `/address/[address]/entries` | 10 kB | 1.15 MB |
+| Dynamic | `/address/[address]/domains` | 10 kB | 1.16 MB |
+| Dynamic | `/address/[address]/entries` | 10 kB | 1.16 MB |
 | Dynamic | `/address/[address]/feature-gate` | 380 B | 1.07 MB |
 | Dynamic | `/address/[address]/idl` | 160 kB | 1.43 MB |
 | Dynamic | `/address/[address]/instructions` | 10 kB | 1.25 MB |
@@ -25,7 +25,7 @@
 | Dynamic | `/address/[address]/slot-hashes` | 10 kB | 1.14 MB |
 | Dynamic | `/address/[address]/stake-history` | 10 kB | 1.14 MB |
 | Dynamic | `/address/[address]/token-extensions` | 10 kB | 1.22 MB |
-| Dynamic | `/address/[address]/tokens` | 30 kB | 1.34 MB |
+| Dynamic | `/address/[address]/tokens` | 30 kB | 1.35 MB |
 | Dynamic | `/address/[address]/transfers` | 10 kB | 1.28 MB |
 | Dynamic | `/address/[address]/verified-build` | 10 kB | 1.21 MB |
 | Dynamic | `/address/[address]/vote-history` | 10 kB | 1.14 MB |


### PR DESCRIPTION
## Description

Follow-up fix to #985. After native `fetch` replaced `node-fetch`, the three verification routes started throwing `"body.tee is not a function"` for some upstream gzip/chunked responses. Root cause: Next.js's dedupe-fetch wrapper calls `response.body.tee()` on every GET (`node_modules/next/dist/server/lib/dedupe-fetch.js:144-149` → `clone-response.js:30`); on certain undici-decoded bodies the resulting `body` doesn't expose `tee`.

Per `dedupe-fetch.js:81-90`, passing a `signal` is Next's explicit opt-out of the wrapper. Caching (`patchFetch`), tracing, and Sentry instrumentation still run (signal short-circuits dedupe only).

This PR also takes the opportunity to add a 30s timeout — bounding hung upstreams instead of hitting Vercel's function-level timeout — and maps `TimeoutError` to `504 + ERROR_CACHE_HEADERS`, matching the existing pattern in `app/api/verification/bluprynt/[mintAddress]/route.ts`.

### Changes

- **New `app/api/verification/upstream.ts`**:
  - `fetchUpstream(url, init?)` — wraps `fetch`, injects `AbortSignal.timeout(30_000)` (opts out of dedupe-fetch + bounds upstream call duration). Caller-supplied signal wins if passed.
  - `isTimeoutError(error)` — `DOMException` with `name === 'TimeoutError'`, matching `bluprynt/[mintAddress]/route.ts:91-93`.
- **`coingecko`, `jupiter`, `rugcheck` routes**:
  - `fetch(...)` → `fetchUpstream(...)` (one-line swap, removes the duplicated workaround comment).
  - Catch block: timeout → `504 + ERROR_CACHE_HEADERS` + `Logger.warn({ sentry: true })`. Non-timeout errors retain the original `Logger.panic` + `500 + NO_STORE_HEADERS` path verbatim, including all log messages.
- **Tests**: added timeout-branch coverage to coingecko + rugcheck following the bluprynt test pattern (`new DOMException('Signal timed out.', 'TimeoutError')`).

## Type of change

- [x] Bug fix

## Testing

### Test plan
- One smoke test is enough https://explorer-git-fork-hoodieshq-fix-verifi-3df1ea-solana-foundation.vercel.app/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v

Timeout-branch behaviour is exercised by unit tests; faking a 30s upstream hang on a preview is impractical.

## Related Issues
Close [HOO-502](https://linear.app/solana-fndn/issue/HOO-502/responsebodytee-error) 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass locally and in CI
- [ ] I have run `build:info` script to update build information
- [x] CI/CD checks pass