### PR TITLE
feat: Parse Token-2022 confidential transfer and ZK ElGamal Proof instructions

### DIFF
--- a/app/components/instruction/ZkElGamalProofDetailsCard.tsx
+++ b/app/components/instruction/ZkElGamalProofDetailsCard.tsx
@@ -1,10 +1,9 @@
 import { Address } from '@components/common/Address';
 import { SignatureResult, TransactionInstruction } from '@solana/web3.js';
+import { ZK_ELGAMAL_PROOF_PROGRAM_ID } from '@utils/programs';
 import React from 'react';
 
 import { InstructionCard } from './InstructionCard';
-
-export const ZK_ELGAMAL_PROOF_PROGRAM_ID = 'ZkE1Gama1Proof11111111111111111111111111111';
 
 const INSTRUCTION_NAMES: Record<number, string> = {
     0: 'Close Context State',
@@ -41,6 +40,9 @@ export function ZkElGamalProofDetailsCard({
     childIndex?: number;
     InstructionCardComponent?: React.FC<Parameters<typeof InstructionCard>[0]>;
 }) {
+    // Instruction data layout: [discriminator (1 byte), ...raw_proof_bytes].
+    // For verify variants using a record/context-state account, raw_proof_bytes is
+    // empty and the proof lives off-instruction; the row below stays hidden.
     const data = ix.data;
     const discriminator = data.length > 0 ? data[0] : -1;
     const instructionName = INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';

--- a/app/components/instruction/ZkElGamalProofDetailsCard.tsx
+++ b/app/components/instruction/ZkElGamalProofDetailsCard.tsx
@@ -5,21 +5,22 @@ import React from 'react';
 
 import { InstructionCard } from './InstructionCard';
 
-const INSTRUCTION_NAMES: Record<number, string> = {
-    0: 'Close Context State',
-    1: 'Verify Zero Ciphertext',
-    2: 'Verify Ciphertext-Ciphertext Equality',
-    3: 'Verify Ciphertext-Commitment Equality',
-    4: 'Verify Pubkey Validity',
-    5: 'Verify Percentage With Cap',
-    6: 'Verify Batched Range Proof (U64)',
-    7: 'Verify Batched Range Proof (U128)',
-    8: 'Verify Batched Range Proof (U256)',
-    9: 'Verify Grouped Ciphertext (2 handles)',
-    10: 'Verify Batched Grouped Ciphertext (2 handles)',
-    11: 'Verify Grouped Ciphertext (3 handles)',
-    12: 'Verify Batched Grouped Ciphertext (3 handles)',
-};
+// Indexed by the 1-byte discriminator (0..=12).
+const INSTRUCTION_NAMES: readonly string[] = [
+    'Close Context State',
+    'Verify Zero Ciphertext',
+    'Verify Ciphertext-Ciphertext Equality',
+    'Verify Ciphertext-Commitment Equality',
+    'Verify Pubkey Validity',
+    'Verify Percentage With Cap',
+    'Verify Batched Range Proof (U64)',
+    'Verify Batched Range Proof (U128)',
+    'Verify Batched Range Proof (U256)',
+    'Verify Grouped Ciphertext (2 handles)',
+    'Verify Batched Grouped Ciphertext (2 handles)',
+    'Verify Grouped Ciphertext (3 handles)',
+    'Verify Batched Grouped Ciphertext (3 handles)',
+];
 
 export function isZkElGamalProofInstruction(ix: TransactionInstruction): boolean {
     return ix.programId.toBase58() === ZK_ELGAMAL_PROOF_PROGRAM_ID;

--- a/app/components/instruction/ZkElGamalProofDetailsCard.tsx
+++ b/app/components/instruction/ZkElGamalProofDetailsCard.tsx
@@ -1,0 +1,102 @@
+import { Address } from '@components/common/Address';
+import { SignatureResult, TransactionInstruction } from '@solana/web3.js';
+import React from 'react';
+
+import { InstructionCard } from './InstructionCard';
+
+export const ZK_ELGAMAL_PROOF_PROGRAM_ID = 'ZkE1Gama1Proof11111111111111111111111111111';
+
+const INSTRUCTION_NAMES: Record<number, string> = {
+    0: 'Close Context State',
+    1: 'Verify Zero Ciphertext',
+    2: 'Verify Ciphertext-Ciphertext Equality',
+    3: 'Verify Ciphertext-Commitment Equality',
+    4: 'Verify Pubkey Validity',
+    5: 'Verify Percentage With Cap',
+    6: 'Verify Batched Range Proof (U64)',
+    7: 'Verify Batched Range Proof (U128)',
+    8: 'Verify Batched Range Proof (U256)',
+    9: 'Verify Grouped Ciphertext (2 handles)',
+    10: 'Verify Batched Grouped Ciphertext (2 handles)',
+    11: 'Verify Grouped Ciphertext (3 handles)',
+    12: 'Verify Batched Grouped Ciphertext (3 handles)',
+};
+
+export function isZkElGamalProofInstruction(ix: TransactionInstruction): boolean {
+    return ix.programId.toBase58() === ZK_ELGAMAL_PROOF_PROGRAM_ID;
+}
+
+export function ZkElGamalProofDetailsCard({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+    InstructionCardComponent = InstructionCard,
+}: {
+    ix: TransactionInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: JSX.Element[];
+    childIndex?: number;
+    InstructionCardComponent?: React.FC<Parameters<typeof InstructionCard>[0]>;
+}) {
+    const data = ix.data;
+    const discriminator = data.length > 0 ? data[0] : -1;
+    const instructionName = INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';
+    const isClose = discriminator === 0;
+    const proofBytes = data.length > 1 ? data.length - 1 : 0;
+    const accountCount = ix.keys.length;
+
+    return (
+        <InstructionCardComponent
+            ix={ix}
+            index={index}
+            result={result}
+            title={`ZK ElGamal Proof Program: ${instructionName}`}
+            innerCards={innerCards}
+            childIndex={childIndex}
+        >
+            <tr>
+                <td>Program</td>
+                <td className="text-lg-end">
+                    <Address pubkey={ix.programId} alignRight link />
+                </td>
+            </tr>
+            {ix.keys.map((meta, i) => (
+                <tr key={i}>
+                    <td>{labelFor(i, isClose, accountCount)}</td>
+                    <td className="text-lg-end">
+                        <Address pubkey={meta.pubkey} alignRight link />
+                    </td>
+                </tr>
+            ))}
+            {!isClose && proofBytes > 0 && (
+                <tr>
+                    <td>Proof size</td>
+                    <td className="text-lg-end font-monospace">{proofBytes} bytes</td>
+                </tr>
+            )}
+        </InstructionCardComponent>
+    );
+}
+
+// Account layouts:
+//   CloseContextState: [context_state, destination, authority]
+//   Verify with proof in instruction data: []
+//   Verify with record account: [record_account]
+//   Verify with context state account: [context_state, context_state_authority]
+function labelFor(idx: number, isClose: boolean, total: number): string {
+    if (isClose) {
+        if (idx === 0) return 'Context State Account';
+        if (idx === 1) return 'Destination';
+        if (idx === 2) return 'Authority';
+        return `Account #${idx + 1}`;
+    }
+    if (total === 1 && idx === 0) return 'Record Account';
+    if (total === 2) {
+        if (idx === 0) return 'Context State Account';
+        if (idx === 1) return 'Context State Authority';
+    }
+    return `Account #${idx + 1}`;
+}

--- a/app/components/instruction/token/types.ts
+++ b/app/components/instruction/token/types.ts
@@ -363,6 +363,152 @@ const InitializeTokenGroupMember = type({
     memberMintAuthority: PublicKeyFromString,
 });
 
+// Confidential Transfer extension instructions (Token-2022).
+// JSON shapes mirror agave/transaction-status/src/parse_token/extension/confidential_transfer.rs.
+
+const InitializeConfidentialTransferMint = type({
+    auditorElGamalPubkey: nullable(string()),
+    authority: optional(PublicKeyFromString),
+    autoApproveNewAccounts: boolean(),
+    mint: PublicKeyFromString,
+});
+
+const UpdateConfidentialTransferMint = type({
+    auditorElGamalPubkey: nullable(string()),
+    autoApproveNewAccounts: boolean(),
+    confidentialTransferMintAuthority: PublicKeyFromString,
+    mint: PublicKeyFromString,
+});
+
+const ConfigureConfidentialTransferAccount = type({
+    account: PublicKeyFromString,
+    decryptableZeroBalance: string(),
+    instructionsSysvar: optional(PublicKeyFromString),
+    maximumPendingBalanceCreditCounter: union([string(), number()]),
+    mint: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    owner: optional(PublicKeyFromString),
+    proofContextStateAccount: optional(PublicKeyFromString),
+    proofInstructionOffset: number(),
+    recordAccount: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+});
+
+const ApproveConfidentialTransferAccount = type({
+    account: PublicKeyFromString,
+    confidentialTransferAuditorAuthority: PublicKeyFromString,
+    mint: PublicKeyFromString,
+});
+
+const EmptyConfidentialTransferAccount = type({
+    account: PublicKeyFromString,
+    instructionsSysvar: optional(PublicKeyFromString),
+    multisigOwner: optional(PublicKeyFromString),
+    owner: optional(PublicKeyFromString),
+    proofContextStateAccount: optional(PublicKeyFromString),
+    proofInstructionOffset: number(),
+    recordAccount: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+});
+
+const DepositConfidentialTransfer = type({
+    amount: union([string(), number()]),
+    decimals: number(),
+    destination: PublicKeyFromString,
+    mint: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    owner: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+    source: PublicKeyFromString,
+});
+
+const WithdrawConfidentialTransfer = type({
+    amount: union([string(), number()]),
+    decimals: number(),
+    destination: PublicKeyFromString,
+    equalityProofContextStateAccount: optional(PublicKeyFromString),
+    equalityProofInstructionOffset: number(),
+    equalityProofRecordAccount: optional(PublicKeyFromString),
+    instructionsSysvar: optional(PublicKeyFromString),
+    mint: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    newDecryptableAvailableBalance: string(),
+    owner: optional(PublicKeyFromString),
+    rangeProofContextStateAccount: optional(PublicKeyFromString),
+    rangeProofInstructionOffset: number(),
+    rangeProofRecordAccount: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+    source: PublicKeyFromString,
+});
+
+const ConfidentialTransfer = type({
+    ciphertextValidityProofContextStateAccount: optional(PublicKeyFromString),
+    ciphertextValidityProofInstructionOffset: number(),
+    ciphertextValidityProofRecordAccount: optional(PublicKeyFromString),
+    destination: PublicKeyFromString,
+    equalityProofContextStateAccount: optional(PublicKeyFromString),
+    equalityProofInstructionOffset: number(),
+    equalityProofRecordAccount: optional(PublicKeyFromString),
+    instructionsSysvar: optional(PublicKeyFromString),
+    mint: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    newSourceDecryptableAvailableBalance: string(),
+    owner: optional(PublicKeyFromString),
+    rangeProofContextStateAccount: optional(PublicKeyFromString),
+    rangeProofInstructionOffset: number(),
+    rangeProofRecordAccount: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+    source: PublicKeyFromString,
+});
+
+const ConfidentialTransferWithFee = type({
+    destination: PublicKeyFromString,
+    equalityProofContextStateAccount: optional(PublicKeyFromString),
+    equalityProofInstructionOffset: number(),
+    equalityProofRecordAccount: optional(PublicKeyFromString),
+    feeCiphertextValidityProofContextStateAccount: optional(PublicKeyFromString),
+    feeCiphertextValidityProofInstructionOffset: number(),
+    feeCiphertextValidityProofRecordAccount: optional(PublicKeyFromString),
+    feeSigmaProofContextStateAccount: optional(PublicKeyFromString),
+    feeSigmaProofInstructionOffset: number(),
+    feeSigmaProofRecordAccount: optional(PublicKeyFromString),
+    instructionsSysvar: optional(PublicKeyFromString),
+    mint: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    newSourceDecryptableAvailableBalance: string(),
+    owner: optional(PublicKeyFromString),
+    rangeProofContextStateAccount: optional(PublicKeyFromString),
+    rangeProofInstructionOffset: number(),
+    rangeProofRecordAccount: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+    source: PublicKeyFromString,
+    transferAmountCiphertextValidityProofContextStateAccount: optional(PublicKeyFromString),
+    transferAmountCiphertextValidityProofInstructionOffset: number(),
+    transferAmountCiphertextValidityProofRecordAccount: optional(PublicKeyFromString),
+});
+
+const ApplyPendingConfidentialTransferBalance = type({
+    account: PublicKeyFromString,
+    expectedPendingBalanceCreditCounter: union([string(), number()]),
+    multisigOwner: optional(PublicKeyFromString),
+    newDecryptableAvailableBalance: string(),
+    owner: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+});
+
+const ConfidentialTransferCreditsToggle = type({
+    account: PublicKeyFromString,
+    multisigOwner: optional(PublicKeyFromString),
+    owner: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+});
+
+const ConfigureConfidentialAccountWithRegistry = type({
+    account: PublicKeyFromString,
+    mint: PublicKeyFromString,
+    registry: PublicKeyFromString,
+});
+
 export type TokenInstructionType = Infer<typeof TokenInstructionType>;
 export const TokenInstructionType = enums([
     'initializeMint',
@@ -417,25 +563,53 @@ export const TokenInstructionType = enums([
     'updateTokenGroupMaxSize',
     'updateTokenGroupUpdateAuthority',
     'createNativeMint',
+    'initializeConfidentialTransferMint',
+    'updateConfidentialTransferMint',
+    'configureConfidentialTransferAccount',
+    'approveConfidentialTransferAccount',
+    'emptyConfidentialTransferAccount',
+    'depositConfidentialTransfer',
+    'withdrawConfidentialTransfer',
+    'confidentialTransfer',
+    'confidentialTransferWithFee',
+    'applyPendingConfidentialTransferBalance',
+    'enableConfidentialTransferConfidentialCredits',
+    'disableConfidentialTransferConfidentialCredits',
+    'enableConfidentialTransferNonConfidentialCredits',
+    'disableConfidentialTransferNonConfidentialCredits',
+    'configureConfidentialAccountWithRegistry',
 ]);
 
 export const IX_STRUCTS = {
     amountToUiAmount: AmountToUiAmount,
+    applyPendingConfidentialTransferBalance: ApplyPendingConfidentialTransferBalance,
     approve: Approve,
     approve2: ApproveChecked,
     approveChecked: ApproveChecked,
+    approveConfidentialTransferAccount: ApproveConfidentialTransferAccount,
     burn: Burn,
     burn2: BurnChecked,
     burnChecked: BurnChecked,
     closeAccount: CloseAccount,
+    confidentialTransfer: ConfidentialTransfer,
+    confidentialTransferWithFee: ConfidentialTransferWithFee,
+    configureConfidentialAccountWithRegistry: ConfigureConfidentialAccountWithRegistry,
+    configureConfidentialTransferAccount: ConfigureConfidentialTransferAccount,
     createNativeMint: CreateNativeMint,
     defaultAccountStateExtension: DefaultAccountStateExtension,
+    depositConfidentialTransfer: DepositConfidentialTransfer,
+    disableConfidentialTransferConfidentialCredits: ConfidentialTransferCreditsToggle,
+    disableConfidentialTransferNonConfidentialCredits: ConfidentialTransferCreditsToggle,
     emitTokenMetadata: EmitTokenMetadata,
+    emptyConfidentialTransferAccount: EmptyConfidentialTransferAccount,
+    enableConfidentialTransferConfidentialCredits: ConfidentialTransferCreditsToggle,
+    enableConfidentialTransferNonConfidentialCredits: ConfidentialTransferCreditsToggle,
     freezeAccount: FreezeAccount,
     getAccountDataSize: GetAccountDataSize,
     initializeAccount: InitializeAccount,
     initializeAccount2: InitializeAccount2,
     initializeAccount3: InitializeAccount3,
+    initializeConfidentialTransferMint: InitializeConfidentialTransferMint,
     initializeGroupMemberPointer: InitializeGroupMemberPointer,
     initializeGroupPointer: InitializeGroupPointer,
     initializeImmutableOwner: InitializeImmutableOwner,
@@ -464,6 +638,7 @@ export const IX_STRUCTS = {
     transferChecked: TransferChecked,
     transferFeeExtension: TransferFeeExtension,
     uiAmountToAmount: UiAmountToAmount,
+    updateConfidentialTransferMint: UpdateConfidentialTransferMint,
     updateGroupMemberPointer: UpdateGroupMemberPointer,
     updateGroupPointer: UpdateGroupPointer,
     updateMetadataPointer: UpdateMetadataPointer,
@@ -472,25 +647,39 @@ export const IX_STRUCTS = {
     updateTokenMetadataAuthority: UpdateTokenMetadataAuthority,
     updateTokenMetadataField: UpdateTokenMetadataField,
     updateTokenMetadataUpdateAuthority: UpdateTokenMetadataUpdateAuthority,
+    withdrawConfidentialTransfer: WithdrawConfidentialTransfer,
 };
 
 export const IX_TITLES = {
     amountToUiAmount: 'Amount To UiAmount',
+    applyPendingConfidentialTransferBalance: 'Apply Pending Confidential Transfer Balance',
     approve: 'Approve',
     approve2: 'Approve (Checked)',
     approveChecked: 'Approve (Checked)',
+    approveConfidentialTransferAccount: 'Approve Confidential Transfer Account',
     burn: 'Burn',
     burn2: 'Burn (Checked)',
     burnChecked: 'Burn (Checked)',
     closeAccount: 'Close Account',
+    confidentialTransfer: 'Confidential Transfer',
+    confidentialTransferWithFee: 'Confidential Transfer With Fee',
+    configureConfidentialAccountWithRegistry: 'Configure Confidential Account With Registry',
+    configureConfidentialTransferAccount: 'Configure Confidential Transfer Account',
     createNativeMint: 'Create Native Mint',
     defaultAccountStateExtension: 'Default Account State Extension',
+    depositConfidentialTransfer: 'Deposit Confidential Transfer',
+    disableConfidentialTransferConfidentialCredits: 'Disable Confidential Credits',
+    disableConfidentialTransferNonConfidentialCredits: 'Disable Non-Confidential Credits',
     emitTokenMetadata: 'Emit Token Metadata',
+    emptyConfidentialTransferAccount: 'Empty Confidential Transfer Account',
+    enableConfidentialTransferConfidentialCredits: 'Enable Confidential Credits',
+    enableConfidentialTransferNonConfidentialCredits: 'Enable Non-Confidential Credits',
     freezeAccount: 'Freeze Account',
     getAccountDataSize: 'Get Account Data Size',
     initializeAccount: 'Initialize Account',
     initializeAccount2: 'Initialize Account (2)',
     initializeAccount3: 'Initialize Account (3)',
+    initializeConfidentialTransferMint: 'Initialize Confidential Transfer Mint',
     initializeGroupMemberPointer: 'Initialize Group Member Pointer',
     initializeGroupPointer: 'Initialize Group Pointer',
     initializeImmutableOwner: 'Initialize Immutable Owner',
@@ -519,6 +708,7 @@ export const IX_TITLES = {
     transferChecked: 'Transfer (Checked)',
     transferFeeExtension: 'Transfer Fee Extension',
     uiAmountToAmount: 'UiAmount To Amount',
+    updateConfidentialTransferMint: 'Update Confidential Transfer Mint',
     updateGroupMemberPointer: 'Update Group Member Pointer',
     updateGroupPointer: 'Update Group Pointer',
     updateMetadataPointer: 'Update Metadata Pointer',
@@ -527,4 +717,5 @@ export const IX_TITLES = {
     updateTokenMetadataAuthority: 'Update Token Metadata Authority',
     updateTokenMetadataField: 'Update Token Metadata Field',
     updateTokenMetadataUpdateAuthority: 'Update Token Metadata Update Authority',
+    withdrawConfidentialTransfer: 'Withdraw Confidential Transfer',
 };

--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -19,13 +19,13 @@ import { isTokenSwapInstruction } from '@components/instruction/token-swap/types
 import { TokenLendingDetailsCard } from '@components/instruction/TokenLendingDetailsCard';
 import { TokenSwapDetailsCard } from '@components/instruction/TokenSwapDetailsCard';
 import { UnknownDetailsCard } from '@components/instruction/UnknownDetailsCard';
+import { VoteDetailsCard } from '@components/instruction/vote/VoteDetailsCard';
+import { isWormholeInstruction } from '@components/instruction/wormhole/types';
+import { WormholeDetailsCard } from '@components/instruction/WormholeDetailsCard';
 import {
     isZkElGamalProofInstruction,
     ZkElGamalProofDetailsCard,
 } from '@components/instruction/ZkElGamalProofDetailsCard';
-import { VoteDetailsCard } from '@components/instruction/vote/VoteDetailsCard';
-import { isWormholeInstruction } from '@components/instruction/wormhole/types';
-import { WormholeDetailsCard } from '@components/instruction/WormholeDetailsCard';
 import { useAnchorProgram } from '@entities/idl';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { isTokenBatchInstruction, TokenBatchCard } from '@features/token-batch';

--- a/app/components/transaction/InstructionsSection.tsx
+++ b/app/components/transaction/InstructionsSection.tsx
@@ -19,6 +19,10 @@ import { isTokenSwapInstruction } from '@components/instruction/token-swap/types
 import { TokenLendingDetailsCard } from '@components/instruction/TokenLendingDetailsCard';
 import { TokenSwapDetailsCard } from '@components/instruction/TokenSwapDetailsCard';
 import { UnknownDetailsCard } from '@components/instruction/UnknownDetailsCard';
+import {
+    isZkElGamalProofInstruction,
+    ZkElGamalProofDetailsCard,
+} from '@components/instruction/ZkElGamalProofDetailsCard';
 import { VoteDetailsCard } from '@components/instruction/vote/VoteDetailsCard';
 import { isWormholeInstruction } from '@components/instruction/wormhole/types';
 import { WormholeDetailsCard } from '@components/instruction/WormholeDetailsCard';
@@ -259,6 +263,9 @@ function InstructionCard({
     }
     if (ComputeBudgetProgram.programId.equals(transactionIx.programId)) {
         return <ComputeBudgetDetailsCard key={key} {...props} />;
+    }
+    if (isZkElGamalProofInstruction(transactionIx)) {
+        return <ZkElGamalProofDetailsCard key={key} {...props} />;
     }
     if (isLighthouseInstruction(transactionIx)) {
         return <LighthouseDetailsCard key={key} {...props} />;

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -129,6 +129,8 @@ export type ProgramInfo = {
     deployments: Cluster[];
 };
 
+export const ZK_ELGAMAL_PROOF_PROGRAM_ID = 'ZkE1Gama1Proof11111111111111111111111111111';
+
 export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     '11111111111111111111111111111111': {
         deployments: ALL_CLUSTERS,
@@ -429,7 +431,7 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.SERUM_POOL,
     },
-    ZkE1Gama1Proof11111111111111111111111111111: {
+    [ZK_ELGAMAL_PROOF_PROGRAM_ID]: {
         deployments: ALL_CLUSTERS,
         name: PROGRAM_NAMES.ZK_ELGAMAL_PROOF,
     },

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -103,6 +103,9 @@ export enum PROGRAM_NAMES {
     ZK_COMPRESSED_TOKEN_PROGRAM = 'ZK Compressed Token Program',
     ZK_ACCOUNT_COMPRESSION_PROGRAM = 'ZK Account Compression Program',
 
+    // ZK ElGamal Proof
+    ZK_ELGAMAL_PROOF = 'ZK ElGamal Proof Program',
+
     // Lighthouse
     LIGHTHOUSE_PROGRAM = 'Lighthouse Program',
 }
@@ -425,6 +428,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     WvmTNLpGMVbwJVYztYL4Hnsy82cJhQorxjnnXcRm3b6: {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.SERUM_POOL,
+    },
+    ZkE1Gama1Proof11111111111111111111111111111: {
+        deployments: ALL_CLUSTERS,
+        name: PROGRAM_NAMES.ZK_ELGAMAL_PROOF,
     },
     auctxRXPeJoc4817jDhf4HbjnhEcr1cCXenosMhK5R8: {
         deployments: LIVE_CLUSTERS,

--- a/public/accounts-sitemap.xml
+++ b/public/accounts-sitemap.xml
@@ -353,6 +353,11 @@
     <priority>0.4</priority>
   </url>
   <url>
+    <loc>https://explorer.solana.com/address/ZkE1Gama1Proof11111111111111111111111111111</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://explorer.solana.com/address/auctxRXPeJoc4817jDhf4HbjnhEcr1cCXenosMhK5R8</loc>
     <changefreq>daily</changefreq>
     <priority>0.4</priority>


### PR DESCRIPTION
Both Token-2022 confidential transfer instructions and the ZK ElGamal Proof program were rendering as "Unknown Instruction" with raw byte dumps. This adds parsers/decoders for both.

Token-2022 confidential transfer extension: register all 15 instruction variants emitted by the agave parser (`agave/transaction-status/src/parse_token/extension/confidential_transfer.rs`). Initialize/update mint, configure/approve/empty account, deposit, withdraw, transfer, transferWithFee, applyPendingBalance, the four enable/disable credit toggles, and configureAccountWithRegistry.

ZK ElGamal Proof Program: register the program (`ZkE1Gama1Proof11111111111111111111111111111`) under PROGRAM_NAMES and add a custom details card that decodes the 1-byte discriminator into one of 13 verify variants plus closeContextState. Account labels are inferred from the verify mode (instruction data vs record account vs context state account) and the proof body size is shown.

## Before / After

### Apply pending confidential transfer balance

Before: `Token-2022 Program: Unknown Instruction` with raw bytes
After: `Token-2022 Program: Apply Pending Confidential Transfer Balance` with parsed fields

<img width="2394" height="5682" alt="explorer solana com_tx_5NRW5kSsdYoDT7fjbH5vifunqB3kS39wPxNfh6ognFBnBTS6rfjMccrLvjuWjGtarSccVBohmTSNdyW91wNN5sVY_cluster=devnet" src="https://github.com/user-attachments/assets/4c0050f1-de02-4c16-aea4-de60102a757a" />

![Uploading localhost_3000_tx_5NRW5kSsdYoDT7fjbH5vifunqB3kS39wPxNfh6ognFBnBTS6rfjMccrLvjuWjGtarSccVBohmTSNdyW91wNN5sVY_cluster=devnet.png…]()


### Confidential transfer (with proof verifies and closes)

Before: every instruction is `Unknown`
After: `Verify Ciphertext-Commitment Equality`, `Confidential Transfer`, three `Close Context State`

<img width="2394" height="11704" alt="explorer solana com_tx_2o3nKstVT14wNmym4v6EFr9f2KGkPJBhpYQStV1cTQaNXcpV2wZNY1BnWRoVXTTcBfuXyVAT1edvgbrnFpTLBKDD_cluster=devnet" src="https://github.com/user-attachments/assets/b94244f1-e26d-4503-b1df-895bfc5ecea0" />

<img width="2394" height="9712" alt="localhost_3000_tx_2o3nKstVT14wNmym4v6EFr9f2KGkPJBhpYQStV1cTQaNXcpV2wZNY1BnWRoVXTTcBfuXyVAT1edvgbrnFpTLBKDD_cluster=devnet (1)" src="https://github.com/user-attachments/assets/70f62eb7-ba39-49b7-84b6-ae654c902f80" />


### ZK ElGamal Proof: verify batched range proof

Before: `Unknown Program (ZkE1Gama1...): Unknown Instruction`
After: `ZK ElGamal Proof Program: Verify Batched Range Proof (U128)` with labelled context state account, authority, and 1000 byte proof size

<img width="2394" height="6552" alt="explorer solana com_tx_2VNEBBvK7aQv1uAhRgobYnsdBRT7rg6ksKAMFhXbqhrjX47Fg2t5jT6kVRX3ciC4a4rV3ByBFvB3EL4vy6qzunHk_cluster=devnet" src="https://github.com/user-attachments/assets/a2445c88-cf05-461f-962a-b2ae9ad9ea5a" />

<img width="2394" height="4420" alt="localhost_3000_tx_2VNEBBvK7aQv1uAhRgobYnsdBRT7rg6ksKAMFhXbqhrjX47Fg2t5jT6kVRX3ciC4a4rV3ByBFvB3EL4vy6qzunHk_cluster=devnet" src="https://github.com/user-attachments/assets/06f1de79-b0a7-4757-bb1d-f5e2fe48e10d" />
