### PR TITLE
refactor: unify react hooks import

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -41,7 +41,7 @@ import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 import { ClusterStatus } from '@utils/cluster';
 import { FEATURE_PROGRAM_ID } from '@utils/parseFeatureAccount';
 import { useSearchParams } from 'next/navigation';
-import React, { PropsWithChildren, Suspense, use } from 'react';
+import { PropsWithChildren, Suspense, use, useCallback, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { SOLANA_ATTESTATION_SERVICE_PROGRAM_ADDRESS as SAS_PROGRAM_ID } from 'sas-lib';
 import useSWRImmutable from 'swr/immutable';
@@ -159,7 +159,7 @@ function AddressLayoutInner({ children, params: { address } }: InnerProps) {
     const isTokenInfoLoading = isAccountLoading || isFullTokenInfoLoading;
 
     // Fetch account on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'parsed');
         }
@@ -332,7 +332,7 @@ function MoreSection({
     asyncChildren?: React.ReactNode;
 }) {
     const searchParams = useSearchParams();
-    const buildHref = React.useCallback(
+    const buildHref = useCallback(
         (path: string) => pickClusterParams(`${baseUrl}/${path}`, searchParams ?? undefined),
         [baseUrl, searchParams],
     );

--- a/app/block/[slot]/accounts/page-client.tsx
+++ b/app/block/[slot]/accounts/page-client.tsx
@@ -5,7 +5,7 @@ import { useBlock, useFetchBlock } from '@providers/block';
 import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { notFound } from 'next/navigation';
-import React from 'react';
+import { useEffect } from 'react';
 
 type Props = Readonly<{ params: { slot: string } }>;
 
@@ -18,7 +18,7 @@ export default function BlockAccountsTab({ params: { slot } }: Props) {
     const fetchBlock = useFetchBlock();
     const { status } = useCluster();
     // Fetch block on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {
             fetchBlock(slotNumber);
         }

--- a/app/block/[slot]/layout.tsx
+++ b/app/block/[slot]/layout.tsx
@@ -14,7 +14,7 @@ import { ClusterStatus } from '@utils/cluster';
 import { displayTimestamp, displayTimestampUtc } from '@utils/date';
 import { IBRL_EXPLORER_URL } from '@utils/env';
 import { notFound, useSearchParams } from 'next/navigation';
-import React, { PropsWithChildren, use } from 'react';
+import { PropsWithChildren, use, useCallback, useEffect } from 'react';
 import { ExternalLink } from 'react-feather';
 
 import { type NavigationTab, NavigationTabs } from '@/app/shared/ui/navigation-tabs';
@@ -37,7 +37,7 @@ function BlockLayoutInner({ children, params: { slot } }: InnerProps) {
     const refresh = () => fetchBlock(slotNumber);
 
     // Fetch block on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) refresh();
     }, [slotNumber, status]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -250,7 +250,7 @@ const TABS: NavigationTab[] = [
 
 function MoreSection({ children, slot }: { children: React.ReactNode; slot: number }) {
     const searchParams = useSearchParams();
-    const buildHref = React.useCallback(
+    const buildHref = useCallback(
         (path: string) => pickClusterParams(`/block/${slot}/${path}`, searchParams ?? undefined),
         [slot, searchParams],
     );

--- a/app/block/[slot]/page-client.tsx
+++ b/app/block/[slot]/page-client.tsx
@@ -6,7 +6,7 @@ import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { getEpochForSlot } from '@utils/epoch-schedule';
 import { notFound } from 'next/navigation';
-import React from 'react';
+import { useEffect, useMemo } from 'react';
 
 type Props = Readonly<{ params: { slot: string } }>;
 
@@ -20,7 +20,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
     const { status, clusterInfo } = useCluster();
 
     // Calculate epoch from slot
-    const epoch = React.useMemo(() => {
+    const epoch = useMemo(() => {
         if (clusterInfo) {
             return getEpochForSlot(clusterInfo.epochSchedule, BigInt(slotNumber));
         }
@@ -28,7 +28,7 @@ export default function BlockTransactionsTabClient({ params: { slot } }: Props) 
     }, [clusterInfo, slotNumber]);
 
     // Fetch block on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {
             fetchBlock(slotNumber);
         }

--- a/app/block/[slot]/programs/page-client.tsx
+++ b/app/block/[slot]/programs/page-client.tsx
@@ -5,7 +5,7 @@ import { useBlock, useFetchBlock } from '@providers/block';
 import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { notFound } from 'next/navigation';
-import React from 'react';
+import { useEffect } from 'react';
 
 type Props = Readonly<{ params: { slot: string } }>;
 
@@ -18,7 +18,7 @@ export default function BlockProgramsTab({ params: { slot } }: Props) {
     const fetchBlock = useFetchBlock();
     const { status } = useCluster();
     // Fetch block on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {
             fetchBlock(slotNumber);
         }

--- a/app/block/[slot]/rewards/page-client.tsx
+++ b/app/block/[slot]/rewards/page-client.tsx
@@ -5,7 +5,7 @@ import { useBlock, useFetchBlock } from '@providers/block';
 import { useCluster } from '@providers/cluster';
 import { ClusterStatus } from '@utils/cluster';
 import { notFound } from 'next/navigation';
-import React from 'react';
+import { useEffect } from 'react';
 
 type Props = Readonly<{ params: { slot: string } }>;
 
@@ -18,7 +18,7 @@ export default function BlockRewardsTabClient({ params: { slot } }: Props) {
     const fetchBlock = useFetchBlock();
     const { status } = useCluster();
     // Fetch block on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!confirmedBlock && status === ClusterStatus.Connected) {
             fetchBlock(slotNumber);
         }

--- a/app/components/ClusterModal.tsx
+++ b/app/components/ClusterModal.tsx
@@ -14,7 +14,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Trash2 } from 'react-feather';
 
 import { Overlay } from './common/Overlay';
@@ -74,16 +74,16 @@ function CustomClusterInput({ status, active, savedClusters }: InputProps) {
     const { customUrl } = useCluster();
     const updateCustomUrl = useUpdateCustomUrl();
     const addSavedCluster = useSetAtom(addSavedClusterAtom);
-    const [editing, setEditing] = React.useState(false);
-    const [saving, setSaving] = React.useState(false);
-    const [savedName, setSavedName] = React.useState('');
-    const [saveError, setSaveError] = React.useState<Error | undefined>(undefined);
-    const [localUrl, setLocalUrl] = React.useState(customUrl);
+    const [editing, setEditing] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [savedName, setSavedName] = useState('');
+    const [saveError, setSaveError] = useState<Error | undefined>(undefined);
+    const [localUrl, setLocalUrl] = useState(customUrl);
     const searchParams = useSearchParams();
     const pathname = usePathname();
     const router = useRouter();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!editing) setLocalUrl(customUrl);
     }, [customUrl, editing]);
 

--- a/app/components/LiveTransactionStatsCard.tsx
+++ b/app/components/LiveTransactionStatsCard.tsx
@@ -6,7 +6,7 @@ import { ClusterStatsStatus, PERF_UPDATE_SEC, usePerformanceInfo } from '@provid
 import { PerformanceInfo } from '@providers/stats/solanaPerformanceInfo';
 import { BarElement, CategoryScale, Chart, ChartData, ChartOptions, LinearScale, Tooltip } from 'chart.js';
 import classNames from 'classnames';
-import React from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import CountUp from 'react-countup';
 
@@ -31,7 +31,7 @@ const SERIES_INFO = {
 };
 
 export function LiveTransactionStatsCard() {
-    const [series, setSeries] = React.useState<Series>('short');
+    const [series, setSeries] = useState<Series>('short');
     return (
         <div className="card flex-grow-1 d-flex flex-column">
             <div className="card-header">
@@ -154,7 +154,7 @@ function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
     const averageTps = Math.round(avgTps != null ? avgTps : 0.0).toLocaleString('en-US');
     const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
     const seriesData = perfHistory[series];
-    const chartOptions = React.useMemo<ChartOptions<'bar'>>(() => TPS_CHART_OPTIONS(historyMaxTps), [historyMaxTps]);
+    const chartOptions = useMemo<ChartOptions<'bar'>>(() => TPS_CHART_OPTIONS(historyMaxTps), [historyMaxTps]);
 
     const seriesLength = seriesData.length;
     const chartData: ChartData<'bar'> = {
@@ -227,8 +227,8 @@ function TpsBarChart({ performanceInfo, series, setSeries }: TpsBarChartProps) {
 }
 
 function AnimatedTransactionCount({ info }: { info: PerformanceInfo }) {
-    const txCountRef = React.useRef(0);
-    const countUpRef = React.useRef({ lastUpdate: 0, period: 0, start: 0 });
+    const txCountRef = useRef(0);
+    const countUpRef = useRef({ lastUpdate: 0, period: 0, start: 0 });
     const countUp = countUpRef.current;
 
     const { transactionCount, avgTps } = info;

--- a/app/components/StatsNotReady.tsx
+++ b/app/components/StatsNotReady.tsx
@@ -1,6 +1,6 @@
 import { useCluster } from '@providers/cluster';
 import { useStatsProvider } from '@providers/stats/solanaClusterStats';
-import React from 'react';
+import { useEffect } from 'react';
 import { RefreshCw } from 'react-feather';
 
 const CLUSTER_STATS_TIMEOUT = 5000;
@@ -9,7 +9,7 @@ export function StatsNotReady({ error }: { error: boolean }) {
     const { setTimedOut, retry, active } = useStatsProvider();
     const { cluster } = useCluster();
 
-    React.useEffect(() => {
+    useEffect(() => {
         let timedOut: NodeJS.Timeout;
         if (!error) {
             timedOut = setTimeout(setTimedOut, CLUSTER_STATS_TIMEOUT);

--- a/app/components/SupplyCard.tsx
+++ b/app/components/SupplyCard.tsx
@@ -3,14 +3,14 @@ import { LoadingCard } from '@components/common/LoadingCard';
 import { SolBalance } from '@components/common/SolBalance';
 import { TableCardBody } from '@components/common/TableCardBody';
 import { Status, useFetchSupply, useSupply } from '@providers/supply';
-import React from 'react';
+import { useEffect } from 'react';
 
 export function SupplyCard() {
     const supply = useSupply();
     const fetchSupply = useFetchSupply();
 
     // Fetch supply on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (supply === Status.Idle) fetchSupply();
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/components/account/CompressedNFTInfoCard.tsx
+++ b/app/components/account/CompressedNFTInfoCard.tsx
@@ -2,7 +2,7 @@ import { Account, useAccountInfo, useFetchAccountInfo } from '@providers/account
 import { cn } from '@shared/utils';
 import { ConcurrentMerkleTreeAccount, MerkleTree } from '@solana/spl-account-compression';
 import { PublicKey } from '@solana/web3.js';
-import React from 'react';
+import { useEffect } from 'react';
 
 import { useCluster } from '@/app/providers/cluster';
 import {
@@ -33,7 +33,7 @@ function DasCompressionInfoCard({ proof, compressedNft }: { proof: CompressedNft
     const treeAccountInfo = useAccountInfo(compressedInfo.tree);
     const treeAddress = new PublicKey(compressedInfo.tree);
 
-    React.useEffect(() => {
+    useEffect(() => {
         fetchAccountInfo(treeAddress, 'raw');
     }, [compressedInfo.tree]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/components/account/MetaplexNFTAttributesCard.tsx
+++ b/app/components/account/MetaplexNFTAttributesCard.tsx
@@ -1,7 +1,7 @@
 import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { Account, isTokenProgramData } from '@providers/accounts';
-import React from 'react';
+import { useEffect, useState } from 'react';
 
 import { getProxiedUri } from '@/app/features/metadata/utils';
 import { useCluster } from '@/app/providers/cluster';
@@ -27,8 +27,8 @@ export function MetaplexNFTAttributesCard({ account, onNotFound }: { account?: A
 }
 
 function NormalMetaplexNFTAttributesCard({ metadataUri }: { metadataUri: string }) {
-    const [attributes, setAttributes] = React.useState<Attribute[]>([]);
-    const [status, setStatus] = React.useState<'loading' | 'success' | 'error'>('loading');
+    const [attributes, setAttributes] = useState<Attribute[]>([]);
+    const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
 
     async function fetchMetadataAttributes() {
         try {
@@ -56,7 +56,7 @@ function NormalMetaplexNFTAttributesCard({ metadataUri }: { metadataUri: string 
         }
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         fetchMetadataAttributes();
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/components/account/MetaplexNFTHeader.tsx
+++ b/app/components/account/MetaplexNFTHeader.tsx
@@ -6,7 +6,7 @@ import { NFTData, useFetchAccountInfo, useMintAccountInfo } from '@providers/acc
 import { PublicKey } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React, { createRef } from 'react';
+import { createRef, useEffect } from 'react';
 import { AlertOctagon, Check, ChevronDown } from 'react-feather';
 import useAsyncEffect from 'use-async-effect';
 
@@ -17,7 +17,7 @@ export function MetaplexNFTHeader({ nftData, address }: { nftData: NFTData; addr
     const collectionMintInfo = useMintAccountInfo(collectionAddress?.toString());
     const fetchAccountInfo = useFetchAccountInfo();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (collectionAddress && !collectionMintInfo) {
             fetchAccountInfo(new PublicKey(collectionAddress.toString()), 'parsed');
         }

--- a/app/components/account/OwnedTokensCard.tsx
+++ b/app/components/account/OwnedTokensCard.tsx
@@ -16,7 +16,7 @@ import { BigNumber } from 'bignumber.js';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronDown } from 'react-feather';
 
 import { getProxiedUri } from '@/app/features/metadata/utils';
@@ -41,12 +41,12 @@ export function OwnedTokensCard({ address }: { address: string }) {
     const ownedTokens = useAccountOwnedTokens(address);
     const fetchAccountTokens = useFetchAccountOwnedTokens();
     const refresh = () => fetchAccountTokens(pubkey);
-    const [showDropdown, setDropdown] = React.useState(false);
-    const [visibleCount, setVisibleCount] = React.useState(INITIAL_VISIBLE_COUNT);
+    const [showDropdown, setDropdown] = useState(false);
+    const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
     const display = useQueryDisplay();
 
     // Fetch owned tokens
-    React.useEffect(() => {
+    useEffect(() => {
         if (!ownedTokens) refresh();
     }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/components/account/RewardsCard.tsx
+++ b/app/components/account/RewardsCard.tsx
@@ -9,17 +9,17 @@ import { useFetchRewards, useRewards } from '@providers/accounts/rewards';
 import { FetchStatus } from '@providers/cache';
 import { PublicKey } from '@solana/web3.js';
 import { lamportsToSolString } from '@utils/index';
-import React from 'react';
+import { useEffect, useMemo } from 'react';
 
 const U64_MAX = BigInt('0xffffffffffffffff');
 
 export function RewardsCard({ address }: { address: string }) {
-    const pubkey = React.useMemo(() => new PublicKey(address), [address]);
+    const pubkey = useMemo(() => new PublicKey(address), [address]);
     const info = useAccountInfo(address);
     const account = info?.data;
     const parsedData = account?.data.parsed;
 
-    const highestEpoch = React.useMemo(() => {
+    const highestEpoch = useMemo(() => {
         if (!parsedData) return;
         if (parsedData.program !== 'stake') return;
         const stakeInfo = parsedData.parsed.info.stake;
@@ -32,7 +32,7 @@ export function RewardsCard({ address }: { address: string }) {
     const fetchRewards = useFetchRewards();
     const loadMore = () => fetchRewards(pubkey, highestEpoch);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!rewards) {
             fetchRewards(pubkey, highestEpoch);
         }

--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -27,7 +27,7 @@ import { getTokenProgramInstructionName } from '@utils/instruction';
 import { displayAddress, intoTransactionInstruction } from '@utils/tx';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
-import React, { useCallback } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown, MinusSquare, PlusSquare } from 'react-feather';
 
 import { INITIAL_TOKENS_TO_FETCH, INITIAL_VISIBLE_COUNT, LOAD_MORE_COUNT } from '@/app/features/token-history/config';
@@ -75,12 +75,12 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     const accountHistories = useAccountHistories();
     const fetchAccountHistory = useFetchAccountHistory();
     const transactionDetailsCache = useTransactionDetailsCache();
-    const [showDropdown, setDropdown] = React.useState(false);
-    const [tokensToFetchCount, setTokensToFetchCount] = React.useState(INITIAL_TOKENS_TO_FETCH);
-    const [visibleTxCount, setVisibleTxCount] = React.useState(INITIAL_VISIBLE_COUNT);
+    const [showDropdown, setDropdown] = useState(false);
+    const [tokensToFetchCount, setTokensToFetchCount] = useState(INITIAL_TOKENS_TO_FETCH);
+    const [visibleTxCount, setVisibleTxCount] = useState(INITIAL_VISIBLE_COUNT);
     const filter = useQueryFilter();
 
-    const filteredTokens = React.useMemo(
+    const filteredTokens = useMemo(
         () =>
             tokens.filter(token => {
                 if (filter === ALL_TOKENS) {
@@ -92,12 +92,12 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     );
 
     // Slice tokens - this controls what gets fetched
-    const tokensToFetch = React.useMemo(
+    const tokensToFetch = useMemo(
         () => filteredTokens.slice(0, tokensToFetchCount),
         [filteredTokens, tokensToFetchCount],
     );
 
-    const fetchHistories = React.useCallback(
+    const fetchHistories = useCallback(
         (refresh?: boolean) => {
             tokensToFetch.forEach(token => {
                 fetchAccountHistory(token.pubkey, false, refresh);
@@ -107,8 +107,8 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     );
 
     // Fetch histories when tokensToFetch expands (user clicks Load More)
-    const prevTokensToFetchCount = React.useRef(0);
-    React.useEffect(() => {
+    const prevTokensToFetchCount = useRef(0);
+    useEffect(() => {
         if (prevTokensToFetchCount.current < tokensToFetchCount) {
             // Only fetch newly added tokens
             const newTokens = tokensToFetch.slice(prevTokensToFetchCount.current);
@@ -356,7 +356,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
     );
 };
 
-const TokenTransactionRow = React.memo(function TokenTransactionRow({
+const TokenTransactionRow = memo(function TokenTransactionRow({
     mint,
     tx,
     details,
@@ -399,7 +399,7 @@ const TokenTransactionRow = React.memo(function TokenTransactionRow({
 });
 
 function InstructionDetails({ instructionType, tx }: { instructionType: InstructionType; tx: ConfirmedSignatureInfo }) {
-    const [expanded, setExpanded] = React.useState(false);
+    const [expanded, setExpanded] = useState(false);
 
     const instructionTypes = instructionType.innerInstructions
         .map(ix => {
@@ -463,7 +463,7 @@ function InstructionDetailsCell({
     const fetchDetails = useFetchTransactionDetails();
     const { cluster } = useCluster();
 
-    const handleLoadClick = React.useCallback(() => {
+    const handleLoadClick = useCallback(() => {
         fetchDetails(signature);
     }, [fetchDetails, signature]);
 

--- a/app/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
+++ b/app/components/account/address-lookup-table/AddressLookupTableAccountSection.tsx
@@ -6,7 +6,7 @@ import { AccountCard } from '@features/account';
 import { Account } from '@providers/accounts';
 import { AddressLookupTableAccount } from '@solana/web3.js';
 import { AddressLookupTableAccountInfo } from '@validators/accounts/address-lookup-table';
-import React from 'react';
+import { useMemo } from 'react';
 
 export function AddressLookupTableAccountSection(
     params:
@@ -20,7 +20,7 @@ export function AddressLookupTableAccountSection(
           },
 ) {
     const account = params.account;
-    const lookupTableState = React.useMemo(() => {
+    const lookupTableState = useMemo(() => {
         if ('data' in params) {
             return AddressLookupTableAccount.deserialize(params.data);
         } else {

--- a/app/components/account/address-lookup-table/LookupTableEntriesCard.tsx
+++ b/app/components/account/address-lookup-table/LookupTableEntriesCard.tsx
@@ -1,7 +1,7 @@
 import { Address } from '@components/common/Address';
 import { AddressLookupTableAccount, PublicKey } from '@solana/web3.js';
 import { AddressLookupTableAccountInfo } from '@validators/accounts/address-lookup-table';
-import React from 'react';
+import { useMemo } from 'react';
 
 export function LookupTableEntriesCard(
     params:
@@ -12,7 +12,7 @@ export function LookupTableEntriesCard(
               lookupTableAccountData: Uint8Array;
           },
 ) {
-    const lookupTableState = React.useMemo(() => {
+    const lookupTableState = useMemo(() => {
         if ('lookupTableAccountData' in params) {
             return AddressLookupTableAccount.deserialize(params.lookupTableAccountData);
         } else {

--- a/app/components/account/history/TokenInstructionsCard.tsx
+++ b/app/components/account/history/TokenInstructionsCard.tsx
@@ -9,7 +9,7 @@ import { useFetchAccountHistory } from '@providers/accounts/history';
 import { FetchStatus } from '@providers/cache';
 import { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
 import { getTokenInstructionName, InstructionContainer } from '@utils/instruction';
-import React, { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import Moment from 'react-moment';
 
 import { getTransactionRows, HistoryCardFooter, HistoryCardHeader } from '../HistoryCardComponents';
@@ -22,20 +22,20 @@ export function TokenInstructionsCard({ address }: { address: string }) {
     const refresh = () => fetchAccountHistory(pubkey, true, true);
     const loadMore = () => fetchAccountHistory(pubkey, true);
 
-    const transactionRows = React.useMemo(() => {
+    const transactionRows = useMemo(() => {
         if (history?.data?.fetched) {
             return getTransactionRows(history.data.fetched);
         }
         return [];
     }, [history]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!history || !history.data?.transactionMap?.size) {
             refresh();
         }
     }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const { hasTimestamps, detailsList } = React.useMemo(() => {
+    const { hasTimestamps, detailsList } = useMemo(() => {
         const detailedHistoryMap = history?.data?.transactionMap || new Map<string, ParsedTransactionWithMeta>();
         const hasTimestamps = transactionRows.some(element => element.blockTime);
         const detailsList: React.ReactNode[] = [];

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -15,7 +15,7 @@ import { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstructi
 import { Cluster } from '@utils/cluster';
 import { normalizeTokenAmount } from '@utils/index';
 import { InstructionContainer } from '@utils/instruction';
-import React, { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import Moment from 'react-moment';
 import { create } from 'superstruct';
 import useSWR from 'swr';
@@ -104,20 +104,20 @@ export function TokenTransfersCard({ address }: { address: string }) {
     const swrKey = useMemo(() => getTokenInfoSwrKey(address, cluster, url), [address, cluster, url]);
     const { data: tokenInfo, isLoading: tokenInfoLoading } = useSWR(swrKey, fetchTokenInfo);
 
-    const transactionRows = React.useMemo(() => {
+    const transactionRows = useMemo(() => {
         if (history?.data?.fetched) {
             return getTransactionRows(history.data.fetched);
         }
         return [];
     }, [history]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!history || !history.data?.transactionMap?.size) {
             refresh();
         }
     }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const { allTransfers, hasTimestamps } = React.useMemo(() => {
+    const { allTransfers, hasTimestamps } = useMemo(() => {
         const detailedHistoryMap = history?.data?.transactionMap || new Map<string, ParsedTransactionWithMeta>();
         const hasTimestamps = transactionRows.some(element => element.blockTime);
         const mintMap = new Map<string, MintDetails>();

--- a/app/components/account/sas/AttestationDataCard.tsx
+++ b/app/components/account/sas/AttestationDataCard.tsx
@@ -1,5 +1,5 @@
 import { Account, useAccountInfo, useFetchAccountInfo } from '@providers/accounts';
-import React from 'react';
+import { useEffect } from 'react';
 import {
     Attestation as SasAttestation,
     convertSasSchemaToBorshSchema,
@@ -55,7 +55,7 @@ function SchemaCard({ schema }: { schema: SasSchema }) {
 function AttestationCard({ attestation }: { attestation: SasAttestation }) {
     const schemaAccountInfo = useAccountInfo(mapToPublicKey(attestation.schema).toBase58());
     const fetchAccountInfo = useFetchAccountInfo();
-    React.useEffect(() => {
+    useEffect(() => {
         if (!schemaAccountInfo?.data) {
             fetchAccountInfo(mapToPublicKey(attestation.schema), 'parsed');
         }

--- a/app/components/block/BlockAccountsCard.tsx
+++ b/app/components/block/BlockAccountsCard.tsx
@@ -2,7 +2,7 @@ import { Address } from '@components/common/Address';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React from 'react';
+import { useMemo, useState } from 'react';
 
 import { invariant } from '@/app/shared/lib/invariant';
 
@@ -14,10 +14,10 @@ type AccountStats = {
 const PAGE_SIZE = 25;
 
 export function BlockAccountsCard({ block, blockSlot }: { block: VersionedBlockResponse; blockSlot: number }) {
-    const [numDisplayed, setNumDisplayed] = React.useState(10);
+    const [numDisplayed, setNumDisplayed] = useState(10);
     const totalTransactions = block.transactions.length;
 
-    const accountStats = React.useMemo(() => {
+    const accountStats = useMemo(() => {
         const statsMap = new Map<string, AccountStats>();
         block.transactions.forEach(tx => {
             const message = tx.transaction.message;

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -17,7 +17,7 @@ import { displayAddress } from '@utils/tx';
 import { pickClusterParams } from '@utils/url';
 import Link from 'next/link';
 import { ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { createRef, useMemo } from 'react';
+import { createRef, useMemo, useState } from 'react';
 import { ChevronDown } from 'react-feather';
 import useAsyncEffect from 'use-async-effect';
 
@@ -64,7 +64,7 @@ type TransactionWithInvocations = {
 };
 
 export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockResponse; epoch: bigint | undefined }) {
-    const [numDisplayed, setNumDisplayed] = React.useState(PAGE_SIZE);
+    const [numDisplayed, setNumDisplayed] = useState(PAGE_SIZE);
     const currentPathname = usePathname();
     const currentSearchParams = useSearchParams();
     const programFilter = useQueryProgramFilter(currentSearchParams);
@@ -73,7 +73,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
     const router = useRouter();
     const { cluster } = useCluster();
 
-    const { transactions, invokedPrograms } = React.useMemo(() => {
+    const { transactions, invokedPrograms } = useMemo(() => {
         const invokedPrograms = new Map<string, number>();
 
         const transactions: TransactionWithInvocations[] = block.transactions.map((tx, index) => {
@@ -144,7 +144,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
         return { invokedPrograms, transactions };
     }, [block, cluster, epoch]);
 
-    const [filteredTransactions, showComputeUnits] = React.useMemo((): [TransactionWithInvocations[], boolean] => {
+    const [filteredTransactions, showComputeUnits] = useMemo((): [TransactionWithInvocations[], boolean] => {
         const voteFilter = VOTE_PROGRAM_ID.toBase58();
         const filteredTxs: TransactionWithInvocations[] = transactions
             .filter(({ invocations }) => {

--- a/app/components/block/BlockRewardsCard.tsx
+++ b/app/components/block/BlockRewardsCard.tsx
@@ -1,12 +1,12 @@
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
 import { PublicKey, VersionedBlockResponse } from '@solana/web3.js';
-import React from 'react';
+import { useState } from 'react';
 
 const PAGE_SIZE = 10;
 
 export function BlockRewardsCard({ block }: { block: VersionedBlockResponse }) {
-    const [rewardsDisplayed, setRewardsDisplayed] = React.useState(PAGE_SIZE);
+    const [rewardsDisplayed, setRewardsDisplayed] = useState(PAGE_SIZE);
 
     if (!block.rewards || block.rewards.length < 1) {
         return null;

--- a/app/components/common/BaseInstructionCard.tsx
+++ b/app/components/common/BaseInstructionCard.tsx
@@ -4,7 +4,7 @@ import { CollapsibleCard } from '@shared/ui/collapsible-card';
 import { cn } from '@shared/utils';
 import { ParsedInstruction, SignatureResult, TransactionInstruction } from '@solana/web3.js';
 import getInstructionCardScrollAnchorId from '@utils/get-instruction-card-scroll-anchor-id';
-import React from 'react';
+import { useState } from 'react';
 import { Code } from 'react-feather';
 
 import { BaseRawDetails } from './BaseRawDetails';
@@ -46,7 +46,7 @@ export function BaseInstructionCard({
     collapsible = false,
 }: InstructionProps) {
     const [resultClass] = ixResult(result, index);
-    const [showRaw, setShowRaw] = React.useState(defaultRaw || false);
+    const [showRaw, setShowRaw] = useState(defaultRaw || false);
     const rawClickHandler = () => {
         if (!defaultRaw && !showRaw && !raw) {
             // trigger handler to simulate behaviour for the InstructionCard for the transcation which contains logic in it to fetch raw transaction data

--- a/app/components/common/InspectorInstructionCard.tsx
+++ b/app/components/common/InspectorInstructionCard.tsx
@@ -4,7 +4,7 @@ import { CollapsibleCard } from '@shared/ui/collapsible-card';
 import { cn } from '@shared/utils';
 import { ParsedInstruction, SignatureResult, TransactionInstruction, VersionedMessage } from '@solana/web3.js';
 import getInstructionCardScrollAnchorId from '@utils/get-instruction-card-scroll-anchor-id';
-import React from 'react';
+import { useState } from 'react';
 import { Code } from 'react-feather';
 
 import { BaseRawDetails } from './BaseRawDetails';
@@ -41,7 +41,7 @@ export function InspectorInstructionCard({
     onRequestRaw,
 }: InstructionProps) {
     const [resultClass] = ixResult(result, index);
-    const [showRaw, setShowRaw] = React.useState(defaultRaw || false);
+    const [showRaw, setShowRaw] = useState(defaultRaw || false);
     const rawClickHandler = () => {
         if (!defaultRaw && !showRaw && !raw) {
             // trigger handler to simulate behaviour for the InstructionCard for the transcation which contains logic in it to fetch raw transaction data

--- a/app/components/common/InstructionDetails.tsx
+++ b/app/components/common/InstructionDetails.tsx
@@ -1,7 +1,7 @@
 import { isTokenProgramData } from '@providers/accounts';
 import { ConfirmedSignatureInfo } from '@solana/web3.js';
 import { getTokenProgramInstructionName, InstructionType } from '@utils/instruction';
-import React from 'react';
+import { useState } from 'react';
 import { MinusSquare, PlusSquare } from 'react-feather';
 
 export function InstructionDetails({
@@ -11,7 +11,7 @@ export function InstructionDetails({
     instructionType: InstructionType;
     tx: ConfirmedSignatureInfo;
 }) {
-    const [expanded, setExpanded] = React.useState(false);
+    const [expanded, setExpanded] = useState(false);
 
     const instructionTypes = instructionType.innerInstructions
         .map(ix => {

--- a/app/components/inspector/AccountsCard.tsx
+++ b/app/components/inspector/AccountsCard.tsx
@@ -5,7 +5,7 @@ import { type AccountInfo, useAccountsInfo } from '@entities/account';
 import { useCluster } from '@providers/cluster';
 import { CollapsibleCard } from '@shared/ui/collapsible-card';
 import { PublicKey, VersionedMessage } from '@solana/web3.js';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { toHex } from '@/app/shared/lib/bytes';
 
@@ -17,7 +17,7 @@ export function AccountsCard({ message }: { message: VersionedMessage }) {
     const pubkeys = useMemo(() => message.staticAccountKeys, [message.staticAccountKeys]);
     const { accounts, error: fetchError, loading } = useAccountsInfo(pubkeys, url);
 
-    const { validMessage, error } = React.useMemo(() => {
+    const { validMessage, error } = useMemo(() => {
         const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = message.header;
 
         if (numReadonlySignedAccounts >= numRequiredSignatures) {
@@ -34,7 +34,7 @@ export function AccountsCard({ message }: { message: VersionedMessage }) {
         };
     }, [message]);
 
-    const { accountRows, numAccounts } = React.useMemo(() => {
+    const { accountRows, numAccounts } = useMemo(() => {
         const message = validMessage;
         if (!message) return { accountRows: undefined, numAccounts: 0 };
         const staticAccountRows = message.staticAccountKeys.map((publicKey, accountIndex) => {
@@ -98,7 +98,7 @@ export function AccountsCard({ message }: { message: VersionedMessage }) {
         };
     }, [accounts, loading, validMessage]);
 
-    const totalAccountSize = React.useMemo(
+    const totalAccountSize = useMemo(
         () => Array.from(accounts.values()).reduce((acc, account) => acc + account.size, 0),
         [accounts],
     );

--- a/app/components/inspector/AddressTableLookupsCard.tsx
+++ b/app/components/inspector/AddressTableLookupsCard.tsx
@@ -3,10 +3,10 @@ import { useAddressLookupTable } from '@providers/accounts';
 import { FetchStatus } from '@providers/cache';
 import { CollapsibleCard } from '@shared/ui/collapsible-card';
 import { PublicKey, VersionedMessage } from '@solana/web3.js';
-import React from 'react';
+import { useMemo } from 'react';
 
 export function AddressTableLookupsCard({ message }: { message: VersionedMessage }) {
-    const lookupRows = React.useMemo(() => {
+    const lookupRows = useMemo(() => {
         let key = 0;
         return message.addressTableLookups.flatMap(lookup => {
             const indexes = [

--- a/app/components/inspector/AddressWithContext.tsx
+++ b/app/components/inspector/AddressWithContext.tsx
@@ -5,7 +5,7 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import { ClusterStatus } from '@utils/cluster';
 import { lamportsToSolString } from '@utils/index';
 import { addressLabel } from '@utils/tx';
-import React from 'react';
+import { useEffect } from 'react';
 
 type AccountValidator = (account: Account) => string | undefined;
 
@@ -83,7 +83,7 @@ function AccountInfo({ pubkey, validator }: { pubkey: PublicKey; validator?: Acc
     const { cluster, status } = useCluster();
 
     // Fetch account on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!info && status === ClusterStatus.Connected && pubkey) {
             fetchAccount(pubkey, 'skip');
         }

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -21,7 +21,7 @@ import { generated, PROGRAM_ADDRESS as SQUADS_V4_PROGRAM_ADDRESS } from '@sqds/m
 import { useClusterPath } from '@utils/url';
 import bs58 from 'bs58';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useSWR from 'swr';
 
 import { useCluster } from '@/app/providers/cluster';
@@ -176,7 +176,7 @@ function decodeUrlParams(
 function SquadsProposalInspectorCard({ account, onClear }: { account: string; onClear: () => void }) {
     const { url } = useCluster();
 
-    const fetcher = React.useCallback(async () => {
+    const fetcher = useCallback(async () => {
         const connection = new Connection(url);
         try {
             // First check if the account exists and is owned by the Squads program
@@ -273,15 +273,15 @@ export function TransactionInspectorPage({
     signature?: string;
     showTokenBalanceChanges: boolean;
 }) {
-    const [inspectorData, setInspectorData] = React.useState<InspectorData>();
+    const [inspectorData, setInspectorData] = useState<InspectorData>();
     const currentSearchParams = useSearchParams();
     const currentPathname = usePathname();
     const router = useRouter();
-    const [paramString, setParamString] = React.useState<string>();
+    const [paramString, setParamString] = useState<string>();
 
     // Sync message with url search params
     const prevInspectorData = usePrevious(inspectorData);
-    React.useEffect(() => {
+    useEffect(() => {
         if (signature) return;
         if (inspectorData && inspectorData !== prevInspectorData) {
             if (isSquadsProposalAccountData(inspectorData)) {
@@ -319,7 +319,7 @@ export function TransactionInspectorPage({
         }
     }, [currentPathname, currentSearchParams, prevInspectorData, router, signature, inspectorData]);
 
-    const reset = React.useCallback(() => {
+    const reset = useCallback(() => {
         const nextQueryParams = new URLSearchParams(currentSearchParams?.toString());
         nextQueryParams.delete('message');
         nextQueryParams.delete('signatures');
@@ -329,7 +329,7 @@ export function TransactionInspectorPage({
     }, [currentPathname, currentSearchParams, router]);
 
     // Decode the message url param whenever it changes
-    React.useEffect(() => {
+    useEffect(() => {
         const [result, nextParams, refreshUrl] = decodeUrlParams(new URLSearchParams(currentSearchParams?.toString()));
         if (refreshUrl) {
             const queryString = nextParams.toString();
@@ -385,12 +385,12 @@ function PermalinkView({
     const transaction = details?.data?.raw;
     const inspectorPath = useClusterPath({ pathname: '/tx/inspector' });
     const router = useRouter();
-    const reset = React.useCallback(() => {
+    const reset = useCallback(() => {
         router.push(inspectorPath);
     }, [inspectorPath, router]);
 
     // Fetch details on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!details) fetchTransaction(signature);
     }, [signature, details, fetchTransaction]);
 
@@ -425,7 +425,7 @@ function LoadedView({
     const { message, rawMessage, signatures, accountBalances, compiledInnerInstructions } = transaction;
 
     const fetchAccountInfo = useFetchAccountInfo();
-    React.useEffect(() => {
+    useEffect(() => {
         for (const lookup of message.addressTableLookups) {
             fetchAccountInfo(lookup.accountKey, 'parsed');
         }
@@ -465,7 +465,7 @@ function OverviewCard({
     const fee = message.header.numRequiredSignatures * DEFAULT_FEES.lamportsPerSignature;
     const feePayerValidator = createFeePayerValidator(fee);
 
-    const size = React.useMemo(() => {
+    const size = useMemo(() => {
         const sigBytes = 1 + 64 * message.header.numRequiredSignatures;
         return sigBytes + raw.length;
     }, [message, raw]);

--- a/app/components/inspector/RawInputCard.tsx
+++ b/app/components/inspector/RawInputCard.tsx
@@ -2,7 +2,7 @@ import { cn } from '@shared/utils';
 import { PublicKey, VersionedMessage } from '@solana/web3.js';
 import base58 from 'bs58';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 import { MIN_MESSAGE_LENGTH, parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
@@ -43,7 +43,7 @@ type TabData = {
 };
 
 function TabInstructions() {
-    const [activeTab, setActiveTab] = React.useState('cli');
+    const [activeTab, setActiveTab] = useState('cli');
 
     const tabs: TabData[] = [
         {
@@ -134,14 +134,14 @@ export function RawInput({
     value?: string;
     setTransactionData: (param: InspectorData | undefined) => void;
 }) {
-    const rawInput = React.useRef<HTMLTextAreaElement>(null);
-    const [error, setError] = React.useState<string>();
-    const [rows, setRows] = React.useState(3);
+    const rawInput = useRef<HTMLTextAreaElement>(null);
+    const [error, setError] = useState<string>();
+    const [rows, setRows] = useState(3);
     const currentPathname = usePathname();
     const currentSearchParams = useSearchParams();
     const router = useRouter();
 
-    const onInput = React.useCallback(() => {
+    const onInput = useCallback(() => {
         const input = rawInput.current?.value;
         if (!input) {
             setError(undefined);
@@ -211,7 +211,7 @@ export function RawInput({
         }
     }, [currentSearchParams, router, currentPathname, setTransactionData]);
 
-    const clearInput = React.useCallback(() => {
+    const clearInput = useCallback(() => {
         if (rawInput.current) {
             rawInput.current.value = '';
             setError(undefined);
@@ -228,7 +228,7 @@ export function RawInput({
         }
     }, [currentSearchParams, router, currentPathname, setTransactionData]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const input = rawInput.current;
         if (input && value) {
             input.value = value;

--- a/app/components/inspector/SignaturesCard.tsx
+++ b/app/components/inspector/SignaturesCard.tsx
@@ -2,7 +2,7 @@ import { Address } from '@components/common/Address';
 import { Signature } from '@components/common/Signature';
 import { PublicKey, VersionedMessage } from '@solana/web3.js';
 import bs58 from 'bs58';
-import React from 'react';
+import { useMemo } from 'react';
 import * as nacl from 'tweetnacl';
 
 export function TransactionSignatures({
@@ -14,7 +14,7 @@ export function TransactionSignatures({
     message: VersionedMessage;
     rawMessage: Uint8Array;
 }) {
-    const signatureRows = React.useMemo(() => {
+    const signatureRows = useMemo(() => {
         return signatures.map((signature, index) => {
             const publicKey = message.staticAccountKeys[index];
 

--- a/app/components/instruction/SerumDetailsCard.tsx
+++ b/app/components/instruction/SerumDetailsCard.tsx
@@ -1,6 +1,6 @@
 import { useCluster } from '@providers/cluster';
 import { SignatureResult, TransactionInstruction } from '@solana/web3.js';
-import React from 'react';
+import { useMemo } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -53,7 +53,7 @@ export function SerumDetailsCard(initialProps: {
 }) {
     const { ix, index, result, signature, innerCards, childIndex } = initialProps;
 
-    const props = React.useMemo(() => {
+    const props = useMemo(() => {
         const programName = initialProps.ix.programId.toBase58() === OPEN_BOOK_PROGRAM_ID ? 'OpenBook' : 'Serum';
         return { ...initialProps, programName };
     }, [initialProps]);

--- a/app/components/instruction/token/TokenDetailsCard.tsx
+++ b/app/components/instruction/token/TokenDetailsCard.tsx
@@ -9,7 +9,7 @@ import {
 } from '@solana/web3.js';
 import { normalizeTokenAmount } from '@utils/index';
 import { ParsedInfo } from '@validators/index';
-import React, { ComponentType } from 'react';
+import { ComponentType, useEffect, useMemo } from 'react';
 import { create } from 'superstruct';
 import useSWR from 'swr';
 
@@ -63,7 +63,7 @@ function TokenInstruction({
     title,
     ...props
 }: InfoProps) {
-    const { mintAddress: infoMintAddress, tokenAddress } = React.useMemo(() => {
+    const { mintAddress: infoMintAddress, tokenAddress } = useMemo(() => {
         let mintAddress: string | undefined;
         let tokenAddress: string | undefined;
 
@@ -88,13 +88,13 @@ function TokenInstruction({
     const mintInfo = useMintAccountInfo(mintAddress);
     const fetchAccountInfo = useFetchAccountInfo();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (tokenAddress && !tokenInfo) {
             fetchAccountInfo(new PublicKey(tokenAddress), 'parsed');
         }
     }, [fetchAccountInfo, tokenAddress]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (mintAddress && !mintInfo) {
             fetchAccountInfo(new PublicKey(mintAddress), 'parsed');
         }

--- a/app/components/shared/ui/switch.stories.tsx
+++ b/app/components/shared/ui/switch.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import * as React from 'react';
+import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 
 import { Switch } from './switch';
@@ -98,7 +98,7 @@ export const WithLabel: Story = {
 export const Controlled: Story = {
     render: () => {
         const ControlledSwitch = () => {
-            const [checked, setChecked] = React.useState(false);
+            const [checked, setChecked] = useState(false);
 
             return (
                 <div className="e-flex e-flex-col e-gap-4">

--- a/app/components/shared/ui/tabs.stories.tsx
+++ b/app/components/shared/ui/tabs.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import * as React from 'react';
+import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
@@ -140,7 +140,7 @@ export const WithLongContent: Story = {
 export const Controlled: Story = {
     render: () => {
         const ControlledTabs = () => {
-            const [value, setValue] = React.useState('tab1');
+            const [value, setValue] = useState('tab1');
 
             return (
                 <div className="e-space-y-4">

--- a/app/components/transaction/ProgramLogSection.tsx
+++ b/app/components/transaction/ProgramLogSection.tsx
@@ -5,11 +5,11 @@ import { useTransactionDetails } from '@providers/transactions';
 import { cn } from '@shared/utils';
 import { SignatureProps } from '@utils/index';
 import { parseProgramLogs } from '@utils/program-logs';
-import React from 'react';
+import { useState } from 'react';
 import { Code } from 'react-feather';
 
 export function ProgramLogSection({ signature }: SignatureProps) {
-    const [showRaw, setShowRaw] = React.useState(false);
+    const [showRaw, setShowRaw] = useState(false);
     const { cluster, url } = useCluster();
     const details = useTransactionDetails(signature);
 

--- a/app/entities/compute-unit/ui/CUProfilingCard.tsx
+++ b/app/entities/compute-unit/ui/CUProfilingCard.tsx
@@ -1,6 +1,6 @@
 import { CollapsibleCard } from '@shared/ui/collapsible-card';
 import { BarElement, CategoryScale, Chart, type ChartData, type ChartOptions, LinearScale, Tooltip } from 'chart.js';
-import React from 'react';
+import { useEffect, useMemo } from 'react';
 import { Bar } from 'react-chartjs-2';
 
 import type { InstructionCUData } from '../lib/types';
@@ -184,7 +184,7 @@ type CUProfilingCardProps = {
 };
 
 export function CUProfilingCard({ instructions, unitsConsumed }: CUProfilingCardProps) {
-    const instructionsWithDisplay = React.useMemo(
+    const instructionsWithDisplay = useMemo(
         () =>
             instructions.map(item => ({
                 ...item,
@@ -193,12 +193,12 @@ export function CUProfilingCard({ instructions, unitsConsumed }: CUProfilingCard
         [instructions],
     );
 
-    const totalDisplayCU = React.useMemo(
+    const totalDisplayCU = useMemo(
         () => instructionsWithDisplay.reduce((sum, item) => sum + item.displayCU, 0),
         [instructionsWithDisplay],
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         return () => {
             const tooltipEl = document.getElementById('cu-chartjs-tooltip');
             if (tooltipEl) {
@@ -207,12 +207,12 @@ export function CUProfilingCard({ instructions, unitsConsumed }: CUProfilingCard
         };
     }, []);
 
-    const chartOptions = React.useMemo<ChartOptions<'bar'>>(
+    const chartOptions = useMemo<ChartOptions<'bar'>>(
         () => getCUProfileChartOptions(totalDisplayCU),
         [totalDisplayCU],
     );
 
-    const chartData: ChartData<'bar'> = React.useMemo(
+    const chartData: ChartData<'bar'> = useMemo(
         () => ({
             datasets: instructionsWithDisplay.map((item, i) => ({
                 actualCU: item.computeUnits,

--- a/app/epoch/[epoch]/page-client.tsx
+++ b/app/epoch/[epoch]/page-client.tsx
@@ -10,7 +10,7 @@ import { useCluster } from '@providers/cluster';
 import { useEpoch, useFetchEpoch } from '@providers/epoch';
 import { ClusterStatus } from '@utils/cluster';
 import { displayTimestampUtc } from '@utils/date';
-import React from 'react';
+import { useEffect } from 'react';
 
 import { getFirstSlotInEpoch, getLastSlotInEpoch } from '@/app/utils/epoch-schedule';
 
@@ -50,7 +50,7 @@ function EpochOverviewCard({ epoch }: OverviewProps) {
     const fetchEpoch = useFetchEpoch();
 
     // Fetch extra epoch info on load
-    React.useEffect(() => {
+    useEffect(() => {
         if (!clusterInfo) return;
         const { epochInfo, epochSchedule } = clusterInfo;
         const currentEpoch = epochInfo.epoch;

--- a/app/features/account/ui/BaseAccountCard.tsx
+++ b/app/features/account/ui/BaseAccountCard.tsx
@@ -1,6 +1,6 @@
 import { TableCardBody, type TableCardBodyProps } from '@components/common/TableCardBody';
 import { RefreshButton } from '@shared/ui/refresh-button';
-import React from 'react';
+import { useState } from 'react';
 import { Code } from 'react-feather';
 
 import { Button } from '@/app/components/shared/ui/button';
@@ -24,7 +24,7 @@ export function BaseAccountCard({
     children,
     ...tableProps
 }: BaseAccountCardProps) {
-    const [showRaw, setShowRaw] = React.useState(false);
+    const [showRaw, setShowRaw] = useState(false);
 
     return (
         <div className="card">

--- a/app/features/cu-profiling/ui/CUProfilingSection.tsx
+++ b/app/features/cu-profiling/ui/CUProfilingSection.tsx
@@ -6,7 +6,7 @@ import type { Cluster } from '@utils/cluster';
 import { getEpochForSlot } from '@utils/epoch-schedule';
 import type { SignatureProps } from '@utils/index';
 import { type InstructionLogs, parseProgramLogs } from '@utils/program-logs';
-import React from 'react';
+import { useMemo } from 'react';
 
 export function CUProfilingSection({ signature }: SignatureProps) {
     const details = useTransactionDetails(signature);
@@ -17,12 +17,12 @@ export function CUProfilingSection({ signature }: SignatureProps) {
     const unitsConsumed = transactionWithMeta?.meta?.computeUnitsConsumed || undefined;
     const slot = transactionWithMeta?.slot;
 
-    const instructionLogs: InstructionLogs[] = React.useMemo(
+    const instructionLogs: InstructionLogs[] = useMemo(
         () => formatTransactionLogs(transactionWithMeta, cluster),
         [transactionWithMeta, cluster],
     );
 
-    const instructionsForCU = React.useMemo(() => {
+    const instructionsForCU = useMemo(() => {
         if (!transactionWithMeta || !slot || !clusterInfo) return [];
 
         const epoch = getEpochForSlot(clusterInfo.epochSchedule, BigInt(slot));

--- a/app/features/idl/interactive-idl/ui/Accordion.tsx
+++ b/app/features/idl/interactive-idl/ui/Accordion.tsx
@@ -1,16 +1,16 @@
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { cn } from '@shared/utils';
-import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'react-feather';
 
 const Accordion = AccordionPrimitive.Root;
 const AccordionItem = AccordionPrimitive.Item;
 
 function AccordionTrigger({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
-    const [isOpen, setIsOpen] = React.useState(false);
-    const triggerRef = React.useRef<HTMLButtonElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const triggerRef = useRef<HTMLButtonElement>(null);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const trigger = triggerRef.current;
         if (!trigger) return;
 

--- a/app/features/transaction-history/ui/TransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/TransactionHistoryCard.tsx
@@ -10,7 +10,7 @@ import { useAccountHistory, useFetchAccountHistory } from '@providers/accounts/h
 import { FetchStatus } from '@providers/cache';
 import { PublicKey } from '@solana/web3.js';
 import { displayTimestampUtc } from '@utils/date';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import Moment from 'react-moment';
 
 import { useFetchRawTransaction, useRawTransactionDetails } from '@/app/providers/transactions/raw';
@@ -27,14 +27,14 @@ export function TransactionHistoryCard({ address }: { address: string }) {
     const refresh = () => fetchAccountHistory(pubkey, false, true);
     const loadMore = () => fetchAccountHistory(pubkey, false);
 
-    const transactionRows = React.useMemo(() => {
+    const transactionRows = useMemo(() => {
         if (history?.data?.fetched) {
             return getTransactionRows(history.data.fetched);
         }
         return [];
     }, [history]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!history) {
             refresh();
         }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ import { Status, SupplyProvider, useFetchSupply, useSupply } from '@providers/su
 import { ClusterStatus } from '@utils/cluster';
 import { abbreviatedNumber, lamportsToSol, slotsToHumanString } from '@utils/index';
 import { percentage } from '@utils/math';
-import React from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { DeveloperResources } from './components/DeveloperResources';
 import { SimpleCardSkeleton } from './components/shared/Skeletons';
@@ -71,19 +71,19 @@ function StakingComponent() {
         fetchVoteAccounts();
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (status === ClusterStatus.Connected) {
             fetchData();
         }
     }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const delinquentStake = React.useMemo(() => {
+    const delinquentStake = useMemo(() => {
         if (voteAccounts) {
             return voteAccounts.delinquent.reduce((prev, current) => prev + current.activatedStake, BigInt(0));
         }
     }, [voteAccounts]);
 
-    const activeStake = React.useMemo(() => {
+    const activeStake = useMemo(() => {
         if (voteAccounts && delinquentStake) {
             return (
                 voteAccounts.current.reduce((prev, current) => prev + current.activatedStake, BigInt(0)) +
@@ -168,7 +168,7 @@ function StatsCardBody() {
     const { setActive } = useStatsProvider();
     const { cluster } = useCluster();
 
-    React.useEffect(() => {
+    useEffect(() => {
         setActive(true);
         return () => setActive(false);
     }, [setActive, cluster]);

--- a/app/providers/accounts/history.tsx
+++ b/app/providers/accounts/history.tsx
@@ -14,7 +14,7 @@ import { Cluster } from '@utils/cluster';
 import { fetchAll } from '@utils/fetch-all';
 import { fetchOnce } from '@utils/fetch-once';
 import { withBackoff } from '@utils/with-backoff';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
 
 import { mergeTransactionMap } from '@/app/entities/transaction-data';
 import { Logger } from '@/app/shared/lib/logger';
@@ -102,17 +102,17 @@ function reconcile(history: AccountHistory | undefined, update: HistoryUpdate | 
     };
 }
 
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
-const InFlightContext = React.createContext<Set<string> | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
+const InFlightContext = createContext<Set<string> | undefined>(undefined);
 
 type HistoryProviderProps = { children: React.ReactNode };
 export function HistoryProvider({ children }: HistoryProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useCustomReducer(url, reconcile);
-    const inFlightRef = React.useRef(new Set<string>());
+    const inFlightRef = useRef(new Set<string>());
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
         inFlightRef.current.clear();
     }, [dispatch, url]);
@@ -224,7 +224,7 @@ async function fetchAccountHistory(
 }
 
 export function useAccountHistories() {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useAccountHistories must be used within a AccountsProvider`);
@@ -234,7 +234,7 @@ export function useAccountHistories() {
 }
 
 export function useAccountHistory(address: string): Cache.CacheEntry<AccountHistory> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useAccountHistory must be used within a AccountsProvider`);
@@ -258,14 +258,14 @@ function getUnfetchedSignatures(before: Cache.CacheEntry<AccountHistory>) {
 
 export function useFetchTransactionsForHistory() {
     const { cluster, url } = useCluster();
-    const state = React.useContext(StateContext);
-    const dispatch = React.useContext(DispatchContext);
-    const inFlight = React.useContext(InFlightContext);
+    const state = useContext(StateContext);
+    const dispatch = useContext(DispatchContext);
+    const inFlight = useContext(InFlightContext);
     if (!state || !dispatch || !inFlight) {
         throw new Error(`useFetchTransactionsForHistory must be used within a HistoryProvider`);
     }
 
-    return React.useCallback(
+    return useCallback(
         (pubkey: PublicKey, history: AccountHistory) => {
             const unfetched = getUnfetchedSignaturesFromHistory(history);
             if (unfetched.length === 0) return;
@@ -298,14 +298,14 @@ export function useFetchTransactionsForHistory() {
 
 export function useFetchAccountHistory(limit = 25) {
     const { cluster, url } = useCluster();
-    const state = React.useContext(StateContext);
-    const dispatch = React.useContext(DispatchContext);
-    const inFlight = React.useContext(InFlightContext);
+    const state = useContext(StateContext);
+    const dispatch = useContext(DispatchContext);
+    const inFlight = useContext(InFlightContext);
     if (!state || !dispatch || !inFlight) {
         throw new Error(`useFetchAccountHistory must be used within a HistoryProvider`);
     }
 
-    return React.useCallback(
+    return useCallback(
         (pubkey: PublicKey, fetchTransactions?: boolean, refresh?: boolean) => {
             const before = state.entries[pubkey.toBase58()];
             if (!refresh && before?.data?.fetched && before.data.fetched.length > 0) {

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -28,7 +28,7 @@ import {
 } from '@validators/accounts/upgradeable-program';
 import { VoteAccount } from '@validators/accounts/vote';
 import { ParsedInfo } from '@validators/index';
-import React from 'react';
+import { createContext, useCallback,useContext, useEffect, useMemo, useState } from 'react';
 import { create } from 'superstruct';
 
 import { alloc } from '@/app/shared/lib/bytes';
@@ -131,9 +131,9 @@ export type State = Cache.State<Account>;
 export type Dispatch = Cache.Dispatch<Account>;
 type Fetchers = { [mode in FetchAccountDataMode]: MultipleAccountFetcher };
 
-export const FetchersContext = React.createContext<Fetchers | undefined>(undefined);
-export const StateContext = React.createContext<State | undefined>(undefined);
-export const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+export const FetchersContext = createContext<Fetchers | undefined>(undefined);
+export const StateContext = createContext<State | undefined>(undefined);
+export const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 class MultipleAccountFetcher {
     pubkeys: Set<string> = new Set();
@@ -144,7 +144,7 @@ class MultipleAccountFetcher {
         private cluster: Cluster,
         private url: string,
         private dataMode: FetchAccountDataMode,
-    ) {}
+    ) { }
     fetch = (pubkey: PublicKey) => {
         if (this.pubkeys !== undefined) this.pubkeys.add(pubkey.toBase58());
         if (this.fetchTimeout === undefined) {
@@ -168,14 +168,14 @@ type AccountsProviderProps = { children: React.ReactNode };
 export function AccountsProvider({ children }: AccountsProviderProps) {
     const { cluster, url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Account>(url);
-    const [fetchers, setFetchers] = React.useState<Fetchers>(() => ({
+    const [fetchers, setFetchers] = useState<Fetchers>(() => ({
         parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
         raw: new MultipleAccountFetcher(dispatch, cluster, url, 'raw'),
         skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
     }));
 
     // Clear accounts cache whenever cluster is changed
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
         setFetchers({
             parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
@@ -354,10 +354,10 @@ async function handleParsedAccountData(
             return {
                 activation: activation
                     ? {
-                          active: Number(activation.active),
-                          inactive: Number(activation.inactive),
-                          state: activation.status as any,
-                      }
+                        active: Number(activation.active),
+                        inactive: Number(activation.inactive),
+                        state: activation.status as any,
+                    }
                     : undefined,
                 parsed,
                 program: accountData.program,
@@ -419,7 +419,7 @@ async function handleParsedAccountData(
 }
 
 export function useAccounts() {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
     if (!context) {
         throw new Error(`useAccounts must be used within a AccountsProvider`);
     }
@@ -427,7 +427,7 @@ export function useAccounts() {
 }
 
 export function useAccountInfo(address: string | undefined): Cache.CacheEntry<Account> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useAccountInfo must be used within a AccountsProvider`);
@@ -437,7 +437,7 @@ export function useAccountInfo(address: string | undefined): Cache.CacheEntry<Ac
 }
 
 export function useAccountInfos(addresses: string[]): Cache.CacheEntry<Account>[] {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
     if (!context) {
         throw new Error(`useAccountInfos must be used within a AccountsProvider`);
     }
@@ -446,7 +446,7 @@ export function useAccountInfos(addresses: string[]): Cache.CacheEntry<Account>[
 
 export function useMintAccountInfo(address: string | undefined): MintAccountInfo | undefined {
     const accountInfo = useAccountInfo(address);
-    return React.useMemo(() => {
+    return useMemo(() => {
         if (address === undefined || accountInfo?.data === undefined) return;
         const account = accountInfo.data;
 
@@ -466,7 +466,7 @@ export function useMintAccountInfo(address: string | undefined): MintAccountInfo
 
 export function useTokenAccountInfo(address: string | undefined): TokenAccountInfo | undefined {
     const accountInfo = useAccountInfo(address);
-    return React.useMemo(() => {
+    return useMemo(() => {
         if (address === undefined || accountInfo?.data === undefined) return;
         const account = accountInfo.data;
 
@@ -526,7 +526,7 @@ function parseAddressLookupTableFromCache(
 
 export function useAddressLookupTables(addresses: string[]) {
     const accountInfos = useAccountInfos(addresses);
-    return React.useMemo(() => {
+    return useMemo(() => {
         return accountInfos.map((accountInfo, index) =>
             parseAddressLookupTableFromCache(accountInfo, addresses[index]),
         );
@@ -537,16 +537,16 @@ export function useAddressLookupTable(
     address: string,
 ): [AddressLookupTableAccount | string | undefined, FetchStatus] | undefined {
     const accountInfo = useAccountInfo(address);
-    return React.useMemo(() => parseAddressLookupTableFromCache(accountInfo, address), [address, accountInfo]);
+    return useMemo(() => parseAddressLookupTableFromCache(accountInfo, address), [address, accountInfo]);
 }
 
 export function useFetchAccountInfo() {
-    const fetchers = React.useContext(FetchersContext);
+    const fetchers = useContext(FetchersContext);
     if (!fetchers) {
         throw new Error(`useFetchAccountInfo must be used within a AccountsProvider`);
     }
 
-    return React.useCallback(
+    return useCallback(
         (pubkey: PublicKey, dataMode: FetchAccountDataMode) => {
             fetchers[dataMode].fetch(pubkey);
         },

--- a/app/providers/accounts/rewards.tsx
+++ b/app/providers/accounts/rewards.tsx
@@ -6,7 +6,7 @@ import { FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Connection, InflationReward, PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -53,8 +53,8 @@ function reconcile(rewards: Rewards | undefined, update: RewardsUpdate | undefin
     };
 }
 
-export const StateContext = React.createContext<State | undefined>(undefined);
-export const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+export const StateContext = createContext<State | undefined>(undefined);
+export const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type RewardsProviderProps = { children: React.ReactNode };
 
@@ -62,7 +62,7 @@ export function RewardsProvider({ children }: RewardsProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useCustomReducer(url, reconcile);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -150,7 +150,7 @@ async function fetchRewards(
 }
 
 export function useRewards(address: string): Cache.CacheEntry<Rewards> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useRewards must be used within a AccountsProvider`);
@@ -161,14 +161,14 @@ export function useRewards(address: string): Cache.CacheEntry<Rewards> | undefin
 
 export function useFetchRewards() {
     const { cluster, url } = useCluster();
-    const state = React.useContext(StateContext);
-    const dispatch = React.useContext(DispatchContext);
+    const state = useContext(StateContext);
+    const dispatch = useContext(DispatchContext);
 
     if (!state || !dispatch) {
         throw new Error(`useFetchRewards must be used within a AccountsProvider`);
     }
 
-    return React.useCallback(
+    return useCallback(
         (pubkey: PublicKey, highestEpoch?: number) => {
             const before = state.entries[pubkey.toBase58()];
             if (before?.data) {

--- a/app/providers/accounts/tokens.tsx
+++ b/app/providers/accounts/tokens.tsx
@@ -7,7 +7,7 @@ import { useCluster } from '@providers/cluster';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { TokenAccountInfo } from '@validators/accounts/token';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 import { create } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -29,15 +29,15 @@ interface AccountTokens {
 type State = Cache.State<AccountTokens>;
 type Dispatch = Cache.Dispatch<AccountTokens>;
 
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type ProviderProps = { children: React.ReactNode };
 export function TokensProvider({ children }: ProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useReducer<AccountTokens>(url);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -126,7 +126,7 @@ async function fetchAccountTokens(dispatch: Dispatch, pubkey: PublicKey, cluster
 }
 
 export function useAccountOwnedTokens(address: string): Cache.CacheEntry<AccountTokens> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useAccountOwnedTokens must be used within a AccountsProvider`);
@@ -136,13 +136,13 @@ export function useAccountOwnedTokens(address: string): Cache.CacheEntry<Account
 }
 
 export function useFetchAccountOwnedTokens() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchAccountOwnedTokens must be used within a AccountsProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(
+    return useCallback(
         (pubkey: PublicKey) => {
             fetchAccountTokens(dispatch, pubkey, cluster, url);
         },
@@ -154,7 +154,7 @@ export function useScaledUiAmountForMint(address: string | undefined, rawAmount:
     const mint = useAccountInfo(address);
     const refresh = useFetchAccountInfo();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (address && !mint) {
             refresh(new PublicKey(address), 'parsed');
         }

--- a/app/providers/block.tsx
+++ b/app/providers/block.tsx
@@ -4,7 +4,7 @@ import * as Cache from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Connection, PublicKey, VersionedBlockResponse } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -30,8 +30,8 @@ type Block = {
 type State = Cache.State<Block>;
 type Dispatch = Cache.Dispatch<Block>;
 
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type BlockProviderProps = { children: React.ReactNode };
 
@@ -39,7 +39,7 @@ export function BlockProvider({ children }: BlockProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Block>(url);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -51,7 +51,7 @@ export function BlockProvider({ children }: BlockProviderProps) {
 }
 
 export function useBlock(key: number): Cache.CacheEntry<Block> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useBlock must be used within a BlockProvider`);
@@ -122,11 +122,11 @@ export async function fetchBlock(dispatch: Dispatch, url: string, cluster: Clust
 }
 
 export function useFetchBlock() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchBlock must be used within a BlockProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback((key: number) => fetchBlock(dispatch, url, cluster, key), [dispatch, cluster, url]);
+    return useCallback((key: number) => fetchBlock(dispatch, url, cluster, key), [dispatch, cluster, url]);
 }

--- a/app/providers/cache.tsx
+++ b/app/providers/cache.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 export enum FetchStatus {
     Fetching,
@@ -64,7 +64,7 @@ export function useReducer<T>(url: string) {
 }
 
 export function useCustomReducer<T, U>(url: string, reconciler: Reconciler<T, U>) {
-    const customReducer = React.useMemo(() => {
+    const customReducer = useMemo(() => {
         return (state: State<T>, action: Action<U>) => {
             return reducer(state, action, reconciler);
         };

--- a/app/providers/epoch.tsx
+++ b/app/providers/epoch.tsx
@@ -4,7 +4,7 @@ import * as Cache from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Connection } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -31,8 +31,8 @@ type Epoch = {
 type State = Cache.State<Epoch>;
 type Dispatch = Cache.Dispatch<Epoch>;
 
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type EpochProviderProps = { children: React.ReactNode };
 
@@ -40,7 +40,7 @@ export function EpochProvider({ children }: EpochProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Epoch>(url);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -52,7 +52,7 @@ export function EpochProvider({ children }: EpochProviderProps) {
 }
 
 export function useEpoch(key: number): Cache.CacheEntry<Epoch> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useEpoch must be used within a EpochProvider`);
@@ -129,13 +129,13 @@ export async function fetchEpoch(
 }
 
 export function useFetchEpoch() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchEpoch must be used within a EpochProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(
+    return useCallback(
         (key: number, currentEpoch: bigint, epochSchedule: EpochSchedule) =>
             fetchEpoch(dispatch, url, cluster, epochSchedule, currentEpoch, key),
         [dispatch, cluster, url],

--- a/app/providers/richList.tsx
+++ b/app/providers/richList.tsx
@@ -3,7 +3,7 @@
 import { useCluster } from '@providers/cluster';
 import { AccountBalancePair, Connection } from '@solana/web3.js';
 import { Cluster, ClusterStatus } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -22,15 +22,15 @@ type RichLists = {
 type State = RichLists | Status | string;
 
 type Dispatch = React.Dispatch<React.SetStateAction<State>>;
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type Props = { children: React.ReactNode };
 export function RichListProvider({ children }: Props) {
-    const [state, setState] = React.useState<State>(Status.Idle);
+    const [state, setState] = useState<State>(Status.Idle);
     const { status: clusterStatus, cluster, url } = useCluster();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (state !== Status.Idle) {
             switch (clusterStatus) {
                 case ClusterStatus.Connecting: {
@@ -80,7 +80,7 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
 }
 
 export function useRichList() {
-    const state = React.useContext(StateContext);
+    const state = useContext(StateContext);
     if (state === undefined) {
         throw new Error(`useRichList must be used within a RichListProvider`);
     }
@@ -88,13 +88,13 @@ export function useRichList() {
 }
 
 export function useFetchRichList() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchRichList must be used within a RichListProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(() => {
+    return useCallback(() => {
         fetch(dispatch, cluster, url);
     }, [dispatch, cluster, url]);
 }

--- a/app/providers/stats/solanaClusterStats.tsx
+++ b/app/providers/stats/solanaClusterStats.tsx
@@ -4,7 +4,7 @@ import { useCluster } from '@providers/cluster';
 import { createSolanaRpc } from '@solana/kit';
 import { Cluster } from '@utils/cluster';
 import useTabVisibility from '@utils/use-tab-visibility';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect, useReducer, useState } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -56,31 +56,31 @@ const initialDashboardInfo: DashboardInfo = {
 };
 
 type SetActive = React.Dispatch<React.SetStateAction<boolean>>;
-const StatsProviderContext = React.createContext<
+const StatsProviderContext = createContext<
     | {
-          setActive: SetActive;
-          setTimedOut: () => void;
-          retry: () => void;
-          active: boolean;
-      }
+        setActive: SetActive;
+        setTimedOut: () => void;
+        retry: () => void;
+        active: boolean;
+    }
     | undefined
 >(undefined);
 
 type DashboardState = { info: DashboardInfo };
-const DashboardContext = React.createContext<DashboardState | undefined>(undefined);
+const DashboardContext = createContext<DashboardState | undefined>(undefined);
 
 type PerformanceState = { info: PerformanceInfo };
-const PerformanceContext = React.createContext<PerformanceState | undefined>(undefined);
+const PerformanceContext = createContext<PerformanceState | undefined>(undefined);
 
 type Props = { children: React.ReactNode };
 
 export function SolanaClusterStatsProvider({ children }: Props) {
     const { cluster, url } = useCluster();
-    const [active, setActive] = React.useState(false);
-    const [dashboardInfo, dispatchDashboardInfo] = React.useReducer(dashboardInfoReducer, initialDashboardInfo);
-    const [performanceInfo, dispatchPerformanceInfo] = React.useReducer(performanceInfoReducer, initialPerformanceInfo);
+    const [active, setActive] = useState(false);
+    const [dashboardInfo, dispatchDashboardInfo] = useReducer(dashboardInfoReducer, initialDashboardInfo);
+    const [performanceInfo, dispatchPerformanceInfo] = useReducer(performanceInfoReducer, initialPerformanceInfo);
     const { visible: isTabVisible } = useTabVisibility();
-    React.useEffect(() => {
+    useEffect(() => {
         if (!active || !isTabVisible || !url) return;
 
         const rpc = createSolanaRpc(url);
@@ -233,7 +233,7 @@ export function SolanaClusterStatsProvider({ children }: Props) {
     }, [active, cluster, isTabVisible, url]);
 
     // Reset when cluster changes
-    React.useEffect(() => {
+    useEffect(() => {
         return () => {
             resetData();
         };
@@ -250,7 +250,7 @@ export function SolanaClusterStatsProvider({ children }: Props) {
         });
     }
 
-    const setTimedOut = React.useCallback(() => {
+    const setTimedOut = useCallback(() => {
         dispatchDashboardInfo({
             data: 'Cluster stats timed out',
             type: DashboardInfoActionType.SetError,
@@ -263,7 +263,7 @@ export function SolanaClusterStatsProvider({ children }: Props) {
         setActive(false);
     }, []);
 
-    const retry = React.useCallback(() => {
+    const retry = useCallback(() => {
         resetData();
         setActive(true);
     }, []);
@@ -278,7 +278,7 @@ export function SolanaClusterStatsProvider({ children }: Props) {
 }
 
 export function useStatsProvider() {
-    const context = React.useContext(StatsProviderContext);
+    const context = useContext(StatsProviderContext);
     if (!context) {
         throw new Error(`useContext must be used within a StatsProvider`);
     }
@@ -286,7 +286,7 @@ export function useStatsProvider() {
 }
 
 export function useDashboardInfo() {
-    const context = React.useContext(DashboardContext);
+    const context = useContext(DashboardContext);
     if (!context) {
         throw new Error(`useDashboardInfo must be used within a StatsProvider`);
     }
@@ -294,7 +294,7 @@ export function useDashboardInfo() {
 }
 
 export function usePerformanceInfo() {
-    const context = React.useContext(PerformanceContext);
+    const context = useContext(PerformanceContext);
     if (!context) {
         throw new Error(`usePerformanceInfo must be used within a StatsProvider`);
     }

--- a/app/providers/supply.tsx
+++ b/app/providers/supply.tsx
@@ -3,7 +3,7 @@
 import { useCluster } from '@providers/cluster';
 import { createSolanaRpc } from '@solana/kit';
 import { Cluster, ClusterStatus } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -24,15 +24,15 @@ type Supply = Readonly<{
 type State = Supply | Status | string;
 
 type Dispatch = React.Dispatch<React.SetStateAction<State>>;
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type Props = { children: React.ReactNode };
 export function SupplyProvider({ children }: Props) {
-    const [state, setState] = React.useState<State>(Status.Idle);
+    const [state, setState] = useState<State>(Status.Idle);
     const { status: clusterStatus, cluster, url } = useCluster();
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (state !== Status.Idle) {
             if (clusterStatus === ClusterStatus.Connecting) setState(Status.Disconnected);
             if (clusterStatus === ClusterStatus.Connected) fetch(setState, cluster, url);
@@ -75,7 +75,7 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
 }
 
 export function useSupply() {
-    const state = React.useContext(StateContext);
+    const state = useContext(StateContext);
     if (state === undefined) {
         throw new Error(`useSupply must be used within a SupplyProvider`);
     }
@@ -83,13 +83,13 @@ export function useSupply() {
 }
 
 export function useFetchSupply() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchSupply must be used within a SupplyProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(() => {
+    return useCallback(() => {
         fetch(dispatch, cluster, url);
     }, [dispatch, cluster, url]);
 }

--- a/app/providers/transactions/index.tsx
+++ b/app/providers/transactions/index.tsx
@@ -5,7 +5,7 @@ import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Connection, SignatureResult, TransactionConfirmationStatus, TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -34,8 +34,8 @@ export interface TransactionStatus {
 type State = Cache.State<TransactionStatus>;
 type Dispatch = Cache.Dispatch<TransactionStatus>;
 
-const StateContext = React.createContext<State | undefined>(undefined);
-const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type TransactionsProviderProps = { children: React.ReactNode };
 export function TransactionsProvider({ children }: TransactionsProviderProps) {
@@ -43,7 +43,7 @@ export function TransactionsProvider({ children }: TransactionsProviderProps) {
     const [state, dispatch] = Cache.useReducer<TransactionStatus>(url);
 
     // Clear accounts cache whenever cluster is changed
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -127,7 +127,7 @@ export async function fetchTransactionStatus(
 export function useTransactionStatus(
     signature: TransactionSignature | undefined,
 ): Cache.CacheEntry<TransactionStatus> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useTransactionStatus must be used within a TransactionsProvider`);
@@ -141,13 +141,13 @@ export function useTransactionStatus(
 }
 
 export function useFetchTransactionStatus() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchTransactionStatus must be used within a TransactionsProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(
+    return useCallback(
         (signature: TransactionSignature) => {
             fetchTransactionStatus(dispatch, signature, cluster, url);
         },

--- a/app/providers/transactions/parsed.tsx
+++ b/app/providers/transactions/parsed.tsx
@@ -5,7 +5,7 @@ import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
 import { Connection, ParsedTransactionWithMeta, TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -16,15 +16,15 @@ export interface Details {
 type State = Cache.State<Details>;
 type Dispatch = Cache.Dispatch<Details>;
 
-export const StateContext = React.createContext<State | undefined>(undefined);
-export const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+export const StateContext = createContext<State | undefined>(undefined);
+export const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type DetailsProviderProps = { children: React.ReactNode };
 export function DetailsProvider({ children }: DetailsProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Details>(url);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -67,13 +67,13 @@ async function fetchDetails(dispatch: Dispatch, signature: TransactionSignature,
 }
 
 export function useFetchTransactionDetails() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchTransactionDetails must be used within a TransactionsProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(
+    return useCallback(
         (signature: TransactionSignature) => {
             url && fetchDetails(dispatch, signature, cluster, url);
         },
@@ -82,7 +82,7 @@ export function useFetchTransactionDetails() {
 }
 
 export function useTransactionDetails(signature: TransactionSignature): Cache.CacheEntry<Details> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useTransactionDetails must be used within a TransactionsProvider`);
@@ -95,7 +95,7 @@ export type TransactionDetailsCache = {
     [key: string]: Cache.CacheEntry<Details>;
 };
 export function useTransactionDetailsCache(): TransactionDetailsCache {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useTransactionDetailsCache must be used within a TransactionsProvider`);

--- a/app/providers/transactions/raw.tsx
+++ b/app/providers/transactions/raw.tsx
@@ -12,7 +12,7 @@ import {
     type VersionedMessage,
 } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
-import React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -32,15 +32,15 @@ export interface Details {
 type State = Cache.State<Details>;
 type Dispatch = Cache.Dispatch<Details>;
 
-export const StateContext = React.createContext<State | undefined>(undefined);
-export const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+export const StateContext = createContext<State | undefined>(undefined);
+export const DispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type DetailsProviderProps = { children: React.ReactNode };
 export function RawDetailsProvider({ children }: DetailsProviderProps) {
     const { url } = useCluster();
     const [state, dispatch] = Cache.useReducer<Details>(url);
 
-    React.useEffect(() => {
+    useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
     }, [dispatch, url]);
 
@@ -52,7 +52,7 @@ export function RawDetailsProvider({ children }: DetailsProviderProps) {
 }
 
 export function useRawTransactionDetails(signature: TransactionSignature): Cache.CacheEntry<Details> | undefined {
-    const context = React.useContext(StateContext);
+    const context = useContext(StateContext);
 
     if (!context) {
         throw new Error(`useRawTransactionDetails must be used within a TransactionsProvider`);
@@ -105,13 +105,13 @@ async function fetchRawTransaction(dispatch: Dispatch, signature: TransactionSig
 }
 
 export function useFetchRawTransaction() {
-    const dispatch = React.useContext(DispatchContext);
+    const dispatch = useContext(DispatchContext);
     if (!dispatch) {
         throw new Error(`useFetchRawTransaction must be used within a TransactionsProvider`);
     }
 
     const { cluster, url } = useCluster();
-    return React.useCallback(
+    return useCallback(
         (signature: TransactionSignature) => {
             url && fetchRawTransaction(dispatch, signature, cluster, url);
         },

--- a/app/shared/ui/navigation-tabs/model/navigation-tabs-context.ts
+++ b/app/shared/ui/navigation-tabs/model/navigation-tabs-context.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { createContext, useCallback, useContext, useState } from 'react';
 
 import { type NavigationTab } from './types';
 
@@ -13,25 +13,25 @@ export type NavigationTabsContextValue = {
     unregisterTab: (path: string) => void;
 };
 
-export const NavigationTabsContext = React.createContext<NavigationTabsContextValue | undefined>(undefined);
+export const NavigationTabsContext = createContext<NavigationTabsContextValue | undefined>(undefined);
 
 export function useNavigationTabsContext() {
-    const ctx = React.useContext(NavigationTabsContext);
+    const ctx = useContext(NavigationTabsContext);
     if (!ctx) throw new Error('Tab components must be used within NavigationTabs');
     return ctx;
 }
 
 export function useTabRegistration() {
-    const [registeredTabs, setRegisteredTabs] = React.useState<NavigationTab[]>([]);
+    const [registeredTabs, setRegisteredTabs] = useState<NavigationTab[]>([]);
 
-    const registerTab = React.useCallback((tab: NavigationTab) => {
+    const registerTab = useCallback((tab: NavigationTab) => {
         setRegisteredTabs(prev => {
             if (prev.some(t => t.path === tab.path)) return prev;
             return [...prev, tab];
         });
     }, []);
 
-    const unregisterTab = React.useCallback((path: string) => {
+    const unregisterTab = useCallback((path: string) => {
         setRegisteredTabs(prev => prev.filter(t => t.path !== path));
     }, []);
 

--- a/app/shared/ui/navigation-tabs/model/useTabOverflow.ts
+++ b/app/shared/ui/navigation-tabs/model/useTabOverflow.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { type NavigationTab } from './types';
 
@@ -34,20 +34,20 @@ function getVisibleTabsCount({
 }
 
 export function useTabOverflow(allTabs: NavigationTab[]) {
-    const tablistRef = React.useRef<HTMLDivElement>(null);
-    const moreMeasureRef = React.useRef<HTMLDivElement>(null);
+    const tablistRef = useRef<HTMLDivElement>(null);
+    const moreMeasureRef = useRef<HTMLDivElement>(null);
 
-    const allTabsKey = React.useMemo(() => getTabsKey(allTabs), [allTabs]);
+    const allTabsKey = useMemo(() => getTabsKey(allTabs), [allTabs]);
 
-    const [measuring, setMeasuring] = React.useState(true);
-    const [visibleCount, setVisibleCount] = React.useState<number>(allTabs.length);
+    const [measuring, setMeasuring] = useState(true);
+    const [visibleCount, setVisibleCount] = useState<number>(allTabs.length);
 
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         setMeasuring(true);
         setVisibleCount(allTabs.length);
     }, [allTabs.length, allTabsKey]);
 
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         if (!measuring) return;
 
         const tablist = tablistRef.current;
@@ -66,7 +66,7 @@ export function useTabOverflow(allTabs: NavigationTab[]) {
         setMeasuring(false);
     }, [allTabs.length, allTabsKey, measuring]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const tablist = tablistRef.current;
         if (!tablist) return;
 

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { useMemo } from 'react';
 
 import { cn } from '@/app/components/shared/utils';
 import {
@@ -32,16 +32,16 @@ export function BaseNavigationTabs({
 }: BaseNavigationTabsProps) {
     const { registeredTabs, registerTab, unregisterTab } = useTabRegistration();
 
-    const staticPaths = React.useMemo(() => new Set(tabs.map(t => t.path)), [tabs]);
+    const staticPaths = useMemo(() => new Set(tabs.map(t => t.path)), [tabs]);
 
-    const contextValue = React.useMemo(
+    const contextValue = useMemo(
         () => ({ activeValue, buildHref, registerTab, renderTabLink: true, staticPaths, unregisterTab }),
         [activeValue, buildHref, registerTab, staticPaths, unregisterTab],
     );
 
-    const hiddenContextValue = React.useMemo(() => ({ ...contextValue, renderTabLink: false }), [contextValue]);
+    const hiddenContextValue = useMemo(() => ({ ...contextValue, renderTabLink: false }), [contextValue]);
 
-    const allTabs = React.useMemo(
+    const allTabs = useMemo(
         () => [...tabs, ...registeredTabs.filter(t => !staticPaths.has(t.path))],
         [tabs, registeredTabs, staticPaths],
     );

--- a/app/shared/ui/navigation-tabs/ui/NavigationTabLink.tsx
+++ b/app/shared/ui/navigation-tabs/ui/NavigationTabLink.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import { useEffect } from 'react';
 
 import { useNavigationTabsContext } from '@/app/shared/ui/navigation-tabs/model/navigation-tabs-context';
 
@@ -9,7 +9,7 @@ import { TabLink } from './TabLink';
 export function NavigationTabLink({ path, title, className }: { path: string; title: string; className?: string }) {
     const { registerTab, renderTabLink, staticPaths, unregisterTab } = useNavigationTabsContext();
 
-    React.useEffect(() => {
+    useEffect(() => {
         registerTab({ path, title });
         return () => unregisterTab(path);
     }, [path, title, registerTab, unregisterTab]);

--- a/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/NavigationTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter, useSelectedLayoutSegment } from 'next/navigation';
-import React from 'react';
+import { useCallback } from 'react';
 
 import { type NavigationTab } from '@/app/shared/ui/navigation-tabs/model/types';
 
@@ -19,7 +19,7 @@ export function NavigationTabs({ buildHref, tabs, children, className }: Navigat
     const activeValue = segment ?? '';
     const router = useRouter();
 
-    const onSelectChange = React.useCallback(
+    const onSelectChange = useCallback(
         (path: string) => {
             router.push(buildHref(path), { scroll: false });
         },

--- a/app/shared/ui/sticky-header/StickyHeader.tsx
+++ b/app/shared/ui/sticky-header/StickyHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/app/components/shared/utils';
 
@@ -10,8 +10,8 @@ type Props = {
 };
 
 export function StickyHeader({ children, className }: Props) {
-    const sentinelRef = React.useRef<HTMLDivElement>(null);
-    const [isStuck, setIsStuck] = React.useState(false);
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const [isStuck, setIsStuck] = useState(false);
 
     useEffect(() => {
         const sentinel = sentinelRef.current;


### PR DESCRIPTION
## Description

I noticed that hooks throughout the project are declared in different ways: some files use React.useState / React.useMemo, while others use direct imports from React

I unified the hook style by removing the React. prefix and using direct imports instead

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): small refactor

## Checklist

-   [x] My code follows the project's style guidelines
