### PR TITLE
bugfix: Add check to only show verified for verified programs

### DIFF
--- a/app/features/search/ui/SearchResultItem.tsx
+++ b/app/features/search/ui/SearchResultItem.tsx
@@ -49,7 +49,7 @@ export function SearchResultItem({ option }: { option: SearchItem }) {
                         {option.sublabel}
                     </span>
                 )}
-                {option.verified && (
+                {option.verified && option.pathname.includes('/verified-build') && (
                     <span className="e-block e-text-xs e-text-heavy-metal-400">
                         Source verified — Make sure you trust the source code
                     </span>


### PR DESCRIPTION
## Description
There was a bug that the text for verified programs was also shown for tokens. 
<img width="698" height="364" alt="image" src="https://github.com/user-attachments/assets/36aa3b90-d8f9-4cd7-9138-c5ccf30a46db" />

<img width="717" height="236" alt="image" src="https://github.com/user-attachments/assets/6d29bfa8-ad9a-4e79-8b9a-05bc1583d4b8" />

