### PR TITLE
refactor(dashkit): swap text-muted for e-text-dk-gray-700 in VotesCard

### DIFF
--- a/app/__fixtures__/gen.ts
+++ b/app/__fixtures__/gen.ts
@@ -13,5 +13,7 @@ export const gen = {
         for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
         return bs58.encode(bytes);
     },
-    slot: () => gen.bigint(300_000_000n),
+    /** Deterministic when seed provided (same seed → same value) so story fixtures stay pixel-stable. */
+    slot: (seed?: number) =>
+        seed === undefined ? gen.bigint(300_000_000n) : ((BigInt(seed) + 1n) * 2_654_435_761n) % 300_000_000n,
 };

--- a/app/components/account/VotesCard.tsx
+++ b/app/components/account/VotesCard.tsx
@@ -35,7 +35,7 @@ export function VotesCard({ voteAccount }: { voteAccount: VoteAccount }) {
                 </div>
 
                 <CardFooter ui="dashkit">
-                    <div className="text-muted e-text-center">
+                    <div className="e-text-center e-text-dk-gray-700">
                         {voteAccount.info.votes.length > 0 ? '' : 'No votes found'}
                     </div>
                 </CardFooter>

--- a/app/components/account/__stories__/VotesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/VotesCard.responsive.stories.tsx
@@ -1,0 +1,48 @@
+import { gen } from '@__fixtures__/gen';
+import type { Meta, StoryObj } from '@storybook/react';
+import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+
+import { VotesCard } from '../VotesCard';
+
+// Known: switching between Mobile/Tablet variants has a brief lag from viewport addon iframe resize + remount.
+const meta: Meta<typeof VotesCard> = {
+    component: VotesCard,
+    decorators: [withViewportFromGlobal, withCluster],
+    parameters: {
+        ...nextjsParameters,
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Components/Account/VotesCard/Responsive',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseSlot = Number(gen.slot());
+const votes = Array.from({ length: 6 }, (_, i) => ({
+    confirmationCount: 31 - i,
+    slot: baseSlot + i,
+}));
+
+const args = {
+    voteAccount: {
+        info: { votes },
+    } as any,
+};
+
+export const Mobile: Story = {
+    args,
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    args,
+    globals: { viewport: { value: 'ipad' } },
+};
+
+export const TabletLandscape: Story = {
+    args,
+    globals: { viewport: { isRotated: true, value: 'ipad' } },
+};

--- a/app/components/account/__stories__/VotesCard.responsive.stories.tsx
+++ b/app/components/account/__stories__/VotesCard.responsive.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof VotesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const baseSlot = Number(gen.slot());
+const baseSlot = Number(gen.slot(0));
 const votes = Array.from({ length: 6 }, (_, i) => ({
     confirmationCount: 31 - i,
     slot: baseSlot + i,

--- a/app/components/account/__stories__/VotesCard.stories.tsx
+++ b/app/components/account/__stories__/VotesCard.stories.tsx
@@ -1,3 +1,4 @@
+import { gen } from '@__fixtures__/gen';
 import type { Meta, StoryObj } from '@storybook/react';
 import { nextjsParameters, withCluster } from '@storybook-config/decorators';
 
@@ -14,9 +15,10 @@ const meta: Meta<typeof VotesCard> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const baseSlot = Number(gen.slot(0));
 const votes = Array.from({ length: 6 }, (_, i) => ({
     confirmationCount: 31 - i,
-    slot: 312_456_780 + i,
+    slot: baseSlot + i,
 }));
 
 export const WithVotes: Story = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         ],
         "paths": {
             "@/*": ["./*"],
+            "@__fixtures__/*": ["./app/__fixtures__/*"],
             "@components/*": ["./app/components/*"],
             "@entities/*": ["./app/entities/*"],
             "@features/*": ["./app/features/*"],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,6 +42,7 @@ export default defineConfig({
             '@/validators': path.resolve(__dirname, './app/validators'),
 
             // @ aliases
+            '@__fixtures__': path.resolve(__dirname, './app/__fixtures__'),
             '@app': path.resolve(__dirname, './app'),
             '@img': path.resolve(__dirname, './app/img'),
             '@components': path.resolve(__dirname, './app/components'),


### PR DESCRIPTION
## Description

Part 3 of the Dashkit migration (inside-out follow-up to #1056). Swap inner `text-muted` → `e-text-dk-gray-700` on the `VotesCard` footer "No votes found" copy, and add responsive Storybook variants (Mobile / Tablet-Portrait / Tablet-Landscape).

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Dashkit-removal refactor + Storybook responsive coverage

## Screenshots

**Footer "No votes found" (`Empty` story — exercises the `text-muted` swap):**
<img width="2048" height="1536" alt="components-account-votescard--empty" src="https://github.com/user-attachments/assets/3e7f996a-7b46-46b8-aad4-08fdf2bfaf63" />
<img width="2048" height="1536" alt="components-account-votescard--empty" src="https://github.com/user-attachments/assets/bf2cafcf-9110-4c46-861c-e83888c2ccbd" />

**Responsive layout (`WithVotes` data — confirms no breakpoint regressions; swap not visible because data is present):**

**Mobile (iPhone X):**
<img width="2048" height="1536" alt="components-account-votescard-responsive--mobile" src="https://github.com/user-attachments/assets/22686a49-faed-4cb3-a251-a49fcfd238ef" />
<img width="2048" height="1536" alt="components-account-votescard-responsive--mobile" src="https://github.com/user-attachments/assets/bdb21485-3086-4668-9dc7-bf2f89bef862" />

**Tablet Portrait (iPad):**
<img width="2048" height="1536" alt="components-account-votescard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/a1d85385-787c-47e5-a870-a5ab93b159d7" />
<img width="2048" height="1536" alt="components-account-votescard-responsive--tablet-portrait" src="https://github.com/user-attachments/assets/e668029f-f4f9-4da0-9dc9-2d03bd6224cf" />

**Tablet Landscape (iPad rotated):**
<img width="2048" height="1536" alt="components-account-votescard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/961dd9d9-85fc-4b6e-9f4d-7698c6e5a720" />
<img width="2048" height="1536" alt="components-account-votescard-responsive--tablet-landscape" src="https://github.com/user-attachments/assets/097e4783-0694-433b-8430-e4c716caa3ae" />

## Testing

Live preview: <https://explorer-git-fork-hoodieshq-feat-remov-0833ef-solana-foundation.vercel.app/address/<vote-account>/vote-history>

## Related Issues

Part of the Dashkit removal series. Follow-up to #1056.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [ ] I have added tests that prove my fix/feature works
-   [x] All tests pass locally and in CI
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass
-   [ ] I have included screenshots for protocol screens (if applicable)
-   [ ] For security-related features, I have included links to related information

## Additional Notes

Inside-out migration: one swap in `VotesCard.tsx`. The Bootstrap `text-muted` color in dark mode resolves to `$gray-700` (`#698582`); `e-text-dk-gray-700` is the pixel-matched Tailwind equivalent. (The `e-text-muted` token in `tailwind.config.ts` uses a different OKLCH that produces minor drift — avoided.)

Story file uses `tags: ['autodocs', 'test']` so the Vitest Storybook project smoke-renders each viewport variant in CI. Story mock uses `gen.slot()` via the new `@__fixtures__` alias (added in this PR) — same alias is added independently in PRs #1062 and #1065; patch-ids match, so whichever lands first makes the other's commits a no-op on rebase.

**Deferred families still in this file (held for separate PR series):**
- `<table className="table table-sm table-nowrap card-table">` and `text-muted` / `font-monospace` / `w-1` on inner `<th>`/`<td>` cells (table-family PR)
- `<div className="row">` / `<div className="col">` grid in `CardHeader` (grid-utility PR)
- `card-header-title` (card-* family — final wrap PR)
- Outer `<div className="card">` (final wrap PR)
