### PR TITLE
Only show additional header when there is additional fields.

### DIFF
--- a/app/features/security-txt/ui/PmpSecurityTxtTable.tsx
+++ b/app/features/security-txt/ui/PmpSecurityTxtTable.tsx
@@ -28,10 +28,14 @@ export function PmpSecurityTxtTable({ data }: { data: Record<string, any> }) {
     return (
         <>
             <RenderTable entries={entries.main} />
-            <div className="card-header e-border-0 e-border-t e-border-solid e-border-t-[#282d2b]">
-                <h3 className="card-header-title">Additional:</h3>
-            </div>
-            <RenderTable entries={entries.additional} />
+            {entries.additional.length > 0 && (
+                <>
+                    <div className="card-header e-border-0 e-border-t e-border-solid e-border-t-[#282d2b]">
+                        <h3 className="card-header-title">Additional:</h3>
+                    </div>
+                    <RenderTable entries={entries.additional} />
+                </>
+            )}
         </>
     );
 }


### PR DESCRIPTION
## Description

Currently there is a Addiotnal: headline even when there is no additional fields in the scrurity.txt 

<img width="1271" height="665" alt="image" src="https://github.com/user-attachments/assets/f8701a6c-b346-43a5-8e8b-d93f11fa6adc" />


This is fixed now:

<img width="1376" height="718" alt="image" src="https://github.com/user-attachments/assets/327fa85b-7210-4fd8-82e3-b72c4a669176" />