### PR TITLE
fix: add max height to copy/download acc size popup

### DIFF
--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -40,10 +40,10 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
     const hasData = data !== undefined && data.length > 0;
     const tooLarge = data !== undefined && data.length > MAX_INLINE_BYTES;
 
-    const hexString = useMemo(() => (data && data.length > 0 && !tooLarge ? toHex(data) : ''), [data, tooLarge]);
+    const hexString = useMemo(() => (data && data.length > 0 ? toHex(data) : ''), [data]);
     const base64String = useMemo(
-        () => (data && data.length > 0 && !tooLarge ? toBase64(new Uint8Array(data)) : ''),
-        [data, tooLarge],
+        () => (data && data.length > 0 ? toBase64(new Uint8Array(data)) : ''),
+        [data],
     );
 
     const hasMoreHex = data !== undefined && data.length > VISIBLE_ROWS * HEX_ROW_BYTES;

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -65,7 +65,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
         <Tabs
             value={tab}
             onValueChange={handleTabChange}
-            className="e-max-w-[540px] e-overflow-hidden e-rounded-lg e-border e-border-solid e-border-outer-space-800 e-bg-heavy-metal-900"
+            className="e-max-w-[100vw] lg:e-max-w-[540px] e-overflow-hidden e-rounded-lg e-border e-border-solid e-border-outer-space-800 e-bg-heavy-metal-900"
         >
             <div className="e-flex e-flex-wrap e-justify-between e-gap-8 e-border-b e-border-outer-space-800 e-px-3 [border-bottom-style:solid]">
                 <TabsList>
@@ -86,7 +86,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                         variant="outline"
                         size="sm"
                         aria-label="Copy"
-                        disabled={!hasData || loading || tooLarge}
+                        disabled={!hasData || loading}
                         onClick={() => copy(tab === 'base64' ? base64String : hexString)}
                     >
                         <Copy size={12} />
@@ -102,9 +102,11 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 </div>
             </div>
 
-            <TabsContent value="hex" className={cn('e-text-start', loading ? 'e-p-3' : 'e-p-1.5')}>
+            <TabsContent value="hex" className={cn('e-text-start e-max-h-80 e-overflow-y-auto e-p-1.5', loading && 'e-p-3', tooLarge && 'e-px-3 e-py-2')}>
                 {loading ? (
                     <span className="spinner-grow spinner-grow-sm" />
+                ) : tooLarge ? (
+                    <span className="e-text-sm e-text-outer-space-200">Too large to display - use download/copy.</span>
                 ) : (
                     <HexData
                         className="e-w-full"
@@ -116,13 +118,13 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 )}
             </TabsContent>
 
-            <TabsContent value="base64" className={cn('e-p-3 e-text-start', !loading && data?.length && 'e-py-2')}>
+            <TabsContent value="base64" className={cn('e-p-3 e-text-start e-max-h-80 e-overflow-y-auto', !loading && data?.length && 'e-py-2')}>
                 {loading ? (
                     <span className="spinner-grow spinner-grow-sm" />
                 ) : !hasData ? (
                     <span className="e-text-sm e-text-outer-space-200">No data</span>
                 ) : tooLarge ? (
-                    <span className="e-text-sm e-text-outer-space-200">Too large to display — use download.</span>
+                    <span className="e-text-sm e-text-outer-space-200">Too large to display - use download/copy.</span>
                 ) : (
                     <span className="e-text-wrap e-break-all e-font-mono e-text-xs e-text-white">
                         {visibleBase64}
@@ -131,7 +133,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 )}
             </TabsContent>
 
-            {hasMore && !loading && hasData && (
+            {(hasMore && !tooLarge) && !loading && hasData && (
                 <div className="e-mt-1 e-flex e-justify-center e-border-t e-border-outer-space-800 [border-top-style:solid]">
                     <Button
                         variant="ghost"

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -41,10 +41,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
     const tooLarge = data !== undefined && data.length > MAX_INLINE_BYTES;
 
     const hexString = useMemo(() => (data && data.length > 0 ? toHex(data) : ''), [data]);
-    const base64String = useMemo(
-        () => (data && data.length > 0 ? toBase64(new Uint8Array(data)) : ''),
-        [data],
-    );
+    const base64String = useMemo(() => (data && data.length > 0 ? toBase64(new Uint8Array(data)) : ''), [data]);
 
     const hasMoreHex = data !== undefined && data.length > VISIBLE_ROWS * HEX_ROW_BYTES;
     const visibleData = !expanded && hasMoreHex ? data.subarray(0, VISIBLE_ROWS * HEX_ROW_BYTES) : data;

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -65,7 +65,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
         <Tabs
             value={tab}
             onValueChange={handleTabChange}
-            className="e-max-w-[100vw] lg:e-max-w-[540px] e-overflow-hidden e-rounded-lg e-border e-border-solid e-border-outer-space-800 e-bg-heavy-metal-900"
+            className="e-max-w-[100vw] e-overflow-hidden e-rounded-lg e-border e-border-solid e-border-outer-space-800 e-bg-heavy-metal-900 lg:e-max-w-[540px]"
         >
             <div className="e-flex e-flex-wrap e-justify-between e-gap-8 e-border-b e-border-outer-space-800 e-px-3 [border-bottom-style:solid]">
                 <TabsList>
@@ -102,7 +102,14 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 </div>
             </div>
 
-            <TabsContent value="hex" className={cn('e-text-start e-max-h-80 e-overflow-y-auto e-p-1.5', loading && 'e-p-3', tooLarge && 'e-px-3 e-py-2')}>
+            <TabsContent
+                value="hex"
+                className={cn(
+                    'e-max-h-80 e-overflow-y-auto e-p-1.5 e-text-start',
+                    loading && 'e-p-3',
+                    tooLarge && 'e-px-3 e-py-2',
+                )}
+            >
                 {loading ? (
                     <span className="spinner-grow spinner-grow-sm" />
                 ) : tooLarge ? (
@@ -118,7 +125,10 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 )}
             </TabsContent>
 
-            <TabsContent value="base64" className={cn('e-p-3 e-text-start e-max-h-80 e-overflow-y-auto', !loading && data?.length && 'e-py-2')}>
+            <TabsContent
+                value="base64"
+                className={cn('e-max-h-80 e-overflow-y-auto e-p-3 e-text-start', !loading && data?.length && 'e-py-2')}
+            >
                 {loading ? (
                     <span className="spinner-grow spinner-grow-sm" />
                 ) : !hasData ? (
@@ -133,7 +143,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                 )}
             </TabsContent>
 
-            {(hasMore && !tooLarge) && !loading && hasData && (
+            {hasMore && !tooLarge && !loading && hasData && (
                 <div className="e-mt-1 e-flex e-justify-center e-border-t e-border-outer-space-800 [border-top-style:solid]">
                     <Button
                         variant="ghost"


### PR DESCRIPTION
## Description
1. adding max heigh for big sizes
2. adding max width to mobile view
3. adding 'to large' description for hex more than MAX_INLINE_BYTES

## Type of change
-   [x] Bug fix

## Screenshots
<img width="467" height="184" alt="Screenshot 2026-05-26 at 12 29 04" src="https://github.com/user-attachments/assets/2884891d-7d00-4336-a840-af87e451c865" />
<img width="616" height="472" alt="Screenshot 2026-05-26 at 12 29 16" src="https://github.com/user-attachments/assets/8821aac5-a32b-4b46-bf03-f6a3105aefcd" />
<img width="419" height="553" alt="Screenshot 2026-05-26 at 12 30 04" src="https://github.com/user-attachments/assets/7bfa7465-5eb6-41a3-a77b-9faf2d9871bf" />

## Testing
1. open [transaction page](https://explorer-git-fork-hoodieshq-fix-hoo-56-4def54-solana-foundation.vercel.app/tx/5pv1psJNz9h26uhySt1sb8PtzxKPPBFZsgLugsWSJLh9yh6NE4hxoaUWeiKyQGA2WwfEHVNbx66zoUUAC2EBYZvm) or another [tx page](https://explorer-git-fork-hoodieshq-fix-hoo-56-4def54-solana-foundation.vercel.app/tx/2PXoeg3wvNRp6wg1HAWx2byKeFSfiky5HpvixJ3CwiLRxUNbxb78xxMgY9FxtutuyU1JoQMByHCjXKdrR6VnhAg)
2. scroll to the accounts section

## Related Issues
[HOO-569](https://linear.app/solana-fndn/issue/HOO-569/add-max-height-to-copydownload-acc-size)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)