### PR TITLE
fix(token): parse spl-token WithdrawExcessLamports instruction

### DIFF
--- a/app/components/instruction/token/__tests__/types.spec.ts
+++ b/app/components/instruction/token/__tests__/types.spec.ts
@@ -20,10 +20,7 @@ describe('token instruction types: withdrawExcessLamports', () => {
         const destination = randomAddress();
         const authority = randomAddress();
 
-        const parsed = create(
-            { authority, destination, source },
-            IX_STRUCTS.withdrawExcessLamports,
-        );
+        const parsed = create({ authority, destination, source }, IX_STRUCTS.withdrawExcessLamports);
 
         expect(parsed.authority).toBeInstanceOf(PublicKey);
         expect(parsed.authority?.toBase58()).toBe(authority);
@@ -39,10 +36,7 @@ describe('token instruction types: withdrawExcessLamports', () => {
         const multisigAuthority = randomAddress();
         const signers = [randomAddress(), randomAddress()];
 
-        const parsed = create(
-            { destination, multisigAuthority, signers, source },
-            IX_STRUCTS.withdrawExcessLamports,
-        );
+        const parsed = create({ destination, multisigAuthority, signers, source }, IX_STRUCTS.withdrawExcessLamports);
 
         expect(parsed.multisigAuthority?.toBase58()).toBe(multisigAuthority);
         expect(parsed.signers?.map(s => s.toBase58())).toEqual(signers);

--- a/app/components/instruction/token/__tests__/types.spec.ts
+++ b/app/components/instruction/token/__tests__/types.spec.ts
@@ -1,0 +1,56 @@
+import { PublicKey } from '@solana/web3.js';
+import { create } from 'superstruct';
+import { describe, expect, it } from 'vitest';
+
+import { IX_STRUCTS, IX_TITLES, TokenInstructionType } from '../types';
+
+const SOURCE = '11111111111111111111111111111112';
+const DESTINATION = '11111111111111111111111111111113';
+const AUTHORITY = '11111111111111111111111111111114';
+const MULTISIG_AUTHORITY = '11111111111111111111111111111115';
+const SIGNER_A = '11111111111111111111111111111116';
+const SIGNER_B = '11111111111111111111111111111117';
+
+describe('token instruction types: withdrawExcessLamports', () => {
+    it('should be a recognized TokenInstructionType', () => {
+        expect(() => create('withdrawExcessLamports', TokenInstructionType)).not.toThrow();
+    });
+
+    it('should expose a human-readable title', () => {
+        expect(IX_TITLES.withdrawExcessLamports).toBe('Withdraw Excess Lamports');
+    });
+
+    it('should validate the single-authority RPC parsed shape', () => {
+        const parsed = create(
+            {
+                authority: AUTHORITY,
+                destination: DESTINATION,
+                source: SOURCE,
+            },
+            IX_STRUCTS.withdrawExcessLamports,
+        );
+
+        expect(parsed.authority).toBeInstanceOf(PublicKey);
+        expect(parsed.authority?.toBase58()).toBe(AUTHORITY);
+        expect(parsed.destination.toBase58()).toBe(DESTINATION);
+        expect(parsed.source.toBase58()).toBe(SOURCE);
+        expect(parsed.multisigAuthority).toBeUndefined();
+        expect(parsed.signers).toBeUndefined();
+    });
+
+    it('should validate the multisig RPC parsed shape', () => {
+        const parsed = create(
+            {
+                destination: DESTINATION,
+                multisigAuthority: MULTISIG_AUTHORITY,
+                signers: [SIGNER_A, SIGNER_B],
+                source: SOURCE,
+            },
+            IX_STRUCTS.withdrawExcessLamports,
+        );
+
+        expect(parsed.multisigAuthority?.toBase58()).toBe(MULTISIG_AUTHORITY);
+        expect(parsed.signers?.map(s => s.toBase58())).toEqual([SIGNER_A, SIGNER_B]);
+        expect(parsed.authority).toBeUndefined();
+    });
+});

--- a/app/components/instruction/token/__tests__/types.spec.ts
+++ b/app/components/instruction/token/__tests__/types.spec.ts
@@ -1,15 +1,10 @@
-import { PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import { create } from 'superstruct';
 import { describe, expect, it } from 'vitest';
 
 import { IX_STRUCTS, IX_TITLES, TokenInstructionType } from '../types';
 
-const SOURCE = '11111111111111111111111111111112';
-const DESTINATION = '11111111111111111111111111111113';
-const AUTHORITY = '11111111111111111111111111111114';
-const MULTISIG_AUTHORITY = '11111111111111111111111111111115';
-const SIGNER_A = '11111111111111111111111111111116';
-const SIGNER_B = '11111111111111111111111111111117';
+const randomAddress = () => Keypair.generate().publicKey.toBase58();
 
 describe('token instruction types: withdrawExcessLamports', () => {
     it('should be a recognized TokenInstructionType', () => {
@@ -21,36 +16,36 @@ describe('token instruction types: withdrawExcessLamports', () => {
     });
 
     it('should validate the single-authority RPC parsed shape', () => {
+        const source = randomAddress();
+        const destination = randomAddress();
+        const authority = randomAddress();
+
         const parsed = create(
-            {
-                authority: AUTHORITY,
-                destination: DESTINATION,
-                source: SOURCE,
-            },
+            { authority, destination, source },
             IX_STRUCTS.withdrawExcessLamports,
         );
 
         expect(parsed.authority).toBeInstanceOf(PublicKey);
-        expect(parsed.authority?.toBase58()).toBe(AUTHORITY);
-        expect(parsed.destination.toBase58()).toBe(DESTINATION);
-        expect(parsed.source.toBase58()).toBe(SOURCE);
+        expect(parsed.authority?.toBase58()).toBe(authority);
+        expect(parsed.destination.toBase58()).toBe(destination);
+        expect(parsed.source.toBase58()).toBe(source);
         expect(parsed.multisigAuthority).toBeUndefined();
         expect(parsed.signers).toBeUndefined();
     });
 
     it('should validate the multisig RPC parsed shape', () => {
+        const source = randomAddress();
+        const destination = randomAddress();
+        const multisigAuthority = randomAddress();
+        const signers = [randomAddress(), randomAddress()];
+
         const parsed = create(
-            {
-                destination: DESTINATION,
-                multisigAuthority: MULTISIG_AUTHORITY,
-                signers: [SIGNER_A, SIGNER_B],
-                source: SOURCE,
-            },
+            { destination, multisigAuthority, signers, source },
             IX_STRUCTS.withdrawExcessLamports,
         );
 
-        expect(parsed.multisigAuthority?.toBase58()).toBe(MULTISIG_AUTHORITY);
-        expect(parsed.signers?.map(s => s.toBase58())).toEqual([SIGNER_A, SIGNER_B]);
+        expect(parsed.multisigAuthority?.toBase58()).toBe(multisigAuthority);
+        expect(parsed.signers?.map(s => s.toBase58())).toEqual(signers);
         expect(parsed.authority).toBeUndefined();
     });
 });

--- a/app/components/instruction/token/types.ts
+++ b/app/components/instruction/token/types.ts
@@ -509,6 +509,14 @@ const ConfigureConfidentialAccountWithRegistry = type({
     registry: PublicKeyFromString,
 });
 
+const WithdrawExcessLamports = type({
+    authority: optional(PublicKeyFromString),
+    destination: PublicKeyFromString,
+    multisigAuthority: optional(PublicKeyFromString),
+    signers: optional(array(PublicKeyFromString)),
+    source: PublicKeyFromString,
+});
+
 export type TokenInstructionType = Infer<typeof TokenInstructionType>;
 export const TokenInstructionType = enums([
     'initializeMint',
@@ -578,6 +586,7 @@ export const TokenInstructionType = enums([
     'enableConfidentialTransferNonConfidentialCredits',
     'disableConfidentialTransferNonConfidentialCredits',
     'configureConfidentialAccountWithRegistry',
+    'withdrawExcessLamports',
 ]);
 
 export const IX_STRUCTS = {
@@ -648,6 +657,7 @@ export const IX_STRUCTS = {
     updateTokenMetadataField: UpdateTokenMetadataField,
     updateTokenMetadataUpdateAuthority: UpdateTokenMetadataUpdateAuthority,
     withdrawConfidentialTransfer: WithdrawConfidentialTransfer,
+    withdrawExcessLamports: WithdrawExcessLamports,
 };
 
 export const IX_TITLES = {
@@ -718,4 +728,5 @@ export const IX_TITLES = {
     updateTokenMetadataField: 'Update Token Metadata Field',
     updateTokenMetadataUpdateAuthority: 'Update Token Metadata Update Authority',
     withdrawConfidentialTransfer: 'Withdraw Confidential Transfer',
+    withdrawExcessLamports: 'Withdraw Excess Lamports',
 };


### PR DESCRIPTION
## Description

The classic SPL Token program at `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` (now served by the p-token Pinocchio reimplementation) exposes the `WithdrawExcessLamports` instruction. The RPC's `jsonParsed` encoding surfaces it as:

```json
{ "program": "spl-token", "parsed": { "type": "withdrawExcessLamports", "info": { "source": "...", "destination": "...", "authority": "..." } } }
```

`withdrawExcessLamports` was missing from `TokenInstructionType` / `IX_STRUCTS` / `IX_TITLES`, so the `create(rawType, TokenInstructionType)` call in `TokenDetailsCard` threw and the card rendered as an unknown instruction.

Example transaction: [`3HTD3oSQ…4jCm`](https://explorer.solana.com/tx/3HTD3oSQyVYxBqeXqppitTMKdY4cgnJVkmbrCKqdGzgdwBvCNqhaoPTYDaYtqrqTz4bnZon9NTBC3EZ6r3Jw4jCm) — currently shows "Unknown Instruction" for the third instruction.

This PR adds the parser entry with both single-authority and multisig variants, mirroring the agave `parse_token` JSON shape (see [`agave/transaction-status/src/parse_token.rs`](https://github.com/anza-xyz/agave/blob/master/transaction-status/src/parse_token.rs) — `parse_signers` produces `authority` xor `multisigAuthority`+`signers`).

## Type of change

- [x] Bug fix

## Testing
- [Example](https://explorer-git-fork-hoodieshq-fix-token-ffe349-solana-foundation.vercel.app/tx/3HTD3oSQyVYxBqeXqppitTMKdY4cgnJVkmbrCKqdGzgdwBvCNqhaoPTYDaYtqrqTz4bnZon9NTBC3EZ6r3Jw4jCm)

## Related Issues

Closes [HOO-541](https://linear.app/solana-fndn/issue/HOO-541/add-withdrawexcesslamports-ptoken-instruction-to-explorer) 
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix works
- [x] All tests pass locally