### PR TITLE
refactor(dashkit): add responsive Storybook variants for LoadingCard

### DIFF
--- a/app/components/common/__stories__/LoadingCard.responsive.stories.tsx
+++ b/app/components/common/__stories__/LoadingCard.responsive.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+
+import { LoadingCard } from '../LoadingCard';
+
+// Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
+const meta: Meta<typeof LoadingCard> = {
+    component: LoadingCard,
+    decorators: [withViewportFromGlobal],
+    parameters: {
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Components/Common/LoadingCard/Responsive',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const args = { message: 'Loading account data…' };
+
+export const Mobile: Story = {
+    args,
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    args,
+    globals: { viewport: { value: 'ipad' } },
+};
+
+export const TabletLandscape: Story = {
+    args,
+    globals: { viewport: { isRotated: true, value: 'ipad' } },
+};


### PR DESCRIPTION
## Description

Part 3 of the Dashkit migration (inside-out follow-up to #1056). Add Mobile / Tablet-Portrait / Tablet-Landscape responsive Storybook variants for `LoadingCard`. No source changes — preparation for the upcoming inside-out swap in a follow-up PR.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Storybook responsive coverage (Dashkit-removal series)

## Screenshots

New responsive variants rendering — no `before` since the stories didn't exist on master.

**Mobile (iPhone X):**
<img width="2048" height="1536" alt="components-common-loadingcard-responsive--mobile" src="https://github.com/user-attachments/assets/ff53b86e-f84e-4780-bb59-4c6982f55292" />

**Tablet Portrait (iPad):**
<img width="2048" height="1536" alt="components-common-loadingcard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/2674c4f0-8b61-4a7d-a9dc-15658e92050a" />

**Tablet Landscape (iPad rotated):**
<img width="2048" height="1536" alt="components-common-loadingcard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/f078f90f-3aa5-4975-b759-4a868809c2bb" />

## Testing

Live preview: <https://explorer-git-fork-hoodieshq-feat-remov-ce74b6-solana-foundation.vercel.app/address/SysvarRecentB1ockHashes11111111111111111111> (any page in a loading state renders `LoadingCard`)

## Related Issues

Part of the Dashkit removal series. Follow-up to #1056.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [x] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Story file uses `tags: ['autodocs', 'test']` so the Vitest Storybook project smoke-renders each viewport variant in CI.

`LoadingCard.tsx` itself is intentionally untouched in this PR: its only non-Dashkit-eligible content is `align-text-top spinner-grow spinner-grow-sm` on the loading spinner — that swap lands in the follow-up `feat/remove-dashkit-p3-loadingcard-spinner` PR which depends on the `e-spinner-grow` precedent established in `feat/remove-dashkit-p3-historycardcomponents`.
