### PR TITLE
feat: truncate address

### DIFF
--- a/app/components/account/TokenHistoryCard.tsx
+++ b/app/components/account/TokenHistoryCard.tsx
@@ -386,7 +386,7 @@ const TokenTransactionRow = React.memo(function TokenTransactionRow({
             </td>
 
             <td>
-                <Address pubkey={mint} link truncate />
+                <Address pubkey={mint} link />
             </td>
 
             <InstructionDetailsCell signature={tx.signature} details={details} tx={tx} />

--- a/app/components/account/__tests__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__tests__/TokenExtensionRow.spec.tsx
@@ -55,7 +55,7 @@ describe('TokenExtensionRow', () => {
         );
 
         expect(await screen.findByText(/Close Authority/)).toBeInTheDocument();
-        expect(screen.queryAllByText(new RegExp(`${data.state.closeAuthority.toString()}`))).toHaveLength(2);
+        expect(screen.queryAllByText(new RegExp(`${data.state.closeAuthority.toString()}`))).toHaveLength(1);
     });
 
     test('should render transferFeeAmount extension', async () => {
@@ -320,7 +320,7 @@ describe('TokenExtensionRow', () => {
         );
 
         expect(await screen.findByText('Permanent Delegate')).toBeInTheDocument();
-        expect(screen.queryAllByText(new RegExp(`${data.state.delegate.toString()}`))).toHaveLength(2);
+        expect(screen.queryAllByText(new RegExp(`${data.state.delegate.toString()}`))).toHaveLength(1);
     });
 
     test('should render transferHook extension', async () => {

--- a/app/components/account/history/TokenInstructionsCard.tsx
+++ b/app/components/account/history/TokenInstructionsCard.tsx
@@ -68,7 +68,7 @@ export function TokenInstructionsCard({ address }: { address: string }) {
                     detailsList.push(
                         <tr key={signature + index}>
                             <td>
-                                <Signature signature={signature} link truncateChars={48} />
+                                <Signature signature={signature} link />
                             </td>
 
                             {hasTimestamps && (
@@ -78,7 +78,7 @@ export function TokenInstructionsCard({ address }: { address: string }) {
                             <td>{instructionName}</td>
 
                             <td>
-                                <Address pubkey={programId} link truncate truncateChars={16} />
+                                <Address pubkey={programId} link />
                             </td>
 
                             <td>

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -72,11 +72,11 @@ function TransferRow({
             {hasTimestamps && <td className="text-muted">{blockTime && <RelativeTime date={blockTime * 1000} />}</td>}
 
             <td>
-                <Address pubkey={transfer.source} link truncateChars={16} />
+                <Address pubkey={transfer.source} link />
             </td>
 
             <td>
-                <Address pubkey={transfer.destination} link truncateChars={16} />
+                <Address pubkey={transfer.destination} link />
             </td>
 
             <td>

--- a/app/components/account/history/TokenTransfersCard.tsx
+++ b/app/components/account/history/TokenTransfersCard.tsx
@@ -66,7 +66,7 @@ function TransferRow({
     return (
         <tr key={signature + index + (childIndex || '')}>
             <td>
-                <Signature signature={signature} link truncateChars={24} />
+                <Signature signature={signature} link />
             </td>
 
             {hasTimestamps && <td className="text-muted">{blockTime && <RelativeTime date={blockTime * 1000} />}</td>}

--- a/app/components/block/BlockHistoryCard.tsx
+++ b/app/components/block/BlockHistoryCard.tsx
@@ -315,7 +315,7 @@ export function BlockHistoryCard({ block, epoch }: { block: VersionedBlockRespon
                                 }
 
                                 if (tx.signature) {
-                                    signature = <Signature signature={tx.signature} link truncateChars={32} />;
+                                    signature = <Signature signature={tx.signature} link />;
                                 }
 
                                 const entries = Array.from(tx.invocations.entries());

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -99,6 +99,14 @@ export function Address({
     // Nickname uses CSS text-overflow truncation (trailing ellipsis)
     const innerTextClassName = cn('e-font-mono', nickname && 'e-truncate');
 
+    const innerContent = link ? (
+        <Link href={addressPath} className={innerTextClassName}>
+            {visibleText}
+        </Link>
+    ) : (
+        <span className={innerTextClassName}>{visibleText}</span>
+    );
+
     return (
         <span ref={visibilityRef} className="e-block e-w-full">
             <div
@@ -117,30 +125,35 @@ export function Address({
                     </span>
                 )}
                 <Copyable text={address}>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span
-                                data-address={address}
-                                className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
-                                onMouseEnter={() => handleMouseEnter(address)}
-                                onMouseLeave={() => handleMouseLeave(address)}
-                                title={nickname ? displayText : undefined}
-                            >
-                                {link ? (
-                                    <Link href={addressPath} className={innerTextClassName}>
-                                        {visibleText}
-                                    </Link>
-                                ) : (
-                                    <span className={innerTextClassName}>{visibleText}</span>
-                                )}
-                            </span>
-                        </TooltipTrigger>
-                        {isMidTruncated && (
-                            <TooltipContent>
-                                <span className="e-font-mono">{address}</span>
-                            </TooltipContent>
-                        )}
-                    </Tooltip>
+                    {isMidTruncateCandidate ? (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span
+                                    data-address={address}
+                                    className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                                    onMouseEnter={() => handleMouseEnter(address)}
+                                    onMouseLeave={() => handleMouseLeave(address)}
+                                >
+                                    {innerContent}
+                                </span>
+                            </TooltipTrigger>
+                            {isMidTruncated && (
+                                <TooltipContent>
+                                    <span className="e-font-mono">{address}</span>
+                                </TooltipContent>
+                            )}
+                        </Tooltip>
+                    ) : (
+                        <span
+                            data-address={address}
+                            className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                            onMouseEnter={() => handleMouseEnter(address)}
+                            onMouseLeave={() => handleMouseLeave(address)}
+                            title={nickname ? displayText : undefined}
+                        >
+                            {innerContent}
+                        </span>
+                    )}
                 </Copyable>
                 <button
                     ref={editBtnRef}

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -3,6 +3,7 @@
 import { useTokenMetadata } from '@entities/nft';
 import { useTokenInfo } from '@entities/token-info';
 import { useCluster } from '@providers/cluster';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/ui/tooltip';
 import { cn } from '@shared/utils';
 import { PublicKey } from '@solana/web3.js';
 import { displayAddress, TokenLabelInfo } from '@utils/tx';
@@ -122,21 +123,30 @@ export function Address({
                     </span>
                 )}
                 <Copyable text={address}>
-                    <span
-                        data-address={address}
-                        className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
-                        onMouseEnter={() => handleMouseEnter(address)}
-                        onMouseLeave={() => handleMouseLeave(address)}
-                        title={nickname ? displayText : undefined}
-                    >
-                        {link ? (
-                            <Link href={addressPath} className={innerTextClassName}>
-                                {visibleText}
-                            </Link>
-                        ) : (
-                            <span className={innerTextClassName}>{visibleText}</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span
+                                data-address={address}
+                                className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                                onMouseEnter={() => handleMouseEnter(address)}
+                                onMouseLeave={() => handleMouseLeave(address)}
+                                title={nickname ? displayText : undefined}
+                            >
+                                {link ? (
+                                    <Link href={addressPath} className={innerTextClassName}>
+                                        {visibleText}
+                                    </Link>
+                                ) : (
+                                    <span className={innerTextClassName}>{visibleText}</span>
+                                )}
+                            </span>
+                        </TooltipTrigger>
+                        {isMidTruncated && (
+                            <TooltipContent>
+                                <span className="e-font-mono">{address}</span>
+                            </TooltipContent>
                         )}
-                    </span>
+                    </Tooltip>
                 </Copyable>
                 <button
                     ref={editBtnRef}

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -8,17 +8,13 @@ import { PublicKey } from '@solana/web3.js';
 import { displayAddress, TokenLabelInfo } from '@utils/tx';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { EditIcon, NicknameEditor, useNickname } from '@/app/features/nicknames';
 import { useVisibility } from '@/app/shared/lib/visibility';
 
 import { Copyable } from './Copyable';
-
-const MID_TRUNCATE_CHARS = 5;
-
-// Space reserved for Copyable's copy icon (13px SVG + 8px me-2 margin)
-const COPY_ICON_RESERVED_PX = 24;
+import { useMidTruncation } from './useMidTruncation';
 
 type Props = {
     pubkey: PublicKey;
@@ -26,7 +22,6 @@ type Props = {
     link?: boolean;
     raw?: boolean;
     noTruncate?: boolean;
-    truncateUnknown?: boolean;
     truncateChars?: number;
     useMetadata?: boolean;
     overrideText?: string;
@@ -41,7 +36,6 @@ export function Address({
     link,
     raw,
     noTruncate,
-    truncateUnknown: _truncateUnknown,
     truncateChars,
     useMetadata,
     overrideText,
@@ -83,43 +77,13 @@ export function Address({
 
     // Mid-truncation applies only to raw 44-char addresses (no nickname, no human-readable label)
     const isMidTruncateCandidate = !noTruncate && !nickname && !overrideText && addressLabel === address;
-    const midTruncatedText = `${address.slice(0, MID_TRUNCATE_CHARS)}...${address.slice(-MID_TRUNCATE_CHARS)}`;
 
-    // Ref on the outer flex row — its clientWidth is the true available width
-    const rowRef = useRef<HTMLDivElement>(null);
     const editBtnRef = useRef<HTMLButtonElement>(null);
-    const hiddenTextRef = useRef<HTMLSpanElement>(null);
-    const [isMidTruncated, setIsMidTruncated] = useState(false);
-
-    useEffect(() => {
-        if (!isMidTruncateCandidate) {
-            setIsMidTruncated(false);
-            return;
-        }
-
-        const check = () => {
-            const row = rowRef.current;
-            const hidden = hiddenTextRef.current;
-            if (!row || !hidden) return;
-
-            // Include the edit button's margin-start (e-ms-2 = 0.5rem) in the measurement
-            const editBtn = editBtnRef.current;
-            let editBtnSpace = 0;
-            if (editBtn) {
-                const style = getComputedStyle(editBtn);
-                editBtnSpace = editBtn.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
-            }
-            // Use getBoundingClientRect for sub-pixel precision
-            const available = row.clientWidth - COPY_ICON_RESERVED_PX - editBtnSpace;
-            setIsMidTruncated(hidden.getBoundingClientRect().width > available);
-        };
-
-        const observer = new ResizeObserver(check);
-        if (rowRef.current) observer.observe(rowRef.current);
-        check();
-
-        return () => observer.disconnect();
-    }, [isMidTruncateCandidate, displayText]);
+    const { rowRef, hiddenTextRef, isMidTruncated, midTruncatedText } = useMidTruncation(
+        isMidTruncateCandidate,
+        address,
+        editBtnRef,
+    );
 
     const handleMouseEnter = (text: string) => {
         const elements = document.querySelectorAll(`[data-address="${text}"]`);

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -8,20 +8,24 @@ import { PublicKey } from '@solana/web3.js';
 import { displayAddress, TokenLabelInfo } from '@utils/tx';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React from 'react';
-import { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { EditIcon, NicknameEditor, useNickname } from '@/app/features/nicknames';
 import { useVisibility } from '@/app/shared/lib/visibility';
 
 import { Copyable } from './Copyable';
 
+const MID_TRUNCATE_CHARS = 5;
+
+// Space reserved for Copyable's copy icon (13px SVG + 8px me-2 margin)
+const COPY_ICON_RESERVED_PX = 24;
+
 type Props = {
     pubkey: PublicKey;
     alignRight?: boolean;
     link?: boolean;
     raw?: boolean;
-    truncate?: boolean;
+    noTruncate?: boolean;
     truncateUnknown?: boolean;
     truncateChars?: number;
     useMetadata?: boolean;
@@ -36,8 +40,8 @@ export function Address({
     alignRight,
     link,
     raw,
-    truncate,
-    truncateUnknown,
+    noTruncate,
+    truncateUnknown: _truncateUnknown,
     truncateChars,
     useMetadata,
     overrideText,
@@ -50,12 +54,9 @@ export function Address({
     const addressPath = useClusterPath({ pathname: `/address/${address}` });
     const [showNicknameEditor, setShowNicknameEditor] = useState(false);
     const nickname = useNickname(address);
-    const { ref: containerRef, isVisible } = useVisibility(fetchTokenLabelInfo);
+    const { ref: visibilityRef, isVisible } = useVisibility(fetchTokenLabelInfo);
 
     const display = displayAddress(address, cluster, tokenLabelInfo);
-    if (truncateUnknown && address === display) {
-        truncate = true;
-    }
 
     let addressLabel = raw ? address : display;
 
@@ -78,8 +79,47 @@ export function Address({
         addressLabel = overrideText;
     }
 
-    // Prepend nickname if exists
     const displayText = nickname ? `"${nickname}" (${addressLabel})` : addressLabel;
+
+    // Mid-truncation applies only to raw 44-char addresses (no nickname, no human-readable label)
+    const isMidTruncateCandidate = !noTruncate && !nickname && !overrideText && addressLabel === address;
+    const midTruncatedText = `${address.slice(0, MID_TRUNCATE_CHARS)}...${address.slice(-MID_TRUNCATE_CHARS)}`;
+
+    // Ref on the outer flex row — its clientWidth is the true available width
+    const rowRef = useRef<HTMLDivElement>(null);
+    const editBtnRef = useRef<HTMLButtonElement>(null);
+    const hiddenTextRef = useRef<HTMLSpanElement>(null);
+    const [isMidTruncated, setIsMidTruncated] = useState(false);
+
+    useEffect(() => {
+        if (!isMidTruncateCandidate) {
+            setIsMidTruncated(false);
+            return;
+        }
+
+        const check = () => {
+            const row = rowRef.current;
+            const hidden = hiddenTextRef.current;
+            if (!row || !hidden) return;
+
+            // Include the edit button's margin-start (e-ms-2 = 0.5rem) in the measurement
+            const editBtn = editBtnRef.current;
+            let editBtnSpace = 0;
+            if (editBtn) {
+                const style = getComputedStyle(editBtn);
+                editBtnSpace = editBtn.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
+            }
+            // Use getBoundingClientRect for sub-pixel precision
+            const available = row.clientWidth - COPY_ICON_RESERVED_PX - editBtnSpace;
+            setIsMidTruncated(hidden.getBoundingClientRect().width > available);
+        };
+
+        const observer = new ResizeObserver(check);
+        if (rowRef.current) observer.observe(rowRef.current);
+        check();
+
+        return () => observer.disconnect();
+    }, [isMidTruncateCandidate, displayText]);
 
     const handleMouseEnter = (text: string) => {
         const elements = document.querySelectorAll(`[data-address="${text}"]`);
@@ -95,48 +135,58 @@ export function Address({
         });
     };
 
-    const content = (
-        <div className="d-flex align-items-center gap-2" aria-label={ariaLabel}>
-            <Copyable text={address}>
-                <span
-                    data-address={address}
-                    className="font-monospace"
-                    onMouseEnter={() => handleMouseEnter(address)}
-                    onMouseLeave={() => handleMouseLeave(address)}
-                    title={nickname ? displayText : undefined}
-                >
-                    {link ? (
-                        <Link
-                            className={truncate || nickname ? 'text-truncate address-truncate' : ''}
-                            href={addressPath}
-                        >
-                            {displayText}
-                        </Link>
-                    ) : (
-                        <span className={truncate || nickname ? 'text-truncate address-truncate' : ''}>
-                            {displayText}
-                        </span>
-                    )}
-                </span>
-            </Copyable>
-            <button
-                className="btn btn-sm btn-link p-0 text-muted"
-                onClick={() => setShowNicknameEditor(true)}
-                title="Edit nickname"
-                style={{ fontSize: '0.875rem', lineHeight: 1 }}
-            >
-                <EditIcon />
-            </button>
-            {showNicknameEditor && <NicknameEditor address={address} onClose={() => setShowNicknameEditor(false)} />}
-        </div>
-    );
+    const visibleText = isMidTruncated ? midTruncatedText : displayText;
+
+    // Nickname uses CSS text-overflow truncation (trailing ellipsis)
+    const innerTextClassName = cn('e-font-mono', nickname && 'e-truncate');
 
     return (
-        <span ref={containerRef}>
-            <div className={cn('d-none d-md-flex align-items-center', alignRight && 'justify-content-end')}>
-                {content}
+        <span ref={visibilityRef} className="e-block e-w-full">
+            <div
+                ref={rowRef}
+                className={cn('e-relative e-flex e-w-full e-min-w-0 e-items-center', alignRight && 'md:e-justify-end')}
+                aria-label={ariaLabel}
+            >
+                {/* Hidden span for measuring the natural text width — absolutely positioned so it doesn't affect layout */}
+                {isMidTruncateCandidate && (
+                    <span
+                        ref={hiddenTextRef}
+                        className="e-pointer-events-none e-invisible e-absolute e-whitespace-nowrap e-font-mono"
+                        aria-hidden
+                    >
+                        {displayText}
+                    </span>
+                )}
+                <Copyable text={address}>
+                    <span
+                        data-address={address}
+                        className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                        onMouseEnter={() => handleMouseEnter(address)}
+                        onMouseLeave={() => handleMouseLeave(address)}
+                        title={nickname ? displayText : undefined}
+                    >
+                        {link ? (
+                            <Link href={addressPath} className={innerTextClassName}>
+                                {visibleText}
+                            </Link>
+                        ) : (
+                            <span className={innerTextClassName}>{visibleText}</span>
+                        )}
+                    </span>
+                </Copyable>
+                <button
+                    ref={editBtnRef}
+                    className="e-ms-2 e-flex-none e-shrink-0 e-cursor-pointer e-border-0 e-bg-transparent e-p-0 e-text-muted"
+                    onClick={() => setShowNicknameEditor(true)}
+                    title="Edit nickname"
+                    style={{ fontSize: '0.875rem', lineHeight: 1 }}
+                >
+                    <EditIcon />
+                </button>
+                {showNicknameEditor && (
+                    <NicknameEditor address={address} onClose={() => setShowNicknameEditor(false)} />
+                )}
             </div>
-            <div className="d-flex d-md-none align-items-center">{content}</div>
         </span>
     );
 }

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -23,7 +23,6 @@ type Props = {
     link?: boolean;
     raw?: boolean;
     noTruncate?: boolean;
-    truncateChars?: number;
     useMetadata?: boolean;
     overrideText?: string;
     tokenLabelInfo?: TokenLabelInfo;
@@ -37,7 +36,6 @@ export function Address({
     link,
     raw,
     noTruncate,
-    truncateChars,
     useMetadata,
     overrideText,
     tokenLabelInfo,
@@ -64,10 +62,6 @@ export function Address({
     const tokenInfo = useTokenInfo(shouldFetchTokenInfo, address, cluster, clusterInfo?.genesisHash);
     if (tokenInfo) {
         addressLabel = displayAddress(address, cluster, tokenInfo);
-    }
-
-    if (truncateChars && addressLabel === address) {
-        addressLabel = `${addressLabel.slice(0, truncateChars)}…`;
     }
 
     if (overrideText) {

--- a/app/components/common/Signature.tsx
+++ b/app/components/common/Signature.tsx
@@ -1,36 +1,81 @@
+'use client';
+
 import { cn } from '@shared/utils';
 import { TransactionSignature } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { Copyable } from './Copyable';
+
+const MID_TRUNCATE_CHARS = 5;
+
+// Space reserved for Copyable's copy icon (13px SVG + 8px me-2 margin)
+const COPY_ICON_RESERVED_PX = 24;
 
 type Props = {
     signature: TransactionSignature;
     alignRight?: boolean;
     link?: boolean;
-    truncate?: boolean;
-    truncateChars?: number;
+    noTruncate?: boolean;
 };
 
-export function Signature({ signature, alignRight, link, truncate, truncateChars }: Props) {
-    let signatureLabel = signature;
-
-    if (truncateChars) {
-        signatureLabel = `${signature.slice(0, truncateChars)}…`;
-    }
+export function Signature({ signature, alignRight, link, noTruncate }: Props) {
     const transactionPath = useClusterPath({ pathname: `/tx/${signature}` });
+    const midTruncatedText = `${signature.slice(0, MID_TRUNCATE_CHARS)}...${signature.slice(-MID_TRUNCATE_CHARS)}`;
+
+    const rowRef = useRef<HTMLDivElement>(null);
+    const hiddenTextRef = useRef<HTMLSpanElement>(null);
+    const [isMidTruncated, setIsMidTruncated] = useState(false);
+
+    useEffect(() => {
+        if (noTruncate) {
+            setIsMidTruncated(false);
+            return;
+        }
+
+        const check = () => {
+            const row = rowRef.current;
+            const hidden = hiddenTextRef.current;
+            if (!row || !hidden) return;
+            // Use getBoundingClientRect for sub-pixel precision
+            const available = row.clientWidth - COPY_ICON_RESERVED_PX;
+            setIsMidTruncated(hidden.getBoundingClientRect().width > available);
+        };
+
+        const observer = new ResizeObserver(check);
+        if (rowRef.current) observer.observe(rowRef.current);
+        check();
+        return () => observer.disconnect();
+    }, [noTruncate]);
+
+    const visibleText = isMidTruncated ? midTruncatedText : signature;
+
     return (
-        <div className={cn('d-flex align-items-center', alignRight && 'justify-content-end')}>
+        <div
+            ref={rowRef}
+            className={cn(
+                'e-relative e-flex e-w-full e-min-w-0 e-items-center e-justify-start',
+                alignRight && 'lg:e-justify-end',
+            )}
+        >
+            {!noTruncate && (
+                <span
+                    ref={hiddenTextRef}
+                    className="e-pointer-events-none e-invisible e-absolute e-whitespace-nowrap e-font-mono"
+                    aria-hidden
+                >
+                    {signature}
+                </span>
+            )}
             <Copyable text={signature}>
-                <span className="font-monospace">
+                <span className="e-relative e-min-w-0 e-overflow-hidden e-font-mono">
                     {link ? (
-                        <Link className={truncate ? 'text-truncate signature-truncate' : ''} href={transactionPath}>
-                            {signatureLabel}
+                        <Link href={transactionPath} className="e-font-mono">
+                            {visibleText}
                         </Link>
                     ) : (
-                        signatureLabel
+                        <span className="e-font-mono">{visibleText}</span>
                     )}
                 </span>
             </Copyable>

--- a/app/components/common/Signature.tsx
+++ b/app/components/common/Signature.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/ui/tooltip';
 import { cn } from '@shared/utils';
 import { TransactionSignature } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
@@ -40,15 +41,24 @@ export function Signature({ signature, alignRight, link, noTruncate }: Props) {
                 </span>
             )}
             <Copyable text={signature}>
-                <span className="e-relative e-min-w-0 e-overflow-hidden e-font-mono">
-                    {link ? (
-                        <Link href={transactionPath} className="e-font-mono">
-                            {visibleText}
-                        </Link>
-                    ) : (
-                        <span className="e-font-mono">{visibleText}</span>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span className="e-relative e-min-w-0 e-overflow-hidden e-font-mono">
+                            {link ? (
+                                <Link href={transactionPath} className="e-font-mono">
+                                    {visibleText}
+                                </Link>
+                            ) : (
+                                <span className="e-font-mono">{visibleText}</span>
+                            )}
+                        </span>
+                    </TooltipTrigger>
+                    {isMidTruncated && (
+                        <TooltipContent className="e-max-w-[min(320px,90vw)]">
+                            <span className="e-break-all e-font-mono">{signature}</span>
+                        </TooltipContent>
                     )}
-                </span>
+                </Tooltip>
             </Copyable>
         </div>
     );

--- a/app/components/common/Signature.tsx
+++ b/app/components/common/Signature.tsx
@@ -4,14 +4,10 @@ import { cn } from '@shared/utils';
 import { TransactionSignature } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import { Copyable } from './Copyable';
-
-const MID_TRUNCATE_CHARS = 5;
-
-// Space reserved for Copyable's copy icon (13px SVG + 8px me-2 margin)
-const COPY_ICON_RESERVED_PX = 24;
+import { useMidTruncation } from './useMidTruncation';
 
 type Props = {
     signature: TransactionSignature;
@@ -22,32 +18,7 @@ type Props = {
 
 export function Signature({ signature, alignRight, link, noTruncate }: Props) {
     const transactionPath = useClusterPath({ pathname: `/tx/${signature}` });
-    const midTruncatedText = `${signature.slice(0, MID_TRUNCATE_CHARS)}...${signature.slice(-MID_TRUNCATE_CHARS)}`;
-
-    const rowRef = useRef<HTMLDivElement>(null);
-    const hiddenTextRef = useRef<HTMLSpanElement>(null);
-    const [isMidTruncated, setIsMidTruncated] = useState(false);
-
-    useEffect(() => {
-        if (noTruncate) {
-            setIsMidTruncated(false);
-            return;
-        }
-
-        const check = () => {
-            const row = rowRef.current;
-            const hidden = hiddenTextRef.current;
-            if (!row || !hidden) return;
-            // Use getBoundingClientRect for sub-pixel precision
-            const available = row.clientWidth - COPY_ICON_RESERVED_PX;
-            setIsMidTruncated(hidden.getBoundingClientRect().width > available);
-        };
-
-        const observer = new ResizeObserver(check);
-        if (rowRef.current) observer.observe(rowRef.current);
-        check();
-        return () => observer.disconnect();
-    }, [noTruncate]);
+    const { rowRef, hiddenTextRef, isMidTruncated, midTruncatedText } = useMidTruncation(!noTruncate, signature);
 
     const visibleText = isMidTruncated ? midTruncatedText : signature;
 

--- a/app/components/common/__tests__/BaseInstructionCard.spec.tsx
+++ b/app/components/common/__tests__/BaseInstructionCard.spec.tsx
@@ -60,7 +60,7 @@ describe('BaseInstructionCard', () => {
             </ScrollAnchorProvider>,
         );
         // instruction should relate to specific program
-        expect(await screen.findAllByText(/Associated Token Program/)).toHaveLength(2);
+        expect(await screen.findAllByText(/Associated Token Program/)).toHaveLength(1);
         // we expect specific internal component to be rendered with "defaultRaw"
         expect(screen.getByText('Instruction Data')).toBeInTheDocument();
     });

--- a/app/components/common/__tests__/useMidTruncation.spec.tsx
+++ b/app/components/common/__tests__/useMidTruncation.spec.tsx
@@ -39,9 +39,9 @@ describe('useMidTruncation', () => {
         vi.restoreAllMocks();
     });
 
-    it('should format midTruncatedText as first-5 + "..." + last-5', () => {
+    it('should format midTruncatedText as first-5 + "…" + last-5', () => {
         render(<Harness enabled text="So1111111111111111111111111111111111111111112" />);
-        expect(screen.getByTestId('mid-text')).toHaveTextContent('So111...11112');
+        expect(screen.getByTestId('mid-text')).toHaveTextContent('So111…11112');
     });
 
     it('should not truncate when disabled', () => {
@@ -91,7 +91,7 @@ describe('useMidTruncation', () => {
             if (this.tagName === 'SPAN') return { width: 200 } as DOMRect;
             return { width: 0 } as DOMRect;
         });
-        vi.spyOn(global, 'getComputedStyle').mockReturnValue({ marginLeft: '8px' } as CSSStyleDeclaration);
+        vi.spyOn(global, 'getComputedStyle').mockReturnValue({ marginInlineStart: '8px' } as CSSStyleDeclaration);
 
         render(<Harness enabled text="So1111111111111111111111111111111111111111112" withTrailing />);
 

--- a/app/components/common/__tests__/useMidTruncation.spec.tsx
+++ b/app/components/common/__tests__/useMidTruncation.spec.tsx
@@ -1,0 +1,137 @@
+import { act, render, screen } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMidTruncation } from '../useMidTruncation';
+
+// ─── Minimal harness that wires the hook's refs to real DOM elements ───────────
+
+function Harness({ enabled, text, withTrailing = false }: { enabled: boolean; text: string; withTrailing?: boolean }) {
+    const trailingRef = useRef<HTMLButtonElement>(null);
+    const { rowRef, hiddenTextRef, isMidTruncated, midTruncatedText } = useMidTruncation(
+        enabled,
+        text,
+        withTrailing ? trailingRef : undefined,
+    );
+    return (
+        <div ref={rowRef} data-testid="row">
+            <span ref={hiddenTextRef} data-testid="hidden" />
+            <span data-testid="state">{isMidTruncated ? 'truncated' : 'full'}</span>
+            <span data-testid="mid-text">{midTruncatedText}</span>
+            {withTrailing && <button ref={trailingRef} data-testid="trailing" />}
+        </div>
+    );
+}
+
+describe('useMidTruncation', () => {
+    let triggerResize: () => void;
+
+    beforeEach(() => {
+        triggerResize = () => {};
+        // jsdom does not implement ResizeObserver — assign a vi.fn stub directly
+        global.ResizeObserver = vi.fn(cb => {
+            triggerResize = () => act(() => cb([], {} as ResizeObserver));
+            return { disconnect: vi.fn(), observe: vi.fn(), unobserve: vi.fn() };
+        }) as unknown as typeof ResizeObserver;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should format midTruncatedText as first-5 + "..." + last-5', () => {
+        render(<Harness enabled text="So1111111111111111111111111111111111111111112" />);
+        expect(screen.getByTestId('mid-text')).toHaveTextContent('So111...11112');
+    });
+
+    it('should not truncate when disabled', () => {
+        render(<Harness enabled={false} text="So1111111111111111111111111111111111111111112" />);
+        expect(screen.getByTestId('state')).toHaveTextContent('full');
+    });
+
+    it('should not truncate when text fits within available width', () => {
+        render(<Harness enabled text="So1111111111111111111111111111111111111111112" />);
+
+        const row = screen.getByTestId('row');
+        const hidden = screen.getByTestId('hidden');
+
+        // text (200px) < row (400px) − copyIcon (24px) = 376px → fits
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+            return { width: this === hidden ? 200 : 0 } as DOMRect;
+        });
+        Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => 400 });
+
+        triggerResize();
+
+        expect(screen.getByTestId('state')).toHaveTextContent('full');
+    });
+
+    it('should truncate when text overflows available width', () => {
+        render(<Harness enabled text="So1111111111111111111111111111111111111111112" />);
+
+        const row = screen.getByTestId('row');
+        const hidden = screen.getByTestId('hidden');
+
+        // text (400px) > row (200px) − copyIcon (24px) = 176px → overflows
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+            return { width: this === hidden ? 400 : 0 } as DOMRect;
+        });
+        Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => 200 });
+
+        triggerResize();
+
+        expect(screen.getByTestId('state')).toHaveTextContent('truncated');
+    });
+
+    it('should subtract trailing element width + margin from available width', () => {
+        // trailingSpace is captured once at mount, so mocks must be in place before render.
+        // Discriminate by tag: BUTTON = trailing (20px), SPAN = hidden text (200px).
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+            if (this.tagName === 'BUTTON') return { width: 20 } as DOMRect;
+            if (this.tagName === 'SPAN') return { width: 200 } as DOMRect;
+            return { width: 0 } as DOMRect;
+        });
+        vi.spyOn(global, 'getComputedStyle').mockReturnValue({ marginLeft: '8px' } as CSSStyleDeclaration);
+
+        render(<Harness enabled text="So1111111111111111111111111111111111111111112" withTrailing />);
+
+        // trailing: 20px + 8px margin = 28px; available = 250 − 24 − 28 = 198px; text = 200px → overflows
+        Object.defineProperty(screen.getByTestId('row'), 'clientWidth', { configurable: true, get: () => 250 });
+
+        triggerResize();
+
+        expect(screen.getByTestId('state')).toHaveTextContent('truncated');
+    });
+
+    it('should disconnect the ResizeObserver on unmount', () => {
+        const disconnect = vi.fn();
+        global.ResizeObserver = vi.fn(() => ({
+            disconnect,
+            observe: vi.fn(),
+            unobserve: vi.fn(),
+        })) as unknown as typeof ResizeObserver;
+
+        const { unmount } = render(<Harness enabled text="abc" />);
+        unmount();
+
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+
+    it('should reset to untruncated when enabled switches to false', () => {
+        const { rerender } = render(<Harness enabled text="So1111111111111111111111111111111111111111112" />);
+
+        const row = screen.getByTestId('row');
+        const hidden = screen.getByTestId('hidden');
+
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+            return { width: this === hidden ? 400 : 0 } as DOMRect;
+        });
+        Object.defineProperty(row, 'clientWidth', { configurable: true, get: () => 200 });
+        triggerResize();
+        expect(screen.getByTestId('state')).toHaveTextContent('truncated');
+
+        rerender(<Harness enabled={false} text="So1111111111111111111111111111111111111111112" />);
+
+        expect(screen.getByTestId('state')).toHaveTextContent('full');
+    });
+});

--- a/app/components/common/stories/Address.stories.tsx
+++ b/app/components/common/stories/Address.stories.tsx
@@ -27,9 +27,19 @@ export const Default: Story = {
     args: {
         pubkey: WSOL,
     },
+    decorators: [
+        Story => (
+            <div style={{ width: 1000 }}>
+                <Story />
+            </div>
+        ),
+    ],
     async play({ canvasElement }) {
         const canvas = within(canvasElement);
-        expect(canvas.getByText('So11111111111111111111111111111111111111112')).toBeInTheDocument();
+        const [visible] = canvas
+            .getAllByText('So11111111111111111111111111111111111111112')
+            .filter(el => !el.hasAttribute('aria-hidden'));
+        expect(visible).toBeInTheDocument();
     },
 };
 

--- a/app/components/common/stories/Address.stories.tsx
+++ b/app/components/common/stories/Address.stories.tsx
@@ -1,0 +1,105 @@
+import { PublicKey } from '@solana/web3.js';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+    createNextjsParameters,
+    withClipboardMock,
+    withCluster,
+    withTokenInfoBatch,
+} from '@storybook-config/decorators';
+import { expect, within } from 'storybook/test';
+
+import { Address } from '../Address';
+
+const WSOL = new PublicKey('So11111111111111111111111111111111111111112');
+
+const meta = {
+    component: Address,
+    decorators: [withClipboardMock, withTokenInfoBatch, withCluster],
+    parameters: createNextjsParameters(),
+    tags: ['test'],
+    title: 'Components/Common/Address',
+} satisfies Meta<typeof Address>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        pubkey: WSOL,
+    },
+    async play({ canvasElement }) {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('So11111111111111111111111111111111111111112')).toBeInTheDocument();
+    },
+};
+
+export const WithLink: Story = {
+    args: {
+        link: true,
+        pubkey: WSOL,
+    },
+    async play({ canvasElement }) {
+        const canvas = within(canvasElement);
+        expect(canvas.getByRole('link')).toBeInTheDocument();
+    },
+};
+
+export const AlignRight: Story = {
+    args: {
+        alignRight: true,
+        pubkey: WSOL,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: '100%' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const Raw: Story = {
+    args: {
+        pubkey: WSOL,
+        raw: true,
+    },
+};
+
+export const WithOverrideText: Story = {
+    args: {
+        overrideText: 'Wrapped SOL',
+        pubkey: WSOL,
+    },
+    async play({ canvasElement }) {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Wrapped SOL')).toBeInTheDocument();
+    },
+};
+
+export const NoTruncate: Story = {
+    args: {
+        noTruncate: true,
+        pubkey: WSOL,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: 500 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+/** Narrow container triggers mid-truncation: "So111...11112" */
+export const Truncated: Story = {
+    args: {
+        pubkey: WSOL,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: 200 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/app/components/common/stories/Signature.stories.tsx
+++ b/app/components/common/stories/Signature.stories.tsx
@@ -21,9 +21,17 @@ export const Default: Story = {
     args: {
         signature: EXAMPLE_SIG,
     },
+    decorators: [
+        Story => (
+            <div style={{ width: 1000 }}>
+                <Story />
+            </div>
+        ),
+    ],
     async play({ canvasElement }) {
         const canvas = within(canvasElement);
-        expect(canvas.getByText(EXAMPLE_SIG)).toBeInTheDocument();
+        const [visible] = canvas.getAllByText(EXAMPLE_SIG).filter(el => !el.hasAttribute('aria-hidden'));
+        expect(visible).toBeInTheDocument();
     },
 };
 

--- a/app/components/common/stories/Signature.stories.tsx
+++ b/app/components/common/stories/Signature.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createNextjsParameters, withClipboardMock, withCluster } from '@storybook-config/decorators';
+import { expect, within } from 'storybook/test';
+
+import { Signature } from '../Signature';
+
+const EXAMPLE_SIG = '5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8SnZeznkjtrfEpsXe87KXk5V5BfVMGAv2NhVJFSq7xvMJV';
+
+const meta = {
+    component: Signature,
+    decorators: [withClipboardMock, withCluster],
+    parameters: createNextjsParameters(),
+    tags: ['test'],
+    title: 'Components/Common/Signature',
+} satisfies Meta<typeof Signature>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        signature: EXAMPLE_SIG,
+    },
+    async play({ canvasElement }) {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText(EXAMPLE_SIG)).toBeInTheDocument();
+    },
+};
+
+export const WithLink: Story = {
+    args: {
+        link: true,
+        signature: EXAMPLE_SIG,
+    },
+    async play({ canvasElement }) {
+        const canvas = within(canvasElement);
+        expect(canvas.getByRole('link')).toBeInTheDocument();
+    },
+};
+
+export const AlignRight: Story = {
+    args: {
+        alignRight: true,
+        signature: EXAMPLE_SIG,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: '100%' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const NoTruncate: Story = {
+    args: {
+        noTruncate: true,
+        signature: EXAMPLE_SIG,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: '100%' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+/** Narrow container triggers mid-truncation: "5KKsL...xvMJV" */
+export const Truncated: Story = {
+    args: {
+        signature: EXAMPLE_SIG,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: 200 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/app/components/common/useMidTruncation.ts
+++ b/app/components/common/useMidTruncation.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { RefObject, useEffect, useRef, useState } from 'react';
+
+const MID_TRUNCATE_CHARS = 5;
+
+// Space reserved for Copyable's copy icon (13px SVG + ~11px margin)
+const COPY_ICON_RESERVED_PX = 24;
+
+/**
+ * Measures whether `text` overflows its container and, if so, signals mid-truncation
+ * (e.g. "So111...11112"). Pass `trailingRef` for any sibling element whose width + margin-left
+ * should be subtracted from the available space (e.g. an edit button).
+ */
+export function useMidTruncation(enabled: boolean, text: string, trailingRef?: RefObject<HTMLElement | null>) {
+    const rowRef = useRef<HTMLDivElement>(null);
+    const hiddenTextRef = useRef<HTMLSpanElement>(null);
+    const [isMidTruncated, setIsMidTruncated] = useState(false);
+
+    useEffect(() => {
+        if (!enabled) {
+            setIsMidTruncated(false);
+            return;
+        }
+
+        // Cache trailing element space once — it's static for the lifetime of this effect run
+        let trailingSpace = 0;
+        const trailing = trailingRef?.current;
+        if (trailing) {
+            const style = getComputedStyle(trailing);
+            trailingSpace = trailing.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
+        }
+
+        const check = () => {
+            const row = rowRef.current;
+            const hidden = hiddenTextRef.current;
+            if (!row || !hidden) return;
+            setIsMidTruncated(
+                hidden.getBoundingClientRect().width > row.clientWidth - COPY_ICON_RESERVED_PX - trailingSpace,
+            );
+        };
+
+        const observer = new ResizeObserver(check);
+        if (rowRef.current) observer.observe(rowRef.current);
+        check();
+
+        return () => observer.disconnect();
+    }, [enabled, text, trailingRef]);
+
+    return {
+        hiddenTextRef,
+        isMidTruncated,
+        midTruncatedText: `${text.slice(0, MID_TRUNCATE_CHARS)}...${text.slice(-MID_TRUNCATE_CHARS)}`,
+        rowRef,
+    };
+}

--- a/app/components/common/useMidTruncation.ts
+++ b/app/components/common/useMidTruncation.ts
@@ -31,7 +31,7 @@ export function useMidTruncation(enabled: boolean, text: string, trailingRef?: R
             const trailing = trailingRef?.current;
             if (trailing) {
                 const style = getComputedStyle(trailing);
-                trailingSpace = trailing.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
+                trailingSpace = trailing.getBoundingClientRect().width + parseFloat(style.marginInlineStart || '0');
             }
             setIsMidTruncated(
                 hidden.getBoundingClientRect().width > row.clientWidth - COPY_ICON_RESERVED_PX - trailingSpace,
@@ -48,7 +48,7 @@ export function useMidTruncation(enabled: boolean, text: string, trailingRef?: R
     return {
         hiddenTextRef,
         isMidTruncated,
-        midTruncatedText: `${text.slice(0, MID_TRUNCATE_CHARS)}...${text.slice(-MID_TRUNCATE_CHARS)}`,
+        midTruncatedText: `${text.slice(0, MID_TRUNCATE_CHARS)}…${text.slice(-MID_TRUNCATE_CHARS)}`,
         rowRef,
     };
 }

--- a/app/components/common/useMidTruncation.ts
+++ b/app/components/common/useMidTruncation.ts
@@ -23,18 +23,16 @@ export function useMidTruncation(enabled: boolean, text: string, trailingRef?: R
             return;
         }
 
-        // Cache trailing element space once — it's static for the lifetime of this effect run
-        let trailingSpace = 0;
-        const trailing = trailingRef?.current;
-        if (trailing) {
-            const style = getComputedStyle(trailing);
-            trailingSpace = trailing.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
-        }
-
         const check = () => {
             const row = rowRef.current;
             const hidden = hiddenTextRef.current;
             if (!row || !hidden) return;
+            let trailingSpace = 0;
+            const trailing = trailingRef?.current;
+            if (trailing) {
+                const style = getComputedStyle(trailing);
+                trailingSpace = trailing.getBoundingClientRect().width + parseFloat(style.marginLeft || '0');
+            }
             setIsMidTruncated(
                 hidden.getBoundingClientRect().width > row.clientWidth - COPY_ICON_RESERVED_PX - trailingSpace,
             );

--- a/app/components/inspector/SignaturesCard.tsx
+++ b/app/components/inspector/SignaturesCard.tsx
@@ -91,7 +91,7 @@ function SignatureRow({
             <td>
                 <span className="badge bg-info-soft me-1">{index + 1}</span>
             </td>
-            <td>{signature ? <Signature signature={signature} truncateChars={40} /> : 'Missing Signature'}</td>
+            <td>{signature ? <Signature signature={signature} /> : 'Missing Signature'}</td>
             <td>
                 <Address pubkey={signer} link />
             </td>

--- a/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
+++ b/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
@@ -46,8 +46,8 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
         [/Source/, /Account/, /Mint/, /Wallet/].forEach(pattern => {
             expect(screen.getByText(pattern)).toBeInTheDocument();
         });
-        expect(screen.queryAllByText(/^System Program$/)).toHaveLength(3);
-        expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
+        expect(screen.queryAllByText(/^System Program$/)).toHaveLength(2);
+        expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(2);
     });
 
     test('should render "Create" card', async () => {

--- a/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
+++ b/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
@@ -77,8 +77,8 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
             [/Source/, /Account/, /Mint/, /Wallet/].forEach(pattern => {
                 expect(screen.getByText(pattern)).toBeInTheDocument();
             });
-            expect(screen.queryAllByText(/^System Program$/)).toHaveLength(3);
-            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
+            expect(screen.queryAllByText(/^System Program$/)).toHaveLength(2);
+            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(2);
         });
     });
 
@@ -111,7 +111,7 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
                     expect(screen.getByText(pattern)).toBeInTheDocument();
                 },
             );
-            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
+            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(2);
         });
     });
 });

--- a/app/features/token-batch/ui/SubInstructionRow.tsx
+++ b/app/features/token-batch/ui/SubInstructionRow.tsx
@@ -57,7 +57,7 @@ function FieldRow({ field }: { field: DecodedField }) {
         <div className="e-flex e-items-center e-gap-2 e-text-sm">
             <span className="e-min-w-[120px] e-text-neutral-500">{field.label}:</span>
             {field.isAddress ? (
-                <Address pubkey={new PublicKey(field.value)} link truncateUnknown aria-label={field.value} />
+                <Address pubkey={new PublicKey(field.value)} link aria-label={field.value} />
             ) : (
                 <span className="e-font-mono e-text-xs">{field.value}</span>
             )}
@@ -69,7 +69,7 @@ function AccountRow({ account }: { account: LabeledAccount }) {
     return (
         <div className="e-flex e-items-center e-gap-2 e-text-sm">
             <span className="e-min-w-[120px] e-text-neutral-500">{account.label}:</span>
-            <Address pubkey={account.pubkey} link truncateUnknown />
+            <Address pubkey={account.pubkey} link />
             {account.isWritable && (
                 <Badge variant="warning" size="xs">
                     Writable

--- a/app/features/transaction-history/ui/TransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/TransactionHistoryCard.tsx
@@ -115,7 +115,7 @@ function TransactionRow({ signature, slot, blockTime, statusClass, statusText, h
     return (
         <tr>
             <td>
-                <Signature signature={signature} link truncateChars={40} />
+                <Signature signature={signature} link />
                 {instructionNames !== null && instructionNames.length > 0 ? (
                     <InstructionList instructions={instructionNames} />
                 ) : instructionNames === null ? (

--- a/app/utils/feature-gate/UpcomingFeatures.tsx
+++ b/app/utils/feature-gate/UpcomingFeatures.tsx
@@ -140,10 +140,7 @@ function FeaturesTable({
                                     </div>
                                 </td>
                                 <td className="fs-sm">
-                                    <Address
-                                        pubkey={new PublicKey(feature.key ?? '')}
-                                        link
-                                    />
+                                    <Address pubkey={new PublicKey(feature.key ?? '')} link />
                                 </td>
                                 <td>
                                     {feature.simds.map((simd, index) => (

--- a/app/utils/feature-gate/UpcomingFeatures.tsx
+++ b/app/utils/feature-gate/UpcomingFeatures.tsx
@@ -143,7 +143,6 @@ function FeaturesTable({
                                     <Address
                                         pubkey={new PublicKey(feature.key ?? '')}
                                         link
-                                        truncateChars={feature.simds[0] ? 12 : 20}
                                     />
                                 </td>
                                 <td>

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,5 +1,14 @@
 import '@testing-library/jest-dom';
 
+// ResizeObserver is not available in jsdom
+if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+}
+
 // Needed for @solana/addresses (Solana Kit) which checks isSecureContext before
 // using crypto.subtle for PDA derivation. jsdom does not set this to true.
 if (!globalThis.isSecureContext) {


### PR DESCRIPTION
## Description
adding truncate logic base on screen resolution for components:
- address
- signature

## Type of change
-   [x] New feature

## Screenshots
| full | truncated |
|--|--|
|<img width="1384" height="520" alt="Screenshot 2026-05-25 at 17 45 02" src="https://github.com/user-attachments/assets/d90306d8-2af2-43af-a350-2ad4311c411a" />|<img width="609" height="381" alt="Screenshot 2026-05-25 at 17 45 23" src="https://github.com/user-attachments/assets/803793e9-a63a-48d8-b4e5-db705f32c1de" />|
|<img width="1143" height="458" alt="Screenshot 2026-05-25 at 17 45 08" src="https://github.com/user-attachments/assets/01cf54be-ab33-4d7b-a872-a55031a73e2d" />|<img width="551" height="458" alt="Screenshot 2026-05-25 at 17 45 18" src="https://github.com/user-attachments/assets/3b4373e7-baed-42fe-9df8-98eace329ef5" />|

## Testing
1. open [transaction page](https://explorer-git-fork-hoodieshq-feat-trunc-c4b024-solana-foundation.vercel.app/tx/5pv1psJNz9h26uhySt1sb8PtzxKPPBFZsgLugsWSJLh9yh6NE4hxoaUWeiKyQGA2WwfEHVNbx66zoUUAC2EBYZvm)
2. see signature field in overview section
3. scroll to programs section and see any address

## Related Issues
[HOO-377](https://linear.app/solana-fndn/issue/HOO-377/improve-address-component-truncation-and-hover-tooltip)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
