### PR TITLE
refactor(dashkit): swap text-muted and d-md-none for Tailwind equivalents in ErrorCard

### DIFF
--- a/app/components/common/ErrorCard.tsx
+++ b/app/components/common/ErrorCard.tsx
@@ -23,13 +23,13 @@ export function ErrorCard({
                         <span className="btn btn-white e-ml-3 e-hidden md:e-inline" onClick={retry}>
                             {buttonText}
                         </span>
-                        <div className="d-md-none e-mt-6 e-block">
+                        <div className="e-mt-6 e-block md:e-hidden">
                             <span className="btn btn-white e-w-full" onClick={retry}>
                                 {buttonText}
                             </span>
                         </div>
                         {subtext && (
-                            <div className="text-muted">
+                            <div className="e-text-dk-gray-700">
                                 <hr></hr>
                                 {subtext}
                             </div>

--- a/app/components/common/__stories__/ErrorCard.responsive.stories.tsx
+++ b/app/components/common/__stories__/ErrorCard.responsive.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+
+import { ErrorCard } from '../ErrorCard';
+
+// Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
+// ErrorCard switches button layout under the md breakpoint (full-width on mobile, inline on md+).
+const meta: Meta<typeof ErrorCard> = {
+    component: ErrorCard,
+    decorators: [withViewportFromGlobal],
+    parameters: {
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Components/Common/ErrorCard/Responsive',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const args = {
+    retry: () => {},
+    subtext: 'Please check your network connection',
+    text: 'Failed to fetch',
+};
+
+export const Mobile: Story = {
+    args,
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    args,
+    globals: { viewport: { value: 'ipad' } },
+};
+
+export const TabletLandscape: Story = {
+    args,
+    globals: { viewport: { isRotated: true, value: 'ipad' } },
+};


### PR DESCRIPTION
## Description

Part 3 of the Dashkit migration (inside-out follow-up to #1056). Swap inner `text-muted` → `e-text-dk-gray-700` (subtext copy color) and `d-md-none` → `md:e-hidden` (mobile-only retry-button container) in `ErrorCard`. Add responsive Storybook variants (Mobile / Tablet-Portrait / Tablet-Landscape) covering the breakpoint-sensitive retry-button layout switch.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Dashkit-removal refactor + Storybook responsive coverage

## Screenshots

**Base story `WithSubtext` (exercises both swaps — subtext color + mobile button container at default md+ viewport):**
<img width="2048" height="1536" alt="components-common-errorcard--with-subtext" src="https://github.com/user-attachments/assets/297500a3-829e-4a08-a7ef-4b71ef09338f" />
<img width="2048" height="1536" alt="components-common-errorcard--with-subtext" src="https://github.com/user-attachments/assets/b32e121d-0052-40c8-8369-09d09493bcf9" />

**Mobile (iPhone X) — confirms `md:e-hidden` shows the full-width retry button:**
<img width="2048" height="1536" alt="components-common-errorcard-responsive--mobile" src="https://github.com/user-attachments/assets/423f31c9-a8fd-4568-b2b5-632d26549764" />
<img width="2048" height="1536" alt="components-common-errorcard-responsive--mobile" src="https://github.com/user-attachments/assets/57196fe5-ecdc-413e-a012-6061ece30948" />

**Tablet Portrait (iPad) — confirms `md:e-hidden` hides the mobile container, `md:e-inline` shows the inline button:**
<img width="2048" height="1536" alt="components-common-errorcard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/5bdc68d9-4890-4357-8cbd-86371d456cec" />
<img width="2048" height="1536" alt="components-common-errorcard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/b4bb1231-5d48-4805-8de5-d57b1050da28" />

**Tablet Landscape (iPad rotated):**
<img width="2048" height="1536" alt="components-common-errorcard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/44dab7fd-f828-400d-9c0a-36e958eeb4c2" />
<img width="2048" height="1536" alt="components-common-errorcard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/d8efa6b2-13eb-402d-a902-b8f69e51780f" />

## Testing

Live preview: <https://explorer-git-fork-hoodieshq-feat-remov-c4deb5-solana-foundation.vercel.app/address/SysvarRecentB1ockHashes11111111111111111111> (any failed-fetch state renders `ErrorCard`)

## Related Issues

Part of the Dashkit removal series. Follow-up to #1056.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Inside-out migration: two swaps in `ErrorCard.tsx`.
- `text-muted` → `e-text-dk-gray-700` matches the dark-mode `$gray-700` (`#698582`) Bootstrap resolves `text-muted` to in this codebase. The `e-text-muted` token uses a different OKLCH that produces minor pixel drift — avoided.
- `d-md-none` → `md:e-hidden` is the direct Tailwind responsive equivalent (display:none below md, hidden at md+). The sibling inline retry button already uses `e-hidden md:e-inline` (Part 2 work).

Story file uses `tags: ['autodocs', 'test']` so the Vitest Storybook project smoke-renders each viewport variant in CI.

**Deferred families still in this file (held for separate PR series):**
- `btn btn-white` retry buttons (button-family PR)
- Outer `<div className="card">` and inner `card-body` consumers (final wrap PR — `CardBody ui="dashkit"` is the migration shim)
