### PR TITLE
refactor(dashkit): remove dashkit from BlockhashesCard

### DIFF
--- a/app/__fixtures__/gen.ts
+++ b/app/__fixtures__/gen.ts
@@ -7,6 +7,12 @@ import bs58 from 'bs58';
 export const gen = {
     bigint: (max = 1_000_000n) => BigInt(Math.floor(Math.random() * Number(max))),
     blockHeight: () => gen.bigint(250_000_000n),
+    /** Deterministic blockhash (same seed → same value) so story fixtures stay pixel-stable. */
+    blockhash: (seed = 0) => {
+        const bytes = new Uint8Array(32);
+        for (let i = 0; i < bytes.length; i++) bytes[i] = (seed * 7 + i * 13) & 0xff;
+        return bs58.encode(bytes);
+    },
     epoch: () => gen.bigint(1_000n),
     signature: () => {
         const bytes = new Uint8Array(64);
@@ -15,3 +21,6 @@ export const gen = {
     },
     slot: () => gen.bigint(300_000_000n),
 };
+
+/** Stable single-placeholder blockhash. */
+export const DEFAULT_BLOCKHASH = gen.blockhash();

--- a/app/components/account/BlockhashesCard.tsx
+++ b/app/components/account/BlockhashesCard.tsx
@@ -35,7 +35,7 @@ export function BlockhashesCard({ blockhashes }: { blockhashes: RecentBlockhashe
                 </div>
 
                 <CardFooter ui="dashkit">
-                    <div className="e-text-dk-gray-700 e-text-center">
+                    <div className="e-text-center e-text-dk-gray-700">
                         {blockhashes.length > 0 ? '' : 'No blockhashes found'}
                     </div>
                 </CardFooter>

--- a/app/components/account/BlockhashesCard.tsx
+++ b/app/components/account/BlockhashesCard.tsx
@@ -35,7 +35,7 @@ export function BlockhashesCard({ blockhashes }: { blockhashes: RecentBlockhashe
                 </div>
 
                 <CardFooter ui="dashkit">
-                    <div className="text-muted e-text-center">
+                    <div className="e-text-dk-gray-700 e-text-center">
                         {blockhashes.length > 0 ? '' : 'No blockhashes found'}
                     </div>
                 </CardFooter>

--- a/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
 
+import { gen } from '@__fixtures__/gen';
+
 import { BlockhashesCard } from '../BlockhashesCard';
 
 // Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
@@ -17,12 +19,12 @@ const meta: Meta<typeof BlockhashesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const sampleBlockhash = (i: number) => ({
-    blockhash: `5o7n8u${'A'.repeat(20)}${i}xY${'k'.repeat(20)}`,
-    feeCalculator: { lamportsPerSignature: '5000' },
-});
-
-const args = { blockhashes: Array.from({ length: 4 }, (_, i) => sampleBlockhash(i)) };
+const args = {
+    blockhashes: Array.from({ length: 4 }, (_, i) => ({
+        blockhash: gen.blockhash(i),
+        feeCalculator: { lamportsPerSignature: '5000' },
+    })),
+};
 
 export const Mobile: Story = {
     args,

--- a/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof BlockhashesCard> = {
     parameters: {
         viewport: { options: INITIAL_VIEWPORTS },
     },
-    tags: ['autodocs'],
+    tags: ['autodocs', 'test'],
     title: 'Components/Account/BlockhashesCard/Responsive',
 };
 

--- a/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
@@ -1,7 +1,6 @@
+import { gen } from '@__fixtures__/gen';
 import type { Meta, StoryObj } from '@storybook/react';
 import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
-
-import { gen } from '@__fixtures__/gen';
 
 import { BlockhashesCard } from '../BlockhashesCard';
 

--- a/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.responsive.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+
+import { BlockhashesCard } from '../BlockhashesCard';
+
+// Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
+const meta: Meta<typeof BlockhashesCard> = {
+    component: BlockhashesCard,
+    decorators: [withViewportFromGlobal],
+    parameters: {
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs'],
+    title: 'Components/Account/BlockhashesCard/Responsive',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleBlockhash = (i: number) => ({
+    blockhash: `5o7n8u${'A'.repeat(20)}${i}xY${'k'.repeat(20)}`,
+    feeCalculator: { lamportsPerSignature: '5000' },
+});
+
+const args = { blockhashes: Array.from({ length: 4 }, (_, i) => sampleBlockhash(i)) };
+
+export const Mobile: Story = {
+    args,
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    args,
+    globals: { viewport: { value: 'ipad' } },
+};
+
+export const TabletLandscape: Story = {
+    args,
+    globals: { viewport: { isRotated: true, value: 'ipad' } },
+};

--- a/app/components/account/__stories__/BlockhashesCard.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.stories.tsx
@@ -1,6 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react';
-
 import { gen } from '@__fixtures__/gen';
+import type { Meta, StoryObj } from '@storybook/react';
 
 import { BlockhashesCard } from '../BlockhashesCard';
 

--- a/app/components/account/__stories__/BlockhashesCard.stories.tsx
+++ b/app/components/account/__stories__/BlockhashesCard.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { gen } from '@__fixtures__/gen';
+
 import { BlockhashesCard } from '../BlockhashesCard';
 
 const meta: Meta<typeof BlockhashesCard> = {
@@ -11,14 +13,12 @@ const meta: Meta<typeof BlockhashesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const sampleBlockhash = (i: number) => ({
-    blockhash: `5o7n8u${'A'.repeat(20)}${i}xY${'k'.repeat(20)}`,
-    feeCalculator: { lamportsPerSignature: '5000' },
-});
-
 export const WithEntries: Story = {
     args: {
-        blockhashes: Array.from({ length: 4 }, (_, i) => sampleBlockhash(i)),
+        blockhashes: Array.from({ length: 4 }, (_, i) => ({
+            blockhash: gen.blockhash(i),
+            feeCalculator: { lamportsPerSignature: '5000' },
+        })),
     },
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         ],
         "paths": {
             "@/*": ["./*"],
+            "@__fixtures__/*": ["./app/__fixtures__/*"],
             "@components/*": ["./app/components/*"],
             "@entities/*": ["./app/entities/*"],
             "@features/*": ["./app/features/*"],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,6 +42,7 @@ export default defineConfig({
             '@/validators': path.resolve(__dirname, './app/validators'),
 
             // @ aliases
+            '@__fixtures__': path.resolve(__dirname, './app/__fixtures__'),
             '@app': path.resolve(__dirname, './app'),
             '@img': path.resolve(__dirname, './app/img'),
             '@components': path.resolve(__dirname, './app/components'),


### PR DESCRIPTION
## Description

Part 3 of the Dashkit migration (inside-out follow-up to #1056). Swap inner `text-muted` to `e-text-dk-gray-700` in `BlockhashesCard` footer copy, and add responsive Storybook variants (Mobile / Tablet-Portrait / Tablet-Landscape). Validated against the Storybook pixel-diff harness (zero drift outside the flaky allowlist).

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Dashkit-removal refactor + Storybook responsive coverage

## Screenshots

**Footer "No blockhashes found" (Empty story — where the `text-muted` swap is visible):**
<img width="2048" height="1536" alt="components-account-blockhashescard--empty" src="https://github.com/user-attachments/assets/c969223c-8644-4226-a204-2b917b70a1bb" />
<img width="2048" height="1536" alt="components-account-blockhashescard--empty" src="https://github.com/user-attachments/assets/9b1ef20d-1f01-4a50-a885-9a47ad185f23" />

**Responsive layout (confirms no breakpoint regressions — swap not visible since `--with-entries` data is used):**
<img width="2048" height="1536" alt="components-account-blockhashescard--with-entries" src="https://github.com/user-attachments/assets/cb314e03-2919-4e11-ad59-cfff199491d1" />
<img width="2048" height="1536" alt="components-account-blockhashescard-responsive--mobile" src="https://github.com/user-attachments/assets/49d9d422-86d9-4058-8b70-391b29380e7c" />
<img width="2048" height="1536" alt="components-account-blockhashescard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/ea5ddc1c-0bba-461f-9878-560dfc456a32" />
<img width="2048" height="1536" alt="components-account-blockhashescard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/cbf854e1-9bb5-4cb6-b661-4266084ff109" />

## Testing

Live preview: <https://explorer-git-fork-hoodieshq-feat-remov-b1ee3a-solana-foundation.vercel.app/address/SysvarRecentB1ockHashes11111111111111111111>

## Related Issues

Part of the Dashkit removal series. Follow-up to #1056.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Inside-out migration: this PR swaps a single text utility in `BlockhashesCard.tsx`. The Bootstrap `text-muted` color in dark mode resolves to `$gray-700` (`#698582`); `e-text-dk-gray-700` is the pixel-matched Tailwind equivalent. (The `e-text-muted` token in `tailwind.config.ts` uses a different OKLCH that produces ~0.04% drift — avoided.)

**Deferred families still in this file (held for separate PR series):**
- `<table className="table table-sm table-nowrap card-table">` and `text-muted` / `font-monospace` / `w-1` on inner `<th>`/`<td>` cells (table-family PR)
- `<div className="row">` / `<div className="col">` grid in `CardHeader` (grid-utility PR)
- `card-header-title` (card-* family — final wrap PR)
- Outer `<div className="card">` (final wrap PR)
