### PR TITLE
fix: z index search popup

### DIFF
--- a/app/components/shared/ui/autocomplete.tsx
+++ b/app/components/shared/ui/autocomplete.tsx
@@ -133,7 +133,7 @@ function Autocomplete<Item extends AutocompleteItem = AutocompleteItem>({
                             e.preventDefault();
                         }
                     }}
-                    className="e-z-10 e-w-[var(--radix-popover-trigger-width)] e-min-w-[min(400px,100vw)] e-rounded-md e-border e-border-heavy-metal-900 e-bg-heavy-metal-800 e-shadow-2xl [border-style:solid]"
+                    className="e-z-50 e-w-[var(--radix-popover-trigger-width)] e-min-w-[min(400px,100vw)] e-rounded-md e-border e-border-heavy-metal-900 e-bg-heavy-metal-800 e-shadow-2xl [border-style:solid]"
                 >
                     <CommandList
                         onMouseDown={e => {

--- a/app/features/search/ui/BaseSearch.tsx
+++ b/app/features/search/ui/BaseSearch.tsx
@@ -160,7 +160,7 @@ export function BaseSearch({
                         align="start"
                         sideOffset={4}
                         className={cn(
-                            'e-z-10 e-rounded-md e-shadow-2xl [border-style:solid]',
+                            'e-z-50 e-rounded-md e-shadow-2xl [border-style:solid]',
                             'e-w-[var(--radix-popover-trigger-width)]',
                             'e-border e-border-heavy-metal-950 e-bg-heavy-metal-800',
                         )}


### PR DESCRIPTION
## Description
- Updating z-index for search popup

## Type of change
-   [x] Bug fix

## Screenshots
<img width="1261" height="627" alt="Screenshot 2026-06-03 at 12 06 41" src="https://github.com/user-attachments/assets/82dbbac8-c3de-428e-9104-991b4cc89f52" />


## Testing
1. open [address page](https://explorer-git-fork-hoodieshq-fix-hoo-57-6ed998-solana-foundation.vercel.app/address/Ketsy2Ua9mHaBmGb1zc1TJ7RGTPzZzSHN8CMPLqczJT)
2. try to search anything

## Related Issues
[HOO-572](https://linear.app/solana-fndn/issue/HOO-572/magnetic-navigation-bar-renders-above-token-search-popup)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes