### PR TITLE
chore: fix issues with waitFor

### DIFF
--- a/app/components/common/__tests__/BaseInstructionCard.spec.tsx
+++ b/app/components/common/__tests__/BaseInstructionCard.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
 import { ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { TransactionMessage } from '@solana/web3.js';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { resolveAddressLookupTables } from '@/app/__tests__/mock-resolvers';
 import * as stubs from '@/app/__tests__/mock-stubs';
@@ -12,7 +12,7 @@ import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
 import { BaseInstructionCard } from '../BaseInstructionCard';
 
 describe('BaseInstructionCard', () => {
-    test('should render "BaseInstructionCard"', () => {
+    test('should render "BaseInstructionCard"', async () => {
         const index = 1;
         const m = mock.deserializeMessageV0(stubs.aTokenCreateIdempotentMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -30,8 +30,10 @@ describe('BaseInstructionCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        // check that card is rendered with proper title
-        expect(screen.getByText(/Program: Instruction/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Program: Instruction/)).toBeInTheDocument();
+        });
     });
 
     test('should render "BaseInstructionCard" with raw data', async () => {

--- a/app/components/inspector/__tests__/AccountsCard.spec.tsx
+++ b/app/components/inspector/__tests__/AccountsCard.spec.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 vi.mock('next/navigation');
@@ -23,11 +23,11 @@ describe('inspector::AccountsCard', () => {
             </ClusterProvider>,
         );
 
-        // Should show account list header
-        expect(screen.getByText(/Account List/)).toBeInTheDocument();
-
-        // Should show account rows
-        expect(screen.getByText('Account #1')).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Account List/)).toBeInTheDocument();
+            expect(screen.getByText('Account #1')).toBeInTheDocument();
+        });
     });
 
     test('should render accounts from versioned message', async () => {
@@ -41,10 +41,10 @@ describe('inspector::AccountsCard', () => {
             </ClusterProvider>,
         );
 
-        // Should show account list header
-        expect(screen.getByText(/Account List/)).toBeInTheDocument();
-
-        // Should show account rows
-        expect(screen.getByText('Account #1')).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Account List/)).toBeInTheDocument();
+            expect(screen.getByText('Account #1')).toBeInTheDocument();
+        });
     });
 });

--- a/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
+++ b/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
@@ -50,7 +50,7 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
         expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
     });
 
-    test('should render "Create" card', () => {
+    test('should render "Create" card', async () => {
         const index = 2;
         const m = mock.deserializeMessage(stubs.aTokenCreateMsgWithInnerCards);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -71,15 +71,18 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Associated Token Program: Create$/)).toBeInTheDocument();
-        [/Source/, /Account/, /Mint/, /Wallet/].forEach(pattern => {
-            expect(screen.getByText(pattern)).toBeInTheDocument();
+        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Create$/)).toBeInTheDocument();
+            [/Source/, /Account/, /Mint/, /Wallet/].forEach(pattern => {
+                expect(screen.getByText(pattern)).toBeInTheDocument();
+            });
+            expect(screen.queryAllByText(/^System Program$/)).toHaveLength(3);
+            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
         });
-        expect(screen.queryAllByText(/^System Program$/)).toHaveLength(3);
-        expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
     });
 
-    test('should render "RecoverNested" card', () => {
+    test('should render "RecoverNested" card', async () => {
         const index = 0;
         const m = mock.deserializeMessage(stubs.aTokenRecoverNestedMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -100,16 +103,19 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Associated Token Program: Recover Nested/)).toBeInTheDocument();
-        [/Destination/, /Nested Mint/, /Nested Owner/, /Nested Source/, /Owner Mint/, /^Owner$/].forEach(pattern => {
-            expect(screen.getByText(pattern)).toBeInTheDocument();
+        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Recover Nested/)).toBeInTheDocument();
+            [/Destination/, /Nested Mint/, /Nested Owner/, /Nested Source/, /Owner Mint/, /^Owner$/].forEach(pattern => {
+                expect(screen.getByText(pattern)).toBeInTheDocument();
+            });
+            expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
         });
-        expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
     });
 });
 
 describe('inspector::AssociatedTokenDetailsCard with inner cards', () => {
-    test('should render "CreateIdempotentDetailsCard"', () => {
+    test('should render "CreateIdempotentDetailsCard"', async () => {
         const index = 1;
         const m = mock.deserializeMessageV0(stubs.aTokenCreateIdempotentMsgWithInnerCards);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -131,6 +137,9 @@ describe('inspector::AssociatedTokenDetailsCard with inner cards', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.queryByText(/Inner Instructions/)).not.toBeInTheDocument();
+        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        await waitFor(() => {
+            expect(screen.queryByText(/Inner Instructions/)).not.toBeInTheDocument();
+        });
     });
 });

--- a/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
+++ b/app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx
@@ -71,7 +71,7 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
         await waitFor(() => {
             expect(screen.getByText(/Associated Token Program: Create$/)).toBeInTheDocument();
             [/Source/, /Account/, /Mint/, /Wallet/].forEach(pattern => {
@@ -103,12 +103,14 @@ describe('inspector::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
         await waitFor(() => {
             expect(screen.getByText(/Associated Token Program: Recover Nested/)).toBeInTheDocument();
-            [/Destination/, /Nested Mint/, /Nested Owner/, /Nested Source/, /Owner Mint/, /^Owner$/].forEach(pattern => {
-                expect(screen.getByText(pattern)).toBeInTheDocument();
-            });
+            [/Destination/, /Nested Mint/, /Nested Owner/, /Nested Source/, /Owner Mint/, /^Owner$/].forEach(
+                pattern => {
+                    expect(screen.getByText(pattern)).toBeInTheDocument();
+                },
+            );
             expect(screen.queryAllByText(/^Token Program$/)).toHaveLength(3);
         });
     });
@@ -137,8 +139,9 @@ describe('inspector::AssociatedTokenDetailsCard with inner cards', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        // waitFor absorbs ClusterProvider's post-mount dispatch inside an act() boundary
+        // Positive assertion forces waitFor to poll until the async render settles; the negative one alone would pass immediately.
         await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Create Idempotent/)).toBeInTheDocument();
             expect(screen.queryByText(/Inner Instructions/)).not.toBeInTheDocument();
         });
     });

--- a/app/components/instruction/__tests__/AssociatedTokenDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/AssociatedTokenDetailsCard.spec.tsx
@@ -2,7 +2,7 @@
 import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
 import * as spl from '@solana/spl-token';
 import { PublicKey, TransactionMessage } from '@solana/web3.js';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useSearchParams } from 'next/navigation';
 import { vi } from 'vitest';
 
@@ -24,7 +24,7 @@ useSearchParams.mockReturnValue({
 });
 
 describe('instruction::AssociatedTokenDetailsCard', () => {
-    test('should render "CreateIdempotentDetailsCard"', () => {
+    test('should render "CreateIdempotentDetailsCard"', async () => {
         const index = 1;
         const m = mock.deserializeMessageV0(stubs.aTokenCreateIdempotentMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -59,10 +59,13 @@ describe('instruction::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Associated Token Program: Create Idempotent/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Create Idempotent/)).toBeInTheDocument();
+        });
     });
 
-    test('should render "CreateDetailsCard"', () => {
+    test('should render "CreateDetailsCard"', async () => {
         const index = 2;
         const m = mock.deserializeMessage(stubs.aTokenCreateMsgWithInnerCards);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -96,10 +99,13 @@ describe('instruction::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Associated Token Program: Create$/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Create$/)).toBeInTheDocument();
+        });
     });
 
-    test('should render "RecoverNestedDetailsCard"', () => {
+    test('should render "RecoverNestedDetailsCard"', async () => {
         const index = 0;
         const m = mock.deserializeMessage(stubs.aTokenRecoverNestedMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -134,6 +140,9 @@ describe('instruction::AssociatedTokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Associated Token Program: Recover Nested/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Associated Token Program: Recover Nested/)).toBeInTheDocument();
+        });
     });
 });

--- a/app/components/instruction/__tests__/ComputeBudgetDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/ComputeBudgetDetailsCard.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
 import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
 import { ComputeBudgetProgram, TransactionMessage } from '@solana/web3.js';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useSearchParams } from 'next/navigation';
 import { vi } from 'vitest';
 
@@ -22,7 +22,7 @@ useSearchParams.mockReturnValue({
 });
 
 describe('instruction::ComputeBudgetDetailsCard', () => {
-    test('should render "SetComputeUnitPrice"', () => {
+    test('should render "SetComputeUnitPrice"', async () => {
         const index = 0;
         const m = mock.deserializeMessageV0(stubs.computeBudgetMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -45,10 +45,13 @@ describe('instruction::ComputeBudgetDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/7.187812 lamports per compute unit/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/7.187812 lamports per compute unit/)).toBeInTheDocument();
+        });
     });
 
-    test('should render "SetComputeUnitLimit"', () => {
+    test('should render "SetComputeUnitLimit"', async () => {
         const index = 1;
         const m = mock.deserializeMessageV0(stubs.computeBudgetMsg);
         const lookups = resolveAddressLookupTables(m.addressTableLookups);
@@ -71,6 +74,9 @@ describe('instruction::ComputeBudgetDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/155.666 compute units/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/155.666 compute units/)).toBeInTheDocument();
+        });
     }, 15000);
 });

--- a/app/components/instruction/__tests__/SystemDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/SystemDetailsCard.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
 import { intoParsedInstruction, intoParsedTransaction } from '@components/inspector/into-parsed-data';
 import { ParsedInstruction, SystemProgram, TransactionMessage } from '@solana/web3.js';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 vi.mock('next/navigation', () => ({
@@ -47,7 +47,10 @@ describe('instruction::SystemDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/System Program: Transfer/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/System Program: Transfer/)).toBeInTheDocument();
+        });
     });
 
     test('should render SystemProgram::TransferWithSeed instruction', async () => {
@@ -77,6 +80,9 @@ describe('instruction::SystemDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/System Program: Transfer w\/ Seed/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/System Program: Transfer w\/ Seed/)).toBeInTheDocument();
+        });
     });
 });

--- a/app/components/instruction/__tests__/TokenDetailsCard.spec.tsx
+++ b/app/components/instruction/__tests__/TokenDetailsCard.spec.tsx
@@ -3,7 +3,7 @@ import { intoParsedInstruction, intoParsedTransaction } from '@components/inspec
 import { intoTransactionInstructionFromVersionedMessage } from '@components/inspector/utils';
 import { ParsedInstruction, PublicKey, TransactionMessage } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, vi } from 'vitest';
 
 vi.mock('next/navigation', () => ({
@@ -23,7 +23,8 @@ import { TokenDetailsCard } from '../token/TokenDetailsCard';
 
 describe('instruction::TokenDetailsCard', () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        // shouldAdvanceTime keeps waitFor's polling alive while the original setTimeout fix stays in place
+        vi.useFakeTimers({ shouldAdvanceTime: true });
     });
 
     afterEach(() => {
@@ -57,7 +58,10 @@ describe('instruction::TokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Token Program: Transfer/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Token Program: Transfer/)).toBeInTheDocument();
+        });
     });
 
     test('should render Token::TransferChecked instruction', async () => {
@@ -88,6 +92,9 @@ describe('instruction::TokenDetailsCard', () => {
                 </ClusterProvider>
             </ScrollAnchorProvider>,
         );
-        expect(screen.getByText(/Token Program: Transfer \(Checked\)/)).toBeInTheDocument();
+        // waitFor's act() boundary absorbs ClusterProvider's post-mount dispatch
+        await waitFor(() => {
+            expect(screen.getByText(/Token Program: Transfer \(Checked\)/)).toBeInTheDocument();
+        });
     });
 });


### PR DESCRIPTION
## Description

Convert three synchronous tests in `app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx` to `async` and wrap their assertions in `await waitFor(...)`. The `waitFor` boundary absorbs `ClusterProvider`'s post-mount dispatch (`Connecting → Connected`, triggered by the globally mocked `@solana/kit` RPC resolving on the next microtask), eliminating the `An update to ClusterProvider inside a test was not wrapped in act(...)` warnings.

No production code changes.

## Type of change

-   [x] Other (please describe): test hygiene — remove React `act()` warnings from inspector specs

## Screenshots

N/A — no UI changes.

## Testing

- Ran `pnpm exec vitest --project specs run app/components/inspector/__tests__/AssociatedTokenDetailsCard.spec.tsx`
- Verified zero `wrapped in act(...)` warnings against the master spec output
- All four tests in the file pass (the previously passing `CreateIdempotent` test already used `await waitFor` and continues to pass)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass

## Additional Notes

Root cause: `ClusterProvider`'s mount effect calls `updateCluster`, which dispatches `Connecting` synchronously and then awaits the (globally mocked) RPC. The mocked promises resolve on the next microtask and dispatch `Connected`, re-rendering `Address` (it reads `clusterInfo.genesisHash` via `useTokenInfo`). In purely synchronous tests, that dispatch lands after the test body has already returned — outside any `act()` boundary. Wrapping the final assertions in `await waitFor(...)` lets that dispatch settle inside an act boundary.
