### PR TITLE
refactor(dashkit): swap text-muted for e-text-dk-gray-700 in SlotHashesCard

### DIFF
--- a/app/__fixtures__/gen.ts
+++ b/app/__fixtures__/gen.ts
@@ -19,5 +19,7 @@ export const gen = {
         for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
         return bs58.encode(bytes);
     },
-    slot: () => gen.bigint(300_000_000n),
+    /** Deterministic when seed provided (same seed → same value) so story fixtures stay pixel-stable. */
+    slot: (seed?: number) =>
+        seed === undefined ? gen.bigint(300_000_000n) : ((BigInt(seed) + 1n) * 2_654_435_761n) % 300_000_000n,
 };

--- a/app/__fixtures__/gen.ts
+++ b/app/__fixtures__/gen.ts
@@ -7,6 +7,12 @@ import bs58 from 'bs58';
 export const gen = {
     bigint: (max = 1_000_000n) => BigInt(Math.floor(Math.random() * Number(max))),
     blockHeight: () => gen.bigint(250_000_000n),
+    /** Deterministic blockhash (same seed → same value) so story fixtures stay pixel-stable. */
+    blockhash: (seed = 0) => {
+        const bytes = new Uint8Array(32);
+        for (let i = 0; i < bytes.length; i++) bytes[i] = (seed * 7 + i * 13) & 0xff;
+        return bs58.encode(bytes);
+    },
     epoch: () => gen.bigint(1_000n),
     signature: () => {
         const bytes = new Uint8Array(64);

--- a/app/components/account/SlotHashesCard.tsx
+++ b/app/components/account/SlotHashesCard.tsx
@@ -35,7 +35,7 @@ export function SlotHashesCard({ sysvarAccount }: { sysvarAccount: SysvarAccount
             </div>
 
             <CardFooter ui="dashkit">
-                <div className="text-muted e-text-center">{slotHashes.length > 0 ? '' : 'No hashes found'}</div>
+                <div className="e-text-center e-text-dk-gray-700">{slotHashes.length > 0 ? '' : 'No hashes found'}</div>
             </CardFooter>
         </div>
     );

--- a/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+
+import type { SysvarSlotHashesAccount } from '@/app/validators/accounts/sysvar';
+
+import { SlotHashesCard } from '../SlotHashesCard';
+
+// Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
+const meta: Meta<typeof SlotHashesCard> = {
+    component: SlotHashesCard,
+    decorators: [withViewportFromGlobal, withCluster],
+    parameters: {
+        ...nextjsParameters,
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Components/Account/SlotHashesCard/Responsive',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const hash = (i: number) => `4xY${'k'.repeat(40)}${i}`;
+
+const args = {
+    sysvarAccount: {
+        info: [
+            { hash: hash(0), slot: 312_456_789 },
+            { hash: hash(1), slot: 312_456_788 },
+            { hash: hash(2), slot: 312_456_787 },
+            { hash: hash(3), slot: 312_456_786 },
+        ],
+        type: 'slotHashes',
+    } satisfies SysvarSlotHashesAccount,
+};
+
+export const Mobile: Story = {
+    args,
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    args,
+    globals: { viewport: { value: 'ipad' } },
+};
+
+export const TabletLandscape: Story = {
+    args,
+    globals: { viewport: { isRotated: true, value: 'ipad' } },
+};

--- a/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
@@ -1,3 +1,4 @@
+import { gen } from '@__fixtures__/gen';
 import type { Meta, StoryObj } from '@storybook/react';
 import { nextjsParameters, withCluster } from '@storybook-config/decorators';
 import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
@@ -21,16 +22,13 @@ const meta: Meta<typeof SlotHashesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const hash = (i: number) => `4xY${'k'.repeat(40)}${i}`;
-
+const baseSlot = gen.slot();
 const args = {
     sysvarAccount: {
-        info: [
-            { hash: hash(0), slot: 312_456_789 },
-            { hash: hash(1), slot: 312_456_788 },
-            { hash: hash(2), slot: 312_456_787 },
-            { hash: hash(3), slot: 312_456_786 },
-        ],
+        info: Array.from({ length: 4 }, (_, i) => ({
+            hash: gen.blockhash(i),
+            slot: Number(baseSlot) - i,
+        })),
         type: 'slotHashes',
     } satisfies SysvarSlotHashesAccount,
 };

--- a/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/SlotHashesCard.responsive.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof SlotHashesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const baseSlot = gen.slot();
+const baseSlot = gen.slot(0);
 const args = {
     sysvarAccount: {
         info: Array.from({ length: 4 }, (_, i) => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         ],
         "paths": {
             "@/*": ["./*"],
+            "@__fixtures__/*": ["./app/__fixtures__/*"],
             "@components/*": ["./app/components/*"],
             "@entities/*": ["./app/entities/*"],
             "@features/*": ["./app/features/*"],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,6 +42,7 @@ export default defineConfig({
             '@/validators': path.resolve(__dirname, './app/validators'),
 
             // @ aliases
+            '@__fixtures__': path.resolve(__dirname, './app/__fixtures__'),
             '@app': path.resolve(__dirname, './app'),
             '@img': path.resolve(__dirname, './app/img'),
             '@components': path.resolve(__dirname, './app/components'),


### PR DESCRIPTION
## Description

Part 3 of the Dashkit migration (inside-out follow-up to #1056). Swap inner `text-muted` → `e-text-dk-gray-700` on the `SlotHashesCard` footer "No hashes found" copy, and add responsive Storybook variants (Mobile / Tablet-Portrait / Tablet-Landscape).

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Dashkit-removal refactor + Storybook responsive coverage

## Screenshots

**Footer "No hashes found" (`Empty` story — exercises the `text-muted` swap):**
<img width="2048" height="1536" alt="components-account-slothashescard--empty" src="https://github.com/user-attachments/assets/213066e0-d920-4a55-b00b-3e4446bde6f4" />
<img width="2048" height="1536" alt="components-account-slothashescard--empty" src="https://github.com/user-attachments/assets/50678ce4-1290-45c3-ac85-cfaa6355a797" />

**Responsive layout (`WithEntries` data — confirms no breakpoint regressions; swap not visible because data is present):**

**Mobile (iPhone X):**
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--mobile" src="https://github.com/user-attachments/assets/d87e61e6-4494-4d98-8bab-735cddad047f" />
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--mobile" src="https://github.com/user-attachments/assets/5523163e-cd96-438a-afd2-6967a77063b0" />

**Tablet Portrait (iPad):**
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/03c69c3a-a92b-47de-a377-27737fe45496" />
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/6ca3a223-642b-479e-8c6c-6870993676bd" />

**Tablet Landscape (iPad rotated):**
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/e1680a73-e84c-4a5e-b7ce-5ae0f243590e" />
<img width="2048" height="1536" alt="components-account-slothashescard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/63388687-d0c2-48f9-be08-fe62f9cca3ed" />

## Testing

Live preview: <https://explorer-git-fork-hoodieshq-feat-remov-786d5f-solana-foundation.vercel.app//address/SysvarS1otHashes111111111111111111111111111>

## Related Issues

Part of the Dashkit removal series. Follow-up to #1056.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Inside-out migration: one swap in `SlotHashesCard.tsx`. The Bootstrap `text-muted` color in dark mode resolves to `$gray-700` (`#698582`); `e-text-dk-gray-700` is the pixel-matched Tailwind equivalent. (The `e-text-muted` token in `tailwind.config.ts` uses a different OKLCH that produces minor drift — avoided.)

Story file uses `tags: ['autodocs', 'test']` so the Vitest Storybook project smoke-renders each viewport variant in CI.

**Deferred families still in this file (held for separate PR series):**
- `<table className="table table-sm table-nowrap card-table">` and `text-muted` / `font-monospace` / `w-1` on inner `<th>`/`<td>` cells (table-family PR)
- `<div className="row">` / `<div className="col">` grid in `CardHeader` (grid-utility PR)
- `card-header-title` (card-* family — final wrap PR)
- Outer `<div className="card">` (final wrap PR)
