### PR TITLE
feat(agents): Introduce agent rules

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# Lint + format staged files only. Full pipeline still runs on pre-push.
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.mts' '*.mjs' '*.cjs' '*.js')
+[ -z "$files" ] && exit 0
+
+echo "$files" | xargs corepack pnpm pretty:format && \
+echo "$files" | xargs corepack pnpm eslint:lint && \
+echo "$files" | xargs corepack pnpm test:changed

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
 
 # Lint + format staged files only. Full pipeline still runs on pre-push.
-files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.mts' '*.mjs' '*.cjs' '*.js')
-[ -z "$files" ] && exit 0
+staged() {
+  git diff --cached --name-only --diff-filter=ACMR -z -- \
+    '*.ts' '*.tsx' '*.mts' '*.mjs' '*.cjs' '*.js'
+}
 
-echo "$files" | xargs corepack pnpm pretty:format && \
-echo "$files" | xargs corepack pnpm eslint:lint && \
-echo "$files" | xargs corepack pnpm test:changed
+[ -z "$(staged)" ] && exit 0
+
+staged | xargs -0 corepack pnpm pretty:format && \
+staged | xargs -0 corepack pnpm eslint:lint && \
+staged | xargs -0 corepack pnpm test:changed

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Mirrors the CI pipeline: format → lint → build → test
+corepack pnpm format:ci && corepack pnpm lint && corepack pnpm build && corepack pnpm test:ci

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,1 @@
-auto-install-peers=true
-minimum-release-age=20160
-minimum-release-age-exclude[]="@solana-program/token"
-minimum-release-age-exclude[]="@solana/kit"
-minimum-release-age-exclude[]="@codama/dynamic-client"
+# pnpm settings live in pnpm-workspace.yaml; npm-side enforcement via devEngines in package.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ dist/
 build/
 .pnpm-store/
 .claude/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Project Conventions
+
+*Bullets without a prefix are mandatory; `Recommended:` / `Preferred:` mark soft guidance.*
+
+## Principles
+
+- Start with the simplest solution that works. Add complexity only when there is a proven need — not because something "might" be useful.
+
+## Architecture
+**Applies to:** `app/**`
+
+- Follow Feature-Sliced Design (FSD): features in `app/features/`, entities in `app/entities/`, shared code in `app/shared/`.
+  - Server-only code within a slice lives in a dedicated `server.ts` file at the slice root, separate from client code.
+- Prefer functional style. Use classes only to scope domain-specific logic (e.g., IDL interpreters, program executors).
+
+## Code Style
+**Applies to:** `app/**/*.{ts,tsx,mts,mjs,cjs,js}`
+
+- Recommended: organize files top-down — exported/public API at the top, auxiliary helpers toward the bottom.
+- Use path aliases (`@entities/`, `@features/`, `@shared/`, `@utils/`, `@providers/`, `@validators/`) over relative imports.
+- Use object destructuring for function parameters when there are 3+ arguments or 2+ optional arguments.
+- Recommended: argument ordering — stable/context arguments first (cluster, connection, config), data arguments in the middle, arguments with default values last.
+
+## Comments
+**Applies to:** `app/**/*.{ts,tsx}`
+
+- Add a clarification comment when a decision might look wrong or surprising to a future reader (e.g. using an index key when a natural key exists, choosing a seemingly suboptimal approach for a non-obvious reason). Explain why, not what.
+
+## Frontend
+**Applies to:** `app/**/*.tsx`
+
+- Use `class-variance-authority` (CVA) for component variants — not conditional class logic or CSS overrides.
+- Recommended: name stateless, hook-free UI components with a `Base` prefix (e.g., `BaseSearch`, `BaseTransactionCard`). When using the `Base` prefix, pair the component with a Storybook story.
+
+## Storybook
+**Applies to:** `**/*.stories.{ts,tsx}`
+
+- Do not use unnecessary decorators. Do not create wrappers that aren't used in the app.
+- Infer story args from the component signature — do not remap props.
+- Do not use `centered` layout — real component edges must be visible.
+
+## Libraries
+**Applies to:** `app/**/*.{ts,tsx}`
+
+- Use `superstruct` for runtime validation of external data (API responses, URL params, user input).
+- Use the `Logger` abstraction (`Logger.error`, `Logger.warn`, `Logger.info`) instead of direct Sentry imports. Import Sentry utilities from `@/app/shared/lib/sentry`, not from `@sentry/nextjs`.
+- Preferred: use `@solana/kit` for new functionality and when refactoring existing code.
+
+## Testing
+**Applies to:** `app/features/**`, `app/entities/**`, `app/shared/**`
+
+- Cover features, entities, and shared modules with unit tests when adding or modifying code.
+
+## CI
+
+- The CI pipeline runs `pnpm format:ci` → `pnpm lint` → `pnpm build` → `pnpm test:ci`. These checks are mandatory — fix violations, never bypass them (no `--no-verify`, no skipping, no disabling rules to silence output). The local hooks below are a developer convenience to surface failures before push; the checks themselves are not optional. Enable with `git config core.hooksPath .githooks`:
+  - `pre-commit` — runs `pretty:format`, `eslint:lint`, and `test:changed` scoped to staged files.
+  - `pre-push` — runs the full pipeline (format, lint, build, test).
+- Optionally, use [`act`](https://github.com/nektos/act) to run GitHub Actions workflows locally before pushing.
+
+## PR Review
+
+When reviewing a pull request, agents are encouraged to launch their available review tooling and surface findings to the contributor. Scope reviews to the PR's changed files unless instructed otherwise. Findings are advisory — the contributor decides whether and how to act on them. We do suggest addressing the most destructive findings (bugs, security issues, data-loss risks) before merging.
+
+Recommended: check whether the PR's changed files appear in any per-file ignore block (like `eslint.config.mjs`). For overlapping files, suggest fixing existing violations and removing the file from the ignore list — opportunistic cleanup, not a blocker. Flag any *new* violations added in the same file: the ignore list exempts existing code, not new additions.
+
+---
+
+## Adoption
+
+Tools wired up to read these rules:
+- **Claude Code** — reads `AGENTS.md` at project root alongside `CLAUDE.md`
+- **Greptile** — auto-indexes `AGENTS.md` for PR reviews
+- **Codex (OpenAI)** — reads `AGENTS.md` at project root
+- **Cursor** — reads `AGENTS.md` at project root
+- **Zed** — reads `AGENTS.md` at project root
+- **opencode** — reads `AGENTS.md` at project root
+- **GitHub Copilot** — reads `.github/copilot-instructions.md`, symlinked to `AGENTS.md`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,16 @@ const TEST_AND_STORY_FILES = [
 export default tseslint.config(
     // Global ignores
     {
-        ignores: ['dist/**', 'lib/**', '.next/**', '.next-dev/**', 'node_modules/**', '.claude/**', 'next-env.d.ts'],
+        ignores: [
+            'dist/**',
+            'lib/**',
+            '.next/**',
+            '.next-dev/**',
+            'node_modules/**',
+            '.claude/**',
+            '.worktrees/**',
+            'next-env.d.ts',
+        ],
     },
 
     // Next.js config via compat (still legacy format in v15)

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
         "build-sb": "storybook build",
         "coverage": "vitest --coverage",
         "dev": "next dev",
-        "format": "prettier --config .prettierrc.cjs '**/*.{ts,tsx,mts,mjs,cjs}' '*.json' --check",
+        "eslint:lint": "eslint",
+        "format": "pnpm pretty:format '**/*.{ts,tsx,mts,mjs,cjs}' '*.json'",
         "format:ci": "pnpm format",
         "gen": "pnpx shadcn@^2.4.0 add",
-        "lint": "eslint .",
+        "lint": "pnpm eslint:lint .",
+        "pretty:format": "prettier --config .prettierrc.cjs --check",
         "sb": "storybook dev -p 6006",
         "scan": "next dev & react-scan localhost:3000",
         "start": "next start",
         "test": "vitest --project specs run",
+        "test:changed": "pnpm vitest:test related --run",
         "test:ci": "vitest --project specs run",
         "test:e2e": "playwright test",
         "test:e2e:ci": "playwright test",
@@ -24,7 +27,8 @@
         "test:sb:watch": "vitest --project storybook --watch",
         "test:watch": "vitest --project specs --watch",
         "pretypes": "next build",
-        "types": "tsc --noEmit"
+        "types": "tsc --noEmit",
+        "vitest:test": "vitest --project specs"
     },
     "dependencies": {
         "@blockworks-foundation/mango-client": "3.6.7",
@@ -187,6 +191,12 @@
         "vitest": "3.2.4"
     },
     "packageManager": "pnpm@10.17.1",
+    "devEngines": {
+        "packageManager": {
+            "name": "pnpm",
+            "onFail": "error"
+        }
+    },
     "engines": {
         "node": "^22"
     },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+autoInstallPeers: true
+minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
   - '@codama/*'
   - codama
+  - '@solana-program/token'
+  - '@solana/kit'

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -56,7 +56,7 @@ export default defineConfig({
         conditions: ['browser', 'default'],
     },
     test: {
-        exclude: ['**/node_modules/**', '.claude/**'],
+        exclude: ['**/node_modules/**', '.claude/**', '.worktrees/**'],
         projects: [
             {
                 extends: true,


### PR DESCRIPTION
## Description

Add `AGENTS.md` with project-specific code standards extracted from the internal `CLAUDE.md` ruleset, rewritten for multi-agent consumption (Greptile, Codex, Cursor, Copilot). Covers architecture (FSD), code style, frontend conventions, testing, library choices, CI, and PR review guidelines.

Add an optional local pre-push git hook (`.githooks/pre-push`) that mirrors the CI pipeline (`format → lint → build → test`).

## Type of change

-   [x] Documentation update
-   [x] Other (please describe): developer tooling (git hook, agent rules)

## Screenshots

N/A — no UI changes.

## Testing

- Verified all rules in `AGENTS.md` against the actual codebase (directory structure, package names, ESLint config, path aliases)
- Confirmed `.githooks/pre-push` is executable and mirrors CI steps

## Related Issues

[HOO-249](https://linear.app/solana-fndn/issue/HOO-249)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass

## Additional Notes

`AGENTS.md` is read natively by Claude Code, Greptile, Codex, and Cursor. For Copilot/Zed/opencode, symlink or config instructions are included in the Adoption section. The pre-push hook is opt-in via `git config core.hooksPath .githooks`.
