### PR TITLE
feat: clear timer upon unmounting for account providers

### DIFF
--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
-import { Cluster, clusterUrl } from '@utils/cluster';
 import { render, waitFor } from '@testing-library/react';
+import { Cluster, clusterUrl } from '@utils/cluster';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,7 +42,8 @@ describe('AccountsProvider', () => {
             </AccountsProvider>,
         );
         await waitFor(() => expect(captured).toBeDefined());
-        const fetchers = captured!;
+        if (!captured) throw new Error('Fetchers context was not captured');
+        const fetchers = captured;
 
         const parsedCancel = vi.spyOn(fetchers.parsed, 'cancel');
         const rawCancel = vi.spyOn(fetchers.raw, 'cancel');
@@ -64,7 +65,8 @@ describe('AccountsProvider', () => {
             </AccountsProvider>,
         );
         await waitFor(() => expect(captured).toBeDefined());
-        const oldFetchers = captured!;
+        if (!captured) throw new Error('Fetchers context was not captured');
+        const oldFetchers = captured;
 
         const parsedCancel = vi.spyOn(oldFetchers.parsed, 'cancel');
         const rawCancel = vi.spyOn(oldFetchers.raw, 'cancel');
@@ -72,7 +74,11 @@ describe('AccountsProvider', () => {
 
         oldFetchers.parsed.fetch(TEST_PUBKEY);
 
-        useClusterMock.mockReturnValue({ cluster: Cluster.Testnet, customUrl: '', url: clusterUrl(Cluster.Testnet, '') });
+        useClusterMock.mockReturnValue({
+            cluster: Cluster.Testnet,
+            customUrl: '',
+            url: clusterUrl(Cluster.Testnet, ''),
+        });
         rerender(
             <AccountsProvider>
                 <Capture />

--- a/app/providers/accounts/__tests__/accounts-provider.spec.tsx
+++ b/app/providers/accounts/__tests__/accounts-provider.spec.tsx
@@ -1,0 +1,88 @@
+import { PublicKey } from '@solana/web3.js';
+import { Cluster, clusterUrl } from '@utils/cluster';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation');
+
+const { useClusterMock } = vi.hoisted(() => ({ useClusterMock: vi.fn() }));
+
+vi.mock('../../cluster', async importOriginal => {
+    const actual = await importOriginal<typeof import('../../cluster')>();
+    return { ...actual, useCluster: useClusterMock };
+});
+
+import { AccountsProvider, FetchersContext } from '..';
+
+type Captured = NonNullable<React.ContextType<typeof FetchersContext>>;
+
+const TEST_PUBKEY = PublicKey.default;
+
+let captured: Captured | undefined;
+function Capture() {
+    captured = React.useContext(FetchersContext) ?? undefined;
+    return null;
+}
+
+describe('AccountsProvider', () => {
+    beforeEach(() => {
+        captured = undefined;
+        useClusterMock.mockReturnValue({ cluster: Cluster.Devnet, customUrl: '', url: clusterUrl(Cluster.Devnet, '') });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should cancel pending fetcher timeouts when the provider unmounts', async () => {
+        const { unmount } = render(
+            <AccountsProvider>
+                <Capture />
+            </AccountsProvider>,
+        );
+        await waitFor(() => expect(captured).toBeDefined());
+        const fetchers = captured!;
+
+        const parsedCancel = vi.spyOn(fetchers.parsed, 'cancel');
+        const rawCancel = vi.spyOn(fetchers.raw, 'cancel');
+        const skipCancel = vi.spyOn(fetchers.skip, 'cancel');
+
+        fetchers.parsed.fetch(TEST_PUBKEY);
+
+        unmount();
+
+        expect(parsedCancel).toHaveBeenCalledTimes(1);
+        expect(rawCancel).toHaveBeenCalledTimes(1);
+        expect(skipCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cancel the old fetchers when the cluster changes', async () => {
+        const { rerender } = render(
+            <AccountsProvider>
+                <Capture />
+            </AccountsProvider>,
+        );
+        await waitFor(() => expect(captured).toBeDefined());
+        const oldFetchers = captured!;
+
+        const parsedCancel = vi.spyOn(oldFetchers.parsed, 'cancel');
+        const rawCancel = vi.spyOn(oldFetchers.raw, 'cancel');
+        const skipCancel = vi.spyOn(oldFetchers.skip, 'cancel');
+
+        oldFetchers.parsed.fetch(TEST_PUBKEY);
+
+        useClusterMock.mockReturnValue({ cluster: Cluster.Testnet, customUrl: '', url: clusterUrl(Cluster.Testnet, '') });
+        rerender(
+            <AccountsProvider>
+                <Capture />
+            </AccountsProvider>,
+        );
+
+        await waitFor(() => expect(captured).not.toBe(oldFetchers));
+
+        expect(parsedCancel).toHaveBeenCalledTimes(1);
+        expect(rawCancel).toHaveBeenCalledTimes(1);
+        expect(skipCancel).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -162,6 +162,7 @@ class MultipleAccountFetcher {
     };
     cancel = () => {
         clearTimeout(this.fetchTimeout);
+        this.fetchTimeout = undefined;
     };
 }
 

--- a/app/providers/accounts/index.tsx
+++ b/app/providers/accounts/index.tsx
@@ -160,6 +160,9 @@ class MultipleAccountFetcher {
             }, 100);
         }
     };
+    cancel = () => {
+        clearTimeout(this.fetchTimeout);
+    };
 }
 
 export type FetchAccountDataMode = 'parsed' | 'raw' | 'skip';
@@ -174,14 +177,20 @@ export function AccountsProvider({ children }: AccountsProviderProps) {
         skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
     }));
 
-    // Clear accounts cache whenever cluster is changed
+    // Cancel pending timers on deps-change and unmount so a debounced batch can't fire into a stale tree.
     React.useEffect(() => {
         dispatch({ type: ActionType.Clear, url });
-        setFetchers({
+        const next: Fetchers = {
             parsed: new MultipleAccountFetcher(dispatch, cluster, url, 'parsed'),
             raw: new MultipleAccountFetcher(dispatch, cluster, url, 'raw'),
             skip: new MultipleAccountFetcher(dispatch, cluster, url, 'skip'),
-        });
+        };
+        setFetchers(next);
+        return () => {
+            next.parsed.cancel();
+            next.raw.cancel();
+            next.skip.cancel();
+        };
     }, [dispatch, cluster, url]);
 
     return (


### PR DESCRIPTION
## Description

`MultipleAccountFetcher` in `app/providers/accounts/index.tsx` schedules a 100ms `setTimeout` per debounced batch but has no path to cancel it, and the `AccountsProvider` effect that recreates fetchers on cluster change has no cleanup function. Together this leaks timers across both cluster switches — pending timeouts fire and dispatch into a fresh reducer with stale `cluster`/`url`/`dataMode` closure values — and test teardown — the timer fires after jsdom is torn down, React-DOM tries to read `window`, and CI fails with an "Unhandled Rejection: window is not defined" even when every assertion passes. This PR adds a `cancel()` method to `MultipleAccountFetcher` (a single `clearTimeout` call) and returns a cleanup function from the provider's `useEffect` that cancels the newly-created fetchers, so pending timeouts clear on both deps-change and unmount.

## Type of change

-   [x] Bug fix

## Screenshots

N/A — no UI changes.

## Testing

Run `pnpm test --run`; the suite should no longer emit "Unhandled Rejection: window is not defined" originating from `app/components/inspector/__tests__/AccountsCard.spec.tsx`, and Build-And-Test should pass cleanly on both 22.x and 24.x.

## Related Issues

[HOO-597](https://linear.app/solana-fndn/issue/HOO-597).

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] CI/CD checks pass