### PR TITLE
fix: tee is not a function

### DIFF
--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GENESIS_HASHES } from '@/app/entities/chain-id/lib/const';
 import { getAssetBatch } from '@/app/entities/digital-asset/api';
+import { clearLogoCacheForTests } from '@/app/features/search/api/discover-with-jupiter';
 
 import { GET } from '../route';
 
@@ -47,6 +48,7 @@ beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
     process.env = { ...originalEnv, JUPITER_API_KEY: 'test-key' };
     getAssetBatchMock.mockResolvedValue(undefined);
+    clearLogoCacheForTests();
 });
 
 afterEach(() => {

--- a/app/features/search/api/discover-with-jupiter.ts
+++ b/app/features/search/api/discover-with-jupiter.ts
@@ -74,8 +74,6 @@ export async function discoverWithJupiter(query: string, signal: AbortSignal): P
     }
 }
 
-const JUPITER_IMAGES_CACHE_REVALIDATE_S = 30;
-
 // Fetches logo URIs for tokens whose discovery response didn't include one.
 // Searches by symbol (not address) because Jupiter strips the logo field from address-based queries.
 export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: AbortSignal): Promise<Map<string, string>> {
@@ -87,23 +85,15 @@ export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: Abor
 
     const results = new Map<string, string>();
 
-    const abortPromise = new Promise<never>((_, reject) => {
-        if (signal.aborted) {
-            reject(signal.reason);
-        } else {
-            signal.addEventListener('abort', () => reject(signal.reason), { once: true });
-        }
-    });
-
     await Promise.allSettled(
         missing.map(async token => {
             try {
                 const url = `https://api.jup.ag/tokens/v2/search?query=${encodeURIComponent(token.symbol)}`;
-                const fetchPromise = fetch(url, {
+                
+                const response = await fetch(url, {
                     headers: { Accept: 'application/json', 'x-api-key': jupiterApiKey },
-                    next: { revalidate: JUPITER_IMAGES_CACHE_REVALIDATE_S },
+                    signal,
                 });
-                const response = await Promise.race([fetchPromise, abortPromise]);
                 if (!response.ok) {
                     Logger.warn(`[jupiter-images] ${response.status} for ${token.address}`);
                     return;

--- a/app/features/search/api/discover-with-jupiter.ts
+++ b/app/features/search/api/discover-with-jupiter.ts
@@ -75,16 +75,36 @@ export async function discoverWithJupiter(query: string, signal: AbortSignal): P
     }
 }
 
+// In-memory cache for logo lookups — replaces Next.js fetch cache (unavailable when passing signal).
+const logoCache = new Map<string, { expiresAt: number; logo: string }>();
+const LOGO_CACHE_TTL_MS = 30_000;
+
 // Fetches logo URIs for tokens whose discovery response didn't include one.
 // Searches by symbol (not address) because Jupiter strips the logo field from address-based queries.
 export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: AbortSignal): Promise<Map<string, string>> {
     const jupiterApiKey = getJupiterApiKey();
     if (!jupiterApiKey) return new Map();
 
-    const missing = tokens.filter(t => !t.logoUri);
-    if (missing.length === 0) return new Map();
-
+    const now = Date.now();
     const results = new Map<string, string>();
+    const missing: DiscoveredToken[] = [];
+
+    for (const t of tokens) {
+        if (t.logoUri) continue;
+        const cached = logoCache.get(t.address);
+        if (cached) {
+            if (cached.expiresAt > now) {
+                results.set(t.address, cached.logo);
+            } else {
+                logoCache.delete(t.address);
+                missing.push(t);
+            }
+        } else {
+            missing.push(t);
+        }
+    }
+
+    if (missing.length === 0) return results;
 
     await Promise.allSettled(
         missing.map(async token => {
@@ -108,6 +128,7 @@ export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: Abor
                 const logo = match?.icon ?? match?.logoURI;
                 if (logo) {
                     results.set(token.address, logo);
+                    logoCache.set(token.address, { expiresAt: Date.now() + LOGO_CACHE_TTL_MS, logo });
                 } else if (!match) {
                     Logger.warn(`[jupiter-images] no match for ${token.symbol} in ${data.length} results`);
                 }

--- a/app/features/search/api/discover-with-jupiter.ts
+++ b/app/features/search/api/discover-with-jupiter.ts
@@ -79,6 +79,8 @@ export async function discoverWithJupiter(query: string, signal: AbortSignal): P
 const logoCache = new Map<string, { expiresAt: number; logo: string }>();
 const LOGO_CACHE_TTL_MS = 30_000;
 
+export const clearLogoCacheForTests = () => logoCache.clear();
+
 // Fetches logo URIs for tokens whose discovery response didn't include one.
 // Searches by symbol (not address) because Jupiter strips the logo field from address-based queries.
 export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: AbortSignal): Promise<Map<string, string>> {

--- a/app/features/search/api/discover-with-jupiter.ts
+++ b/app/features/search/api/discover-with-jupiter.ts
@@ -1,5 +1,6 @@
 import { array, boolean, is, nullable, number, optional, string, type } from 'superstruct';
 
+import { fetchUpstream } from '@/app/api/verification/upstream';
 import { matchAbortError } from '@/app/shared/lib/errors';
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -27,7 +28,7 @@ export async function discoverWithJupiter(query: string, signal: AbortSignal): P
 
     try {
         const url = `https://api.jup.ag/tokens/v2/search?query=${encodeURIComponent(query)}`;
-        const response = await fetch(url, {
+        const response = await fetchUpstream(url, {
             headers: {
                 Accept: 'application/json',
                 'x-api-key': jupiterApiKey,
@@ -89,8 +90,8 @@ export async function fetchJupiterImages(tokens: DiscoveredToken[], signal: Abor
         missing.map(async token => {
             try {
                 const url = `https://api.jup.ag/tokens/v2/search?query=${encodeURIComponent(token.symbol)}`;
-                
-                const response = await fetch(url, {
+
+                const response = await fetchUpstream(url, {
                     headers: { Accept: 'application/json', 'x-api-key': jupiterApiKey },
                     signal,
                 });


### PR DESCRIPTION
## Description
- fixing tee is not a function

## Type of change
-   [x] Bug fix

## Testing
1. open homepage
2. try to search anything
3. no errors in vercel

## Related Issues
[HOO-573](https://linear.app/solana-fndn/issue/HOO-573/fix-tee-is-not-a-function-for-search-api)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All tests pass locally and in CI
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass