### PR TITLE
fix: make InitializeMint2 freezeAuthority optional

### DIFF
--- a/app/components/instruction/token/types.ts
+++ b/app/components/instruction/token/types.ts
@@ -18,7 +18,7 @@ const InitializeMint = type({
 
 const InitializeMint2 = type({
     decimals: number(),
-    freezeAuthority: PublicKeyFromString,
+    freezeAuthority: optional(PublicKeyFromString),
     freezeAuthorityOption: optional(number()),
     mint: PublicKeyFromString,
     mintAuthority: PublicKeyFromString,


### PR DESCRIPTION
## Description

Page is crashing here https://explorer.solana.com/tx/41e8YZyXft2L2gmevs8FVn6cSyNhEekN1nzxbfdBHFFFCA8Gi7g6t5Z8N5zrnKPSGhsTYCbDJEN7b4fpcRvvr4EE

## Type of change

Added optional for freeze authority 