### PR TITLE
fix: no-transfers and inner-instructions receipt placeholders

### DIFF
--- a/app/features/receipt/__e2e__/receipt.e2e.ts
+++ b/app/features/receipt/__e2e__/receipt.e2e.ts
@@ -22,12 +22,12 @@ test.describe('receipt feature validation', () => {
         await page
             .locator('h3:has-text("Solana Receipt")')
             .or(page.locator('h2:has-text("Transaction")'))
-            .or(page.locator('text=Receipts can only be generated'))
+            .or(page.locator('text=Receipts are only available'))
             .first()
             .waitFor({ state: 'visible', timeout: CONTENT_TIMEOUT });
 
         const hasReceipt = await hasElement(page, 'h3:has-text("Solana Receipt")');
-        const hasNoReceipt = await hasElement(page, 'text=Receipts can only be generated');
+        const hasNoReceipt = await hasElement(page, 'text=Receipts are only available');
         const hasTransactionPage = await hasElement(page, 'h2:has-text("Transaction")');
 
         if (FEATURE_ENABLED) {
@@ -49,7 +49,7 @@ test.describe('when feature enabled', () => {
     test('renders receipt for valid transaction', async ({ page }) => {
         const hasReceipt = await navigateToReceipt(page);
         const hasError = await hasElement(page, 'text=Not Found');
-        const hasNoReceipt = await hasElement(page, 'text=Receipts can only be generated');
+        const hasNoReceipt = await hasElement(page, 'text=Receipts are only available');
 
         expect(hasReceipt || hasError || hasNoReceipt).toBe(true);
 
@@ -67,7 +67,7 @@ test.describe('when feature enabled', () => {
             () => {
                 const text = document.body?.innerText || '';
                 return (
-                    text.includes('Receipts can only be generated') ||
+                    text.includes('Receipts are only available') ||
                     text.includes('Fetch Failed') ||
                     text.includes('Error')
                 );
@@ -190,7 +190,7 @@ async function navigateToReceipt(page: Page): Promise<boolean> {
     await page
         .locator('h3:has-text("Solana Receipt")')
         .or(page.locator('text=Not Found'))
-        .or(page.locator('text=Receipts can only be generated'))
+        .or(page.locator('text=Receipts are only available'))
         .first()
         .waitFor({ state: 'visible', timeout: CONTENT_TIMEOUT });
 

--- a/app/features/receipt/__e2e__/receipt.e2e.ts
+++ b/app/features/receipt/__e2e__/receipt.e2e.ts
@@ -77,9 +77,7 @@ test.describe('when feature enabled', () => {
 
         const text = await page.textContent('body');
         const showsError =
-            text?.includes('Receipts can only be generated') ||
-            text?.includes('Fetch Failed') ||
-            text?.includes('Error');
+            text?.includes('Receipts are only available') || text?.includes('Fetch Failed') || text?.includes('Error');
 
         expect(showsError).toBe(true);
     });

--- a/app/features/receipt/model/create-receipt.ts
+++ b/app/features/receipt/model/create-receipt.ts
@@ -14,7 +14,7 @@ import { createSolTransferReceipt } from './sol-transfer';
 import { createTokenTransferReceipt } from './token-transfer';
 import { hasTransfers, isSolReceipt, isTokenReceipt, type Receipt } from './types';
 
-export type ReceiptUnavailabilityReason = 'mixed-mint' | 'no-transfers';
+export type ReceiptUnavailabilityReason = 'inner-transfers' | 'mixed-mint' | 'no-transfers';
 
 export type ReceiptResult =
     | { kind: 'ok'; receipt: FormattedReceipt }
@@ -41,7 +41,8 @@ export async function extractReceiptData(tx: ParsedTransactionWithMeta, cluster:
         return { kind: 'ok', receipt: formatReceiptData(solReceipt, cluster) };
     }
 
-    return { kind: 'unavailable', reason: 'no-transfers' };
+    const hasInnerInstructions = (tx.meta?.innerInstructions?.length ?? 0) > 0;
+    return { kind: 'unavailable', reason: hasInnerInstructions ? 'inner-transfers' : 'no-transfers' };
 }
 
 export function formatReceiptData(receipt: Receipt, cluster: Cluster): FormattedReceipt {

--- a/app/features/receipt/receipt-page.tsx
+++ b/app/features/receipt/receipt-page.tsx
@@ -132,7 +132,10 @@ function messageForReason(reason: ReceiptUnavailabilityReason | undefined): stri
     switch (reason) {
         case 'mixed-mint':
             return 'Receipts are only available when all token transfers in a transaction use the same mint. This transaction transfers multiple different tokens.';
+        case 'inner-transfers':
+            return 'Receipts are only available for simple transfers. This transaction contains inner program instructions.';
         case 'no-transfers':
+            return 'No transfer instructions found. Receipts are only available for SOL and token transfers.';
         case undefined:
             return undefined;
     }

--- a/app/features/receipt/ui/BaseReceipt.tsx
+++ b/app/features/receipt/ui/BaseReceipt.tsx
@@ -61,10 +61,16 @@ export function BaseReceipt({
     );
 }
 
-export function Header({ date }: { date?: FormattedExtendedReceipt['date'] }) {
+export function Header({
+    date,
+    title = 'Solana Receipt',
+}: {
+    date?: FormattedExtendedReceipt['date'];
+    title?: string;
+}) {
     return (
         <div className="e-flex e-items-center e-justify-between e-gap-x-4 e-border-b e-border-white/10 e-p-6 [border-bottom-style:solid]">
-            <h3 className="e-m-0 e-flex-shrink-0 e-font-medium e-text-white">Solana Receipt</h3>
+            <h3 className="e-m-0 e-flex-shrink-0 e-font-medium e-text-white">{title}</h3>
             {date && (
                 <Tooltip>
                     <TooltipTrigger asChild>
@@ -268,10 +274,10 @@ export function NoReceipt({
 
             <div className="e-w-full e-max-w-lg">
                 <div className="e-min-h-96 e-bg-outer-space-900">
-                    <Header date={date} />
+                    <Header date={date} title="No Receipt" />
                     <div className="e-p-6 e-text-sm e-text-gray-400">
                         <p className="e-m-0">
-                            {message ?? 'Receipts can only be generated for SOL or token transfer transactions.'}
+                            {message ?? 'Receipts are only available for simple SOL and token transfers.'}
                         </p>
                         <p className="e-m-0 e-mt-4">Forwarding to transaction view in {countdown}...</p>
                     </div>

--- a/app/features/receipt/ui/stories/BaseReceipt.stories.tsx
+++ b/app/features/receipt/ui/stories/BaseReceipt.stories.tsx
@@ -6,6 +6,7 @@ import { BaseReceipt, NoReceipt as NoReceiptComponent } from '../BaseReceipt';
 import {
     defaultReceipt,
     forBaseReceipt,
+    innerInstructionsNoReceiptMessage,
     mixedMintNoReceiptMessage,
     receiptLargeAmount,
     receiptMultiTokenTransfer,
@@ -113,6 +114,15 @@ export const NoReceiptMixedMint: Story = {
         <NoReceiptComponent
             transactionPath="https://example.com/tx/ExampleTransactionSignature"
             message={mixedMintNoReceiptMessage}
+        />
+    ),
+};
+
+export const NoReceiptInnerInstructions: Story = {
+    render: () => (
+        <NoReceiptComponent
+            transactionPath="https://example.com/tx/ExampleTransactionSignature"
+            message={innerInstructionsNoReceiptMessage}
         />
     ),
 };

--- a/app/features/receipt/ui/stories/receipt-fixtures.ts
+++ b/app/features/receipt/ui/stories/receipt-fixtures.ts
@@ -182,6 +182,9 @@ export const receiptMultiTokenTransferWithLongMemo: FormattedReceipt = formatRec
 export const mixedMintNoReceiptMessage =
     'Receipts are only available when all token transfers in a transaction use the same mint. This transaction transfers multiple different tokens.';
 
+export const innerInstructionsNoReceiptMessage =
+    'Receipts are only available for simple transfers. This transaction may contain inner program instructions.';
+
 export function forBaseReceipt(
     data: FormattedReceipt,
     overrides?: Partial<FormattedExtendedReceipt>,

--- a/app/features/receipt/ui/stories/receipt-fixtures.ts
+++ b/app/features/receipt/ui/stories/receipt-fixtures.ts
@@ -183,7 +183,7 @@ export const mixedMintNoReceiptMessage =
     'Receipts are only available when all token transfers in a transaction use the same mint. This transaction transfers multiple different tokens.';
 
 export const innerInstructionsNoReceiptMessage =
-    'Receipts are only available for simple transfers. This transaction may contain inner program instructions.';
+    'Receipts are only available for simple transfers. This transaction contains inner program instructions.';
 
 export function forBaseReceipt(
     data: FormattedReceipt,


### PR DESCRIPTION
## Description
- adding a placeholder for inner-instructions receipt cases
- moving back no-transfers issues

## Type of change
-   [x] Bug fix

## Screensh
<img width="913" height="562" alt="Screenshot 2026-05-28 at 15 49 54" src="https://github.com/user-attachments/assets/20699d4a-2800-43e9-87a6-5c79bcc0deae" />
<img width="746" height="621" alt="Screenshot 2026-05-28 at 15 50 10" src="https://github.com/user-attachments/assets/6d23ed3d-2e66-4c30-ab29-ae12eca963c2" />

## Testing
1. open [no transfers receipt](https://explorer-git-fork-hoodieshq-fix-hoo-53-78027f-solana-foundation.vercel.app/tx/34qZEWsTW85uZSd4N53DptMaQ5HTx2cczgwWatW6CPhLbaetEX67jELmrCyz2M2ydkQin3NR9sMbgVxeqDwT8Sqp?view=receipt)
2. open [inner instructions receipt](https://explorer-git-fork-hoodieshq-fix-hoo-53-78027f-solana-foundation.vercel.app/tx/5pv1psJNz9h26uhySt1sb8PtzxKPPBFZsgLugsWSJLh9yh6NE4hxoaUWeiKyQGA2WwfEHVNbx66zoUUAC2EBYZvm?view=receipt)

## Related Issues
[HOO-539](https://linear.app/solana-fndn/issue/HOO-539/update-the-title-of-placeholder-for-transfers-with-inner-instructions)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)