### PR TITLE
fix: added image fetching from das

### DIFF
--- a/app/api/search/__tests__/__fixtures__/das.ts
+++ b/app/api/search/__tests__/__fixtures__/das.ts
@@ -1,0 +1,8 @@
+import type { DigitalAsset } from '@/app/entities/digital-asset/types';
+
+export function makeDasAsset(id: string, image: string | null = null): DigitalAsset {
+    return {
+        content: { links: { image } },
+        id,
+    };
+}

--- a/app/api/search/__tests__/__fixtures__/jupiter.ts
+++ b/app/api/search/__tests__/__fixtures__/jupiter.ts
@@ -1,4 +1,6 @@
-export const VALID_ADDRESS = 'So11111111111111111111111111111111111111112';
+import { DEFAULT_ADDRESS } from '@/app/__fixtures__/gen';
+
+export const VALID_ADDRESS = DEFAULT_ADDRESS;
 
 export function makeJupiterToken(overrides: Record<string, unknown> = {}) {
     return {

--- a/app/api/search/__tests__/__fixtures__/jupiter.ts
+++ b/app/api/search/__tests__/__fixtures__/jupiter.ts
@@ -1,0 +1,13 @@
+export const VALID_ADDRESS = 'So11111111111111111111111111111111111111112';
+
+export function makeJupiterToken(overrides: Record<string, unknown> = {}) {
+    return {
+        decimals: 9,
+        id: VALID_ADDRESS,
+        isVerified: true,
+        logoURI: 'https://example.com/sol.png',
+        name: 'Wrapped SOL',
+        symbol: 'SOL',
+        ...overrides,
+    };
+}

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -238,16 +238,8 @@ describe('GET /api/search', () => {
             mockFetch(200, [makeJupiterToken({ logoURI: null })]);
             getAssetBatchMock.mockResolvedValueOnce([
                 {
-                    burnt: false,
-                    content: {
-                        $schema: '',
-                        json_uri: '',
-                        links: { image: 'https://das.example.com/sol.png' },
-                        metadata: {},
-                    },
+                    content: { links: { image: 'https://das.example.com/sol.png' } },
                     id: VALID_ADDRESS,
-                    interface: 'FungibleToken',
-                    mutable: true,
                 },
             ]);
 
@@ -260,16 +252,8 @@ describe('GET /api/search', () => {
             mockFetch(200, [makeJupiterToken({ logoURI: 'https://original.com/sol.png' })]);
             getAssetBatchMock.mockResolvedValueOnce([
                 {
-                    burnt: false,
-                    content: {
-                        $schema: '',
-                        json_uri: '',
-                        links: { image: 'https://das.example.com/sol.png' },
-                        metadata: {},
-                    },
+                    content: { links: { image: 'https://das.example.com/sol.png' } },
                     id: VALID_ADDRESS,
-                    interface: 'FungibleToken',
-                    mutable: true,
                 },
             ]);
 

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { gen } from '@/app/__fixtures__/gen';
 import { GENESIS_HASHES } from '@/app/entities/chain-id/lib/const';
 import { getAssetBatch } from '@/app/entities/digital-asset/api';
-import { gen } from '@/app/__fixtures__/gen';
 import { clearLogoCacheForTests } from '@/app/features/search/api/discover-with-jupiter';
 
 import { GET } from '../route';

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GENESIS_HASHES } from '@/app/entities/chain-id/lib/const';
 import { getAssetBatch } from '@/app/entities/digital-asset/api';
+import { gen } from '@/app/__fixtures__/gen';
 import { clearLogoCacheForTests } from '@/app/features/search/api/discover-with-jupiter';
 
 import { GET } from '../route';
@@ -251,7 +252,7 @@ describe('GET /api/search', () => {
     });
 
     describe('NEXT_PUBLIC_SEARCH_DISABLE_UNVERIFIED_TOKENS', () => {
-        const OTHER_ADDRESS = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+        const OTHER_ADDRESS = gen.address(1);
 
         beforeEach(() => {
             process.env.NEXT_PUBLIC_SEARCH_DISABLE_UNVERIFIED_TOKENS = 'true';

--- a/app/api/search/__tests__/route.test.ts
+++ b/app/api/search/__tests__/route.test.ts
@@ -5,6 +5,8 @@ import { getAssetBatch } from '@/app/entities/digital-asset/api';
 import { clearLogoCacheForTests } from '@/app/features/search/api/discover-with-jupiter';
 
 import { GET } from '../route';
+import { makeDasAsset } from './__fixtures__/das';
+import { makeJupiterToken, VALID_ADDRESS } from './__fixtures__/jupiter';
 
 vi.mock('@/app/entities/digital-asset/api', () => ({
     getAssetBatch: vi.fn(),
@@ -13,20 +15,6 @@ vi.mock('@/app/entities/digital-asset/api', () => ({
 const fetchMock = vi.fn();
 vi.stubGlobal('fetch', fetchMock);
 const getAssetBatchMock = vi.mocked(getAssetBatch);
-
-const VALID_ADDRESS = 'So11111111111111111111111111111111111111112';
-
-function makeJupiterToken(overrides: Record<string, unknown> = {}) {
-    return {
-        decimals: 9,
-        id: VALID_ADDRESS,
-        isVerified: true,
-        logoURI: 'https://example.com/sol.png',
-        name: 'Wrapped SOL',
-        symbol: 'SOL',
-        ...overrides,
-    };
-}
 
 function mockFetch(status: number, body: unknown) {
     const ok = status >= 200 && status < 300;
@@ -236,12 +224,7 @@ describe('GET /api/search', () => {
     describe('DAS icon enrichment', () => {
         it('should enrich icon from DAS when logoUri is null', async () => {
             mockFetch(200, [makeJupiterToken({ logoURI: null })]);
-            getAssetBatchMock.mockResolvedValueOnce([
-                {
-                    content: { links: { image: 'https://das.example.com/sol.png' } },
-                    id: VALID_ADDRESS,
-                },
-            ]);
+            getAssetBatchMock.mockResolvedValueOnce([makeDasAsset(VALID_ADDRESS, 'https://das.example.com/sol.png')]);
 
             const res = await GET(makeRequest('sol'));
             const data = await res.json();
@@ -250,12 +233,7 @@ describe('GET /api/search', () => {
 
         it('should prefer logoUri over DAS image when both present', async () => {
             mockFetch(200, [makeJupiterToken({ logoURI: 'https://original.com/sol.png' })]);
-            getAssetBatchMock.mockResolvedValueOnce([
-                {
-                    content: { links: { image: 'https://das.example.com/sol.png' } },
-                    id: VALID_ADDRESS,
-                },
-            ]);
+            getAssetBatchMock.mockResolvedValueOnce([makeDasAsset(VALID_ADDRESS, 'https://das.example.com/sol.png')]);
 
             const res = await GET(makeRequest('sol'));
             const data = await res.json();

--- a/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
+++ b/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
@@ -59,7 +59,7 @@ describe('GET /api/token-image/[mintAddress]', () => {
     describe('successful requests', () => {
         it('should return the image URL when the asset has one', async () => {
             getAssetBatch.mockResolvedValueOnce([
-                { id: VALID_MINT, content: { links: { image: 'https://example.com/image.png' } } },
+                { content: { links: { image: 'https://example.com/image.png' } }, id: VALID_MINT },
             ]);
 
             const response = await GET(makeRequest(), makeParams());
@@ -70,7 +70,7 @@ describe('GET /api/token-image/[mintAddress]', () => {
         });
 
         it('should return undefined image when asset has no image link', async () => {
-            getAssetBatch.mockResolvedValueOnce([{ id: VALID_MINT, content: { links: {} } }]);
+            getAssetBatch.mockResolvedValueOnce([{ content: { links: {} }, id: VALID_MINT }]);
 
             const response = await GET(makeRequest(), makeParams());
 
@@ -90,7 +90,7 @@ describe('GET /api/token-image/[mintAddress]', () => {
 
         it('should return cache headers on a successful image response', async () => {
             getAssetBatch.mockResolvedValueOnce([
-                { id: VALID_MINT, content: { links: { image: 'https://example.com/image.png' } } },
+                { content: { links: { image: 'https://example.com/image.png' } }, id: VALID_MINT },
             ]);
 
             const response = await GET(makeRequest(), makeParams());
@@ -101,7 +101,7 @@ describe('GET /api/token-image/[mintAddress]', () => {
         });
 
         it('should call getAssetBatch with the mint address', async () => {
-            getAssetBatch.mockResolvedValueOnce([{ id: VALID_MINT, content: { links: {} } }]);
+            getAssetBatch.mockResolvedValueOnce([{ content: { links: {} }, id: VALID_MINT }]);
 
             await GET(makeRequest(), makeParams());
 

--- a/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
+++ b/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '../route';
+
+vi.mock('@/app/entities/digital-asset/server', () => ({
+    getAssetBatch: vi.fn(),
+}));
+
+const VALID_MINT = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const BASE_URL = `http://localhost:3000/api/token-image/${VALID_MINT}`;
+
+function makeRequest(url = BASE_URL) {
+    return new Request(url);
+}
+
+function makeParams(mintAddress = VALID_MINT) {
+    return { params: Promise.resolve({ mintAddress }) };
+}
+
+describe('GET /api/token-image/[mintAddress]', () => {
+    let getAssetBatch: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        const mod = await import('@/app/entities/digital-asset/server');
+        getAssetBatch = vi.mocked(mod.getAssetBatch);
+    });
+
+    describe('validation', () => {
+        it('should return 400 for an invalid mint address', async () => {
+            const response = await GET(makeRequest(), makeParams('not-a-pubkey'));
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Invalid mint address');
+        });
+
+        it('should return 400 for an invalid cluster slug', async () => {
+            const response = await GET(makeRequest(`${BASE_URL}?cluster=unknown-cluster`), makeParams());
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Invalid cluster');
+        });
+
+        it('should not cache invalid mint address 400 errors', async () => {
+            const response = await GET(makeRequest(), makeParams('not-a-pubkey'));
+
+            expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
+        });
+
+        it('should not cache invalid cluster 400 errors', async () => {
+            const response = await GET(makeRequest(`${BASE_URL}?cluster=unknown-cluster`), makeParams());
+
+            expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
+        });
+    });
+
+    describe('successful requests', () => {
+        it('should return the image URL when the asset has one', async () => {
+            getAssetBatch.mockResolvedValueOnce([
+                { id: VALID_MINT, content: { links: { image: 'https://example.com/image.png' } } },
+            ]);
+
+            const response = await GET(makeRequest(), makeParams());
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.image).toBe('https://example.com/image.png');
+        });
+
+        it('should return undefined image when asset has no image link', async () => {
+            getAssetBatch.mockResolvedValueOnce([{ id: VALID_MINT, content: { links: {} } }]);
+
+            const response = await GET(makeRequest(), makeParams());
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(data.image).toBeUndefined();
+        });
+
+        it('should return no-store headers when no assets are returned', async () => {
+            getAssetBatch.mockResolvedValueOnce(null);
+
+            const response = await GET(makeRequest(), makeParams());
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('Cache-Control')).toBe('no-store, max-age=0');
+        });
+
+        it('should return cache headers on a successful image response', async () => {
+            getAssetBatch.mockResolvedValueOnce([
+                { id: VALID_MINT, content: { links: { image: 'https://example.com/image.png' } } },
+            ]);
+
+            const response = await GET(makeRequest(), makeParams());
+
+            expect(response.headers.get('Cache-Control')).toBe(
+                'public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600',
+            );
+        });
+
+        it('should call getAssetBatch with the mint address', async () => {
+            getAssetBatch.mockResolvedValueOnce([{ id: VALID_MINT, content: { links: {} } }]);
+
+            await GET(makeRequest(), makeParams());
+
+            expect(getAssetBatch).toHaveBeenCalledWith([VALID_MINT], expect.any(String));
+        });
+    });
+});

--- a/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
+++ b/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_ADDRESS } from '@/app/__fixtures__/gen';
+
 import { GET } from '../route';
 
 vi.mock('@/app/entities/digital-asset/server', () => ({
     getAssetBatch: vi.fn(),
 }));
 
-const VALID_MINT = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const VALID_MINT = DEFAULT_ADDRESS;
 const BASE_URL = `http://localhost:3000/api/token-image/${VALID_MINT}`;
 
 function makeRequest(url = BASE_URL) {

--- a/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
+++ b/app/api/token-image/[mintAddress]/__tests__/route.spec.ts
@@ -43,6 +43,17 @@ describe('GET /api/token-image/[mintAddress]', () => {
             expect(data.error).toBe('Invalid cluster');
         });
 
+        it('should return 400 for custom cluster to prevent SSRF', async () => {
+            const response = await GET(
+                makeRequest(`${BASE_URL}?cluster=custom&customUrl=http://internal-service`),
+                makeParams(),
+            );
+
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.error).toBe('Custom cluster is not supported');
+        });
+
         it('should not cache invalid mint address 400 errors', async () => {
             const response = await GET(makeRequest(), makeParams('not-a-pubkey'));
 

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -3,7 +3,6 @@ import { NextResponse } from 'next/server';
 
 import { getAssetBatch } from '@/app/entities/digital-asset/server';
 import { NO_STORE_HEADERS } from '@/app/shared/lib/http-utils';
-import { Logger } from '@/app/shared/lib/logger';
 import { Cluster, clusterFromSlug, clusterSlug, serverClusterUrl } from '@/app/utils/cluster';
 
 const IMAGE_CACHE_HEADERS = {
@@ -16,6 +15,7 @@ type Params = {
     }>;
 };
 
+/* eslint-disable no-console */
 export async function GET(request: Request, props: Params) {
     const { mintAddress } = await props.params;
 
@@ -39,7 +39,7 @@ export async function GET(request: Request, props: Params) {
     }
 
     const rpcUrl = serverClusterUrl(cluster, '');
-    Logger.info(`[token-image] rpcUrl: ${rpcUrl} | mintAddress: ${mintAddress} | cluster: ${cluster}`);
+    console.log('[token-image] rpcUrl:', rpcUrl, '| mint:', mintAddress, '| cluster:', cluster);
 
     // --- FORMAT PROBE: try every common DAS variant in parallel, log each raw result ---
     const probeVariants: { label: string; method: string; params: unknown }[] = [
@@ -58,25 +58,26 @@ export async function GET(request: Request, props: Params) {
                     method: 'POST',
                 });
                 const json = await res.json();
-                Logger.info(`[das-probe] ${label}: ${JSON.stringify(json)}`);
+                console.log(`[das-probe] ${label}:`, JSON.stringify(json));
             } catch (err) {
-                Logger.warn(`[das-probe] ${label} threw: ${String(err)}`);
+                console.log(`[das-probe] ${label} threw:`, String(err));
             }
         }),
     );
     // --- END FORMAT PROBE ---
 
     const assets = await getAssetBatch([mintAddress], rpcUrl);
-    Logger.info(`[token-image] getAssetBatch result: ${JSON.stringify(assets)}`);
+    console.log('[token-image] getAssetBatch result:', JSON.stringify(assets));
 
     if (!assets) {
-        Logger.info('[token-image] No assets returned — responding with no-store');
+        console.log('[token-image] no assets returned');
         return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
     }
 
     const asset = assets.find(a => a.id === mintAddress);
-    Logger.info(`[token-image] matched asset: ${JSON.stringify(asset)}`);
+    console.log('[token-image] matched asset:', JSON.stringify(asset));
     const image = asset?.content?.links?.image;
-    Logger.info(`[token-image] image value: ${image}`);
+    console.log('[token-image] image value:', image);
     return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
 }
+/* eslint-enable no-console */

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -1,9 +1,8 @@
-import { PublicKey } from '@solana/web3.js';
+import { isAddress } from '@solana/kit';
 import { NextResponse } from 'next/server';
 
 import { getAssetBatch } from '@/app/entities/digital-asset/server';
 import { NO_STORE_HEADERS } from '@/app/shared/lib/http-utils';
-import { Logger } from '@/app/shared/lib/logger';
 import { Cluster, clusterFromSlug, clusterSlug, serverClusterUrl } from '@/app/utils/cluster';
 
 const IMAGE_CACHE_HEADERS = {
@@ -19,10 +18,8 @@ type Params = {
 export async function GET(request: Request, props: Params) {
     const { mintAddress } = await props.params;
 
-    try {
-        new PublicKey(mintAddress);
-    } catch {
-        return NextResponse.json({ error: 'Invalid mint address' }, { status: 400 });
+    if (!isAddress(mintAddress)) {
+        return NextResponse.json({ error: 'Invalid mint address' }, { headers: NO_STORE_HEADERS, status: 400 });
     }
 
     const { searchParams } = new URL(request.url);
@@ -35,17 +32,13 @@ export async function GET(request: Request, props: Params) {
     }
 
     const rpcUrl = serverClusterUrl(cluster, customUrl);
+    const assets = await getAssetBatch([mintAddress], rpcUrl);
 
-    try {
-        const assets = await getAssetBatch([mintAddress], rpcUrl);
-        if (!assets) {
-            return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
-        }
-        const asset = assets.find(a => a.id === mintAddress);
-        const image = asset?.content.links?.image;
-        return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
-    } catch (error) {
-        Logger.panic(error instanceof Error ? error : new Error('[api:token-image] DAS request failed'));
-        return NextResponse.json({ error: 'Failed to fetch token image' }, { headers: NO_STORE_HEADERS, status: 500 });
+    if (!assets) {
+        return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
     }
+
+    const asset = assets.find(a => a.id === mintAddress);
+    const image = asset?.content.links?.image;
+    return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
 }

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -41,6 +41,31 @@ export async function GET(request: Request, props: Params) {
     const rpcUrl = serverClusterUrl(cluster, '');
     Logger.info(`[token-image] rpcUrl: ${rpcUrl} | mintAddress: ${mintAddress} | cluster: ${cluster}`);
 
+    // --- FORMAT PROBE: try every common DAS variant in parallel, log each raw result ---
+    const probeVariants: { label: string; method: string; params: unknown }[] = [
+        { label: 'getAsset (singular, {id})', method: 'getAsset', params: { id: mintAddress } },
+        { label: 'getAssets ({ids:[]})', method: 'getAssets', params: { ids: [mintAddress] } },
+        { label: 'getAssetBatch ({ids:[]})', method: 'getAssetBatch', params: { ids: [mintAddress] } },
+        { label: 'getAssets (array params)', method: 'getAssets', params: [mintAddress] },
+        { label: 'getAssetBatch (array params)', method: 'getAssetBatch', params: [mintAddress] },
+    ];
+    await Promise.all(
+        probeVariants.map(async ({ label, method, params }) => {
+            try {
+                const res = await fetch(rpcUrl, {
+                    body: JSON.stringify({ id: 'probe', jsonrpc: '2.0', method, params }),
+                    headers: { 'Content-Type': 'application/json' },
+                    method: 'POST',
+                });
+                const json = await res.json();
+                Logger.info(`[das-probe] ${label}: ${JSON.stringify(json)}`);
+            } catch (err) {
+                Logger.warn(`[das-probe] ${label} threw: ${String(err)}`);
+            }
+        }),
+    );
+    // --- END FORMAT PROBE ---
+
     const assets = await getAssetBatch([mintAddress], rpcUrl);
     Logger.info(`[token-image] getAssetBatch result: ${JSON.stringify(assets)}`);
 

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -15,7 +15,6 @@ type Params = {
     }>;
 };
 
-/* eslint-disable no-console */
 export async function GET(request: Request, props: Params) {
     const { mintAddress } = await props.params;
 
@@ -39,45 +38,13 @@ export async function GET(request: Request, props: Params) {
     }
 
     const rpcUrl = serverClusterUrl(cluster, '');
-    console.log('[token-image] rpcUrl:', rpcUrl, '| mint:', mintAddress, '| cluster:', cluster);
-
-    // --- FORMAT PROBE: try every common DAS variant in parallel, log each raw result ---
-    const probeVariants: { label: string; method: string; params: unknown }[] = [
-        { label: 'getAsset (singular, {id})', method: 'getAsset', params: { id: mintAddress } },
-        { label: 'getAssets ({ids:[]})', method: 'getAssets', params: { ids: [mintAddress] } },
-        { label: 'getAssetBatch ({ids:[]})', method: 'getAssetBatch', params: { ids: [mintAddress] } },
-        { label: 'getAssets (array params)', method: 'getAssets', params: [mintAddress] },
-        { label: 'getAssetBatch (array params)', method: 'getAssetBatch', params: [mintAddress] },
-    ];
-    await Promise.all(
-        probeVariants.map(async ({ label, method, params }) => {
-            try {
-                const res = await fetch(rpcUrl, {
-                    body: JSON.stringify({ id: 'probe', jsonrpc: '2.0', method, params }),
-                    headers: { 'Content-Type': 'application/json' },
-                    method: 'POST',
-                });
-                const json = await res.json();
-                console.log(`[das-probe] ${label}:`, JSON.stringify(json));
-            } catch (err) {
-                console.log(`[das-probe] ${label} threw:`, String(err));
-            }
-        }),
-    );
-    // --- END FORMAT PROBE ---
-
     const assets = await getAssetBatch([mintAddress], rpcUrl);
-    console.log('[token-image] getAssetBatch result:', JSON.stringify(assets));
 
     if (!assets) {
-        console.log('[token-image] no assets returned');
         return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
     }
 
     const asset = assets.find(a => a.id === mintAddress);
-    console.log('[token-image] matched asset:', JSON.stringify(asset));
     const image = asset?.content?.links?.image;
-    console.log('[token-image] image value:', image);
     return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
 }
-/* eslint-enable no-console */

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -41,8 +41,8 @@ export async function GET(request: Request, props: Params) {
         const asset = assets?.find(a => a.id === mintAddress);
         const image = asset?.content.links?.image;
         return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
-    } catch {
-        Logger.warn('[api:token-image] DAS request failed', { mintAddress, sentry: false });
-        return NextResponse.json({ image: undefined }, { headers: IMAGE_CACHE_HEADERS });
+    } catch (error) {
+        Logger.panic(error instanceof Error ? error : new Error('[api:token-image] DAS request failed'));
+        return NextResponse.json({ error: 'Failed to fetch token image' }, { headers: NO_STORE_HEADERS, status: 500 });
     }
 }

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -38,7 +38,10 @@ export async function GET(request: Request, props: Params) {
 
     try {
         const assets = await getAssetBatch([mintAddress], rpcUrl);
-        const asset = assets?.find(a => a.id === mintAddress);
+        if (!assets) {
+            return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
+        }
+        const asset = assets.find(a => a.id === mintAddress);
         const image = asset?.content.links?.image;
         return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
     } catch (error) {

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -24,14 +24,20 @@ export async function GET(request: Request, props: Params) {
 
     const { searchParams } = new URL(request.url);
     const clusterParam = searchParams.get('cluster') ?? clusterSlug(Cluster.MainnetBeta);
-    const customUrl = searchParams.get('customUrl') ?? '';
 
     const cluster = clusterFromSlug(clusterParam);
     if (cluster === null) {
         return NextResponse.json({ error: 'Invalid cluster' }, { headers: NO_STORE_HEADERS, status: 400 });
     }
 
-    const rpcUrl = serverClusterUrl(cluster, customUrl);
+    if (cluster === Cluster.Custom) {
+        return NextResponse.json(
+            { error: 'Custom cluster is not supported' },
+            { headers: NO_STORE_HEADERS, status: 400 },
+        );
+    }
+
+    const rpcUrl = serverClusterUrl(cluster, '');
     const assets = await getAssetBatch([mintAddress], rpcUrl);
 
     if (!assets) {

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -45,6 +45,6 @@ export async function GET(request: Request, props: Params) {
     }
 
     const asset = assets.find(a => a.id === mintAddress);
-    const image = asset?.content.links?.image;
+    const image = asset?.content?.links?.image;
     return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
 }

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 
 import { getAssetBatch } from '@/app/entities/digital-asset/server';
 import { NO_STORE_HEADERS } from '@/app/shared/lib/http-utils';
+import { Logger } from '@/app/shared/lib/logger';
 import { Cluster, clusterFromSlug, clusterSlug, serverClusterUrl } from '@/app/utils/cluster';
 
 const IMAGE_CACHE_HEADERS = {
@@ -38,13 +39,19 @@ export async function GET(request: Request, props: Params) {
     }
 
     const rpcUrl = serverClusterUrl(cluster, '');
+    Logger.info(`[token-image] rpcUrl: ${rpcUrl} | mintAddress: ${mintAddress} | cluster: ${cluster}`);
+
     const assets = await getAssetBatch([mintAddress], rpcUrl);
+    Logger.info(`[token-image] getAssetBatch result: ${JSON.stringify(assets)}`);
 
     if (!assets) {
+        Logger.info('[token-image] No assets returned — responding with no-store');
         return NextResponse.json({ image: undefined }, { headers: NO_STORE_HEADERS });
     }
 
     const asset = assets.find(a => a.id === mintAddress);
+    Logger.info(`[token-image] matched asset: ${JSON.stringify(asset)}`);
     const image = asset?.content?.links?.image;
+    Logger.info(`[token-image] image value: ${image}`);
     return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
 }

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -1,0 +1,48 @@
+import { PublicKey } from '@solana/web3.js';
+import { NextResponse } from 'next/server';
+
+import { getAssetBatch } from '@/app/entities/digital-asset/server';
+import { NO_STORE_HEADERS } from '@/app/shared/lib/http-utils';
+import { Logger } from '@/app/shared/lib/logger';
+import { Cluster, clusterFromSlug, clusterSlug, serverClusterUrl } from '@/app/utils/cluster';
+
+const IMAGE_CACHE_HEADERS = {
+    'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=3600',
+};
+
+type Params = {
+    params: Promise<{
+        mintAddress: string;
+    }>;
+};
+
+export async function GET(request: Request, props: Params) {
+    const { mintAddress } = await props.params;
+
+    try {
+        new PublicKey(mintAddress);
+    } catch {
+        return NextResponse.json({ error: 'Invalid mint address' }, { status: 400 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const clusterParam = searchParams.get('cluster') ?? clusterSlug(Cluster.MainnetBeta);
+    const customUrl = searchParams.get('customUrl') ?? '';
+
+    const cluster = clusterFromSlug(clusterParam);
+    if (cluster === null) {
+        return NextResponse.json({ error: 'Invalid cluster' }, { headers: NO_STORE_HEADERS, status: 400 });
+    }
+
+    const rpcUrl = serverClusterUrl(cluster, customUrl);
+
+    try {
+        const assets = await getAssetBatch([mintAddress], rpcUrl);
+        const asset = assets?.find(a => a.id === mintAddress);
+        const image = asset?.content.links?.image;
+        return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
+    } catch {
+        Logger.warn('[api:token-image] DAS request failed', { mintAddress, sentry: false });
+        return NextResponse.json({ image: undefined }, { headers: IMAGE_CACHE_HEADERS });
+    }
+}

--- a/app/api/token-image/[mintAddress]/route.ts
+++ b/app/api/token-image/[mintAddress]/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request, props: Params) {
     const clusterParam = searchParams.get('cluster') ?? clusterSlug(Cluster.MainnetBeta);
 
     const cluster = clusterFromSlug(clusterParam);
-    if (cluster === null) {
+    if (cluster == undefined) {
         return NextResponse.json({ error: 'Invalid cluster' }, { headers: NO_STORE_HEADERS, status: 400 });
     }
 
@@ -46,5 +46,6 @@ export async function GET(request: Request, props: Params) {
 
     const asset = assets.find(a => a.id === mintAddress);
     const image = asset?.content?.links?.image;
-    return NextResponse.json({ image }, { headers: IMAGE_CACHE_HEADERS });
+    const headers = image ? IMAGE_CACHE_HEADERS : NO_STORE_HEADERS;
+    return NextResponse.json({ image }, { headers });
 }

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -19,6 +19,7 @@ import { create } from 'superstruct';
 
 import { ProgramHeader } from '@/app/components/shared/account/ProgramHeader';
 import { ProxiedImage } from '@/app/features/metadata';
+import { useDasImage } from '@/app/entities/digital-asset/model/use-das-image';
 import { getProxiedUri } from '@/app/features/metadata/utils';
 import { type FullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
 
@@ -112,11 +113,13 @@ function TokenMintHeader({
     const metadataPointerExtension = mintInfo?.extensions?.find(
         ({ extension }: { extension: string }) => extension === 'metadataPointer',
     );
+    const dasImage = useDasImage(address);
 
-    const defaultCard = useMemo(
-        () => <TokenMintHeaderCard token={tokenInfo ? tokenInfo : { logoURI: undefined, name: undefined }} />,
-        [tokenInfo],
-    );
+    const defaultCard = useMemo(() => {
+        const logoURI = tokenInfo?.logoURI ?? dasImage;
+        const token = tokenInfo ? { ...tokenInfo, logoURI } : { logoURI, name: undefined };
+        return <TokenMintHeaderCard token={token} />;
+    }, [dasImage, tokenInfo]);
 
     if (metadataPointerExtension && metadataExtension) {
         return (
@@ -125,6 +128,7 @@ function TokenMintHeader({
                     <Suspense fallback={defaultCard}>
                         <Token22MintHeader
                             address={address}
+                            fallbackLogoURI={dasImage}
                             metadataExtension={metadataExtension as any}
                             metadataPointerExtension={metadataPointerExtension as any}
                         />
@@ -138,23 +142,23 @@ function TokenMintHeader({
         return defaultCard;
     } else if (parsedData?.nftData) {
         const token = {
-            logoURI: parsedData?.nftData?.json?.image,
+            logoURI: parsedData?.nftData?.json?.image ?? dasImage,
             name: parsedData?.nftData?.json?.name ?? parsedData?.nftData.metadata.name,
             symbol: parsedData?.nftData?.metadata.symbol,
         };
         return <TokenMintHeaderCard token={token} />;
-    } else if (tokenInfo) {
-        return defaultCard;
     }
     return defaultCard;
 }
 
 function Token22MintHeader({
     address,
+    fallbackLogoURI,
     metadataExtension,
     metadataPointerExtension,
 }: {
     address: string;
+    fallbackLogoURI?: string;
     metadataExtension: { extension: 'tokenMetadata'; state?: any };
     metadataPointerExtension: { extension: 'metadataPointer'; state?: any };
 }) {
@@ -163,13 +167,10 @@ function Token22MintHeader({
     const metadata = useMetadataJsonLink(getProxiedUri(tokenMetadata.uri));
 
     const headerTokenMetadata = {
-        logoURI: '',
+        logoURI: metadata?.image ?? fallbackLogoURI ?? '',
         name: tokenMetadata.name,
         symbol: tokenMetadata.symbol,
     };
-    if (metadata) {
-        headerTokenMetadata.logoURI = metadata.image;
-    }
 
     // Handles the basic case where MetadataPointer is referencing the Token Metadata extension directly
     // Does not handle the case where MetadataPointer is pointing at a separate account.

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -18,6 +18,7 @@ import React, { Suspense, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { create } from 'superstruct';
 
+import { dasImageAddress } from '@/app/components/account/das-image-address';
 import { ProgramHeader } from '@/app/components/shared/account/ProgramHeader';
 import { ProxiedImage } from '@/app/features/metadata';
 import { getProxiedUri } from '@/app/features/metadata/utils';
@@ -113,11 +114,7 @@ function TokenMintHeader({
     const metadataPointerExtension = mintInfo?.extensions?.find(
         ({ extension }: { extension: string }) => extension === 'metadataPointer',
     );
-    // Skip DAS fetch when a definitive image is already available. Token-2022 is excluded:
-    // its image comes from an async metadata URI fetch, so DAS still serves as a useful fallback.
-    const dasImage = useDasImage(
-        tokenInfo?.logoURI || isRedactedTokenAddress(address) || parsedData?.nftData?.json?.image ? undefined : address,
-    );
+    const dasImage = useDasImage(dasImageAddress(address, tokenInfo, parsedData));
 
     const defaultCard = useMemo(() => {
         const logoURI = tokenInfo?.logoURI ?? dasImage;

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -19,7 +19,7 @@ import { create } from 'superstruct';
 
 import { ProgramHeader } from '@/app/components/shared/account/ProgramHeader';
 import { ProxiedImage } from '@/app/features/metadata';
-import { useDasImage } from '@/app/entities/digital-asset/model/use-das-image';
+import { useDasImage } from '@entities/digital-asset';
 import { getProxiedUri } from '@/app/features/metadata/utils';
 import { type FullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
 
@@ -113,7 +113,11 @@ function TokenMintHeader({
     const metadataPointerExtension = mintInfo?.extensions?.find(
         ({ extension }: { extension: string }) => extension === 'metadataPointer',
     );
-    const dasImage = useDasImage(tokenInfo?.logoURI ? undefined : address);
+    // Skip DAS fetch when a definitive image is already available. Token-2022 is excluded:
+    // its image comes from an async metadata URI fetch, so DAS still serves as a useful fallback.
+    const dasImage = useDasImage(
+        tokenInfo?.logoURI || isRedactedTokenAddress(address) || parsedData?.nftData?.json?.image ? undefined : address,
+    );
 
     const defaultCard = useMemo(() => {
         const logoURI = tokenInfo?.logoURI ?? dasImage;

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -113,7 +113,7 @@ function TokenMintHeader({
     const metadataPointerExtension = mintInfo?.extensions?.find(
         ({ extension }: { extension: string }) => extension === 'metadataPointer',
     );
-    const dasImage = useDasImage(address);
+    const dasImage = useDasImage(tokenInfo?.logoURI ? undefined : address);
 
     const defaultCard = useMemo(() => {
         const logoURI = tokenInfo?.logoURI ?? dasImage;

--- a/app/components/account/AccountHeader.tsx
+++ b/app/components/account/AccountHeader.tsx
@@ -2,6 +2,7 @@ import { CompressedNftAccountHeader } from '@components/account/CompressedNftCar
 import { MetaplexNFTHeader } from '@components/account/MetaplexNFTHeader';
 import { isNFTokenAccount } from '@components/account/nftoken/isNFTokenAccount';
 import { NFTokenAccountHeader } from '@components/account/nftoken/NFTokenAccountHeader';
+import { useDasImage } from '@entities/digital-asset';
 import { isMetaplexNFT } from '@entities/nft';
 import {
     Account,
@@ -19,7 +20,6 @@ import { create } from 'superstruct';
 
 import { ProgramHeader } from '@/app/components/shared/account/ProgramHeader';
 import { ProxiedImage } from '@/app/features/metadata';
-import { useDasImage } from '@entities/digital-asset';
 import { getProxiedUri } from '@/app/features/metadata/utils';
 import { type FullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
 

--- a/app/components/account/das-image-address.ts
+++ b/app/components/account/das-image-address.ts
@@ -1,0 +1,19 @@
+import { TokenProgramData } from '@providers/accounts';
+
+import { type FullTokenInfo, isRedactedTokenAddress } from '@/app/utils/token-info';
+
+/**
+ * Returns the mint address to pass to `useDasImage`, or `undefined` to skip the DAS fetch.
+ * Skip when a definitive image is already available. Token-2022 is excluded: its image comes
+ * from an async metadata URI fetch, so DAS still serves as a useful fallback.
+ */
+export function dasImageAddress(
+    address: string,
+    tokenInfo: FullTokenInfo | undefined,
+    parsedData: TokenProgramData | undefined,
+): string | undefined {
+    const hasDefinitiveImage = Boolean(
+        tokenInfo?.logoURI || isRedactedTokenAddress(address) || parsedData?.nftData?.json?.image,
+    );
+    return hasDefinitiveImage ? undefined : address;
+}

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -73,7 +73,11 @@ export async function getAssetBatch(
         }
 
         if (!is(data, GetAssetBatchResponseSchema)) {
-            Logger.warn('[das] getAssets invalid response', { sentry: true });
+            const resultType = typeof data?.result;
+            const resultIsArray = Array.isArray(data?.result);
+            Logger.warn(`[das] getAssets invalid response (result type: ${resultType}, isArray: ${resultIsArray})`, {
+                sentry: true,
+            });
             return undefined;
         }
 

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -67,6 +67,11 @@ export async function getAssetBatch(
 
         const data = await response.json();
 
+        if (data?.error) {
+            Logger.warn(`[das] getAssets RPC error: ${data.error?.message ?? 'unknown'}`);
+            return undefined;
+        }
+
         if (!is(data, GetAssetBatchResponseSchema)) {
             Logger.warn('[das] getAssets invalid response', { sentry: true });
             return undefined;

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -58,6 +58,7 @@ export async function getAssetBatch(
               })
             : null;
 
+        Logger.info(`[das] calling getAssets on ${url} for ids: ${JSON.stringify(ids)}`);
         const response = await (abortPromise ? Promise.race([fetchPromise, abortPromise]) : fetchPromise);
 
         if (!response.ok) {
@@ -66,6 +67,7 @@ export async function getAssetBatch(
         }
 
         const data = await response.json();
+        Logger.info(`[das] raw response: ${JSON.stringify(data)}`);
 
         if (data?.error) {
             Logger.warn(`[das] getAssets RPC error: ${data.error?.message ?? 'unknown'}`);
@@ -74,10 +76,13 @@ export async function getAssetBatch(
 
         const [validationError, validData] = validate(data, GetAssetBatchResponseSchema);
         if (validationError) {
-            Logger.warn(`[das] getAssets invalid response: ${validationError.message}`, { sentry: true });
+            Logger.warn(
+                `[das] getAssets schema validation failed: ${validationError.message} | path: ${validationError.path.join('.')}`,
+            );
             return undefined;
         }
 
+        Logger.info(`[das] validated result count: ${validData.result.length}`);
         return validData.result.filter((item): item is DigitalAsset => item !== null);
     } catch (error) {
         Logger.error(error instanceof Error ? error : new Error('[das] getAssets failed'), {

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -78,7 +78,7 @@ export async function getAssetBatch(
             return undefined;
         }
 
-        return validData.result;
+        return validData.result.filter((item): item is DigitalAsset => item !== null);
     } catch (error) {
         Logger.error(error instanceof Error ? error : new Error('[das] getAssets failed'), {
             sentry: true,

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -9,14 +9,55 @@ import { validate } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-import { type DigitalAsset, GetAssetBatchResponseSchema } from './types';
+import { type DigitalAsset, GetAssetResponseSchema } from './types';
 
-// How long to cache individual getAssets responses in Next.js Data Cache.
+// How long to cache individual getAsset responses in Next.js Data Cache.
 // Matches the search route's s-maxage so the full pipeline has consistent freshness.
 const DAS_CACHE_REVALIDATE_S = 30;
 
+async function fetchSingleAsset(id: string, url: string, signal?: AbortSignal): Promise<DigitalAsset | null> {
+    // Do not pass `signal` directly to fetch — Next.js skips Data Cache for any
+    // request that carries a signal. Check before and after instead: cached
+    // responses return instantly so the enrichment budget is still respected.
+    signal?.throwIfAborted();
+
+    const response = await fetch(url, {
+        body: JSON.stringify({
+            id: 'explorer-das',
+            jsonrpc: '2.0',
+            method: 'getAsset',
+            params: { id },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        next: { revalidate: DAS_CACHE_REVALIDATE_S },
+    });
+
+    signal?.throwIfAborted();
+
+    if (!response.ok) {
+        Logger.warn(`[das] getAsset returned ${response.status}`, { sentry: true });
+        return null;
+    }
+
+    const data = await response.json();
+
+    if (data?.error) {
+        Logger.warn(`[das] getAsset RPC error: ${data.error?.message ?? 'unknown'}`);
+        return null;
+    }
+
+    const [validationError, validData] = validate(data, GetAssetResponseSchema);
+    if (validationError) {
+        Logger.warn(`[das] getAsset invalid response: ${validationError.message}`, { sentry: true });
+        return null;
+    }
+
+    return validData.result;
+}
+
 /**
- * Fetch metadata for multiple assets in one call.
+ * Fetch metadata for multiple assets via individual getAsset calls in parallel.
  * Returns undefined if url is empty or the request fails.
  */
 export async function getAssetBatch(
@@ -32,60 +73,10 @@ export async function getAssetBatch(
     if (ids.length === 0) return [];
 
     try {
-        // Do not pass `signal` directly to fetch — Next.js skips Data Cache for any
-        // request that carries a signal. Instead, race the fetch against a manual
-        // abort promise so the 2 s enrichment budget is still enforced while cached
-        // responses (which return instantly) are never affected by the signal at all.
-        const fetchPromise = fetch(url, {
-            body: JSON.stringify({
-                id: 'explorer-search',
-                jsonrpc: '2.0',
-                method: 'getAssets',
-                params: { ids },
-            }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-            next: { revalidate: DAS_CACHE_REVALIDATE_S },
-        });
-
-        const abortPromise = signal
-            ? new Promise<never>((_, reject) => {
-                  if (signal.aborted) {
-                      reject(signal.reason);
-                  } else {
-                      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
-                  }
-              })
-            : null;
-
-        Logger.info(`[das] calling getAssets on ${url} for ids: ${JSON.stringify(ids)}`);
-        const response = await (abortPromise ? Promise.race([fetchPromise, abortPromise]) : fetchPromise);
-
-        if (!response.ok) {
-            Logger.warn(`[das] getAssets returned ${response.status}`, { sentry: true });
-            return undefined;
-        }
-
-        const data = await response.json();
-        Logger.info(`[das] raw response: ${JSON.stringify(data)}`);
-
-        if (data?.error) {
-            Logger.warn(`[das] getAssets RPC error: ${data.error?.message ?? 'unknown'}`);
-            return undefined;
-        }
-
-        const [validationError, validData] = validate(data, GetAssetBatchResponseSchema);
-        if (validationError) {
-            Logger.warn(
-                `[das] getAssets schema validation failed: ${validationError.message} | path: ${validationError.path.join('.')}`,
-            );
-            return undefined;
-        }
-
-        Logger.info(`[das] validated result count: ${validData.result.length}`);
-        return validData.result.filter((item): item is DigitalAsset => item !== null);
+        const results = await Promise.all(ids.map(id => fetchSingleAsset(id, url, signal)));
+        return results.filter((item): item is DigitalAsset => item !== null);
     } catch (error) {
-        Logger.error(error instanceof Error ? error : new Error('[das] getAssets failed'), {
+        Logger.error(error instanceof Error ? error : new Error('[das] getAssetBatch failed'), {
             sentry: true,
         });
         return undefined;

--- a/app/entities/digital-asset/api.ts
+++ b/app/entities/digital-asset/api.ts
@@ -5,7 +5,7 @@
  * module fetches them from the cluster's DAS API as a best-effort fallback.
  */
 
-import { is } from 'superstruct';
+import { validate } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -72,16 +72,13 @@ export async function getAssetBatch(
             return undefined;
         }
 
-        if (!is(data, GetAssetBatchResponseSchema)) {
-            const resultType = typeof data?.result;
-            const resultIsArray = Array.isArray(data?.result);
-            Logger.warn(`[das] getAssets invalid response (result type: ${resultType}, isArray: ${resultIsArray})`, {
-                sentry: true,
-            });
+        const [validationError, validData] = validate(data, GetAssetBatchResponseSchema);
+        if (validationError) {
+            Logger.warn(`[das] getAssets invalid response: ${validationError.message}`, { sentry: true });
             return undefined;
         }
 
-        return data.result;
+        return validData.result;
     } catch (error) {
         Logger.error(error instanceof Error ? error : new Error('[das] getAssets failed'), {
             sentry: true,

--- a/app/entities/digital-asset/index.ts
+++ b/app/entities/digital-asset/index.ts
@@ -1,0 +1,1 @@
+export { useDasImage } from './model/use-das-image';

--- a/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
+++ b/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
@@ -41,14 +41,14 @@ describe('useDasImage', () => {
 
     it('should pass correct SWR key including cluster slug and customUrl', () => {
         vi.mocked(useCluster).mockReturnValue({
-            cluster: Cluster.Devnet,
+            cluster: Cluster.Custom,
             customUrl: 'https://custom.rpc',
         } as ReturnType<typeof useCluster>);
 
         renderHook(() => useDasImage('SomeMintAddress'));
 
         expect(useSWR).toHaveBeenCalledWith(
-            ['das-image', 'SomeMintAddress', clusterSlug(Cluster.Devnet), 'https://custom.rpc'],
+            ['das-image', 'SomeMintAddress', clusterSlug(Cluster.Custom), 'https://custom.rpc'],
             expect.any(Function),
             expect.any(Object),
         );

--- a/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
+++ b/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Cluster, clusterSlug } from '@/app/utils/cluster';
+
+vi.mock('@/app/providers/cluster', () => ({ useCluster: vi.fn() }));
+vi.mock('swr', () => ({ default: vi.fn() }));
+
+import useSWR from 'swr';
+
+import { useCluster } from '@/app/providers/cluster';
+
+import { useDasImage } from '../use-das-image';
+
+describe('useDasImage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useCluster).mockReturnValue({ cluster: Cluster.MainnetBeta, customUrl: '' } as ReturnType<typeof useCluster>);
+        vi.mocked(useSWR).mockReturnValue({ data: undefined } as ReturnType<typeof useSWR>);
+    });
+
+    it('should return undefined when no mintAddress', () => {
+        const { result } = renderHook(() => useDasImage(undefined));
+        expect(result.current).toBeUndefined();
+        expect(useSWR).toHaveBeenCalledWith(undefined, expect.any(Function), expect.any(Object));
+    });
+
+    it('should return the image URL from SWR data', () => {
+        vi.mocked(useSWR).mockReturnValue({ data: 'https://example.com/image.png' } as ReturnType<typeof useSWR>);
+
+        const { result } = renderHook(() => useDasImage('SomeMintAddress'));
+        expect(result.current).toBe('https://example.com/image.png');
+    });
+
+    it('should return undefined when SWR has no data', () => {
+        const { result } = renderHook(() => useDasImage('SomeMintAddress'));
+        expect(result.current).toBeUndefined();
+    });
+
+    it('should pass correct SWR key including cluster slug and customUrl', () => {
+        vi.mocked(useCluster).mockReturnValue({ cluster: Cluster.Devnet, customUrl: 'https://custom.rpc' } as ReturnType<typeof useCluster>);
+
+        renderHook(() => useDasImage('SomeMintAddress'));
+
+        expect(useSWR).toHaveBeenCalledWith(
+            ['das-image', 'SomeMintAddress', clusterSlug(Cluster.Devnet), 'https://custom.rpc'],
+            expect.any(Function),
+            expect.any(Object),
+        );
+    });
+
+    it('should pass correct SWR config', () => {
+        renderHook(() => useDasImage('SomeMintAddress'));
+
+        expect(useSWR).toHaveBeenCalledWith(expect.any(Array), expect.any(Function), {
+            dedupingInterval: 5 * 60 * 1000,
+            revalidateOnFocus: false,
+            revalidateOnReconnect: false,
+        });
+    });
+});

--- a/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
+++ b/app/entities/digital-asset/model/__tests__/use-das-image.spec.ts
@@ -15,7 +15,9 @@ import { useDasImage } from '../use-das-image';
 describe('useDasImage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.mocked(useCluster).mockReturnValue({ cluster: Cluster.MainnetBeta, customUrl: '' } as ReturnType<typeof useCluster>);
+        vi.mocked(useCluster).mockReturnValue({ cluster: Cluster.MainnetBeta, customUrl: '' } as ReturnType<
+            typeof useCluster
+        >);
         vi.mocked(useSWR).mockReturnValue({ data: undefined } as ReturnType<typeof useSWR>);
     });
 
@@ -38,7 +40,10 @@ describe('useDasImage', () => {
     });
 
     it('should pass correct SWR key including cluster slug and customUrl', () => {
-        vi.mocked(useCluster).mockReturnValue({ cluster: Cluster.Devnet, customUrl: 'https://custom.rpc' } as ReturnType<typeof useCluster>);
+        vi.mocked(useCluster).mockReturnValue({
+            cluster: Cluster.Devnet,
+            customUrl: 'https://custom.rpc',
+        } as ReturnType<typeof useCluster>);
 
         renderHook(() => useDasImage('SomeMintAddress'));
 

--- a/app/entities/digital-asset/model/use-das-image.ts
+++ b/app/entities/digital-asset/model/use-das-image.ts
@@ -1,0 +1,36 @@
+import useSWR from 'swr';
+
+import { useCluster } from '@/app/providers/cluster';
+import { Cluster, clusterSlug } from '@/app/utils/cluster';
+
+type DasImageKey = ['das-image', string, string, string];
+
+function getDasImageKey(cluster: Cluster, mintAddress: string, customUrl: string): DasImageKey {
+    return ['das-image', mintAddress, clusterSlug(cluster), customUrl];
+}
+
+async function fetchDasImage([, mintAddress, cluster, customUrl]: DasImageKey): Promise<string | undefined> {
+    try {
+        const params = new URLSearchParams({ cluster });
+        if (customUrl) params.set('customUrl', customUrl);
+        const response = await fetch(`/api/token-image/${mintAddress}?${params}`);
+        if (!response.ok) return undefined;
+        const data = await response.json();
+        return typeof data.image === 'string' ? data.image : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+const DAS_IMAGE_SWR_CONFIG = {
+    dedupingInterval: 5 * 60 * 1000,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+};
+
+export function useDasImage(mintAddress?: string): string | undefined {
+    const { cluster, customUrl } = useCluster();
+    const swrKey = mintAddress ? getDasImageKey(cluster, mintAddress, customUrl) : undefined;
+    const { data } = useSWR(swrKey, fetchDasImage, DAS_IMAGE_SWR_CONFIG);
+    return data;
+}

--- a/app/entities/digital-asset/types.ts
+++ b/app/entities/digital-asset/types.ts
@@ -1,14 +1,17 @@
-import { array, Infer, optional, string, type } from 'superstruct';
+import { array, Infer, nullable, optional, string, type } from 'superstruct';
 
 export const DigitalAssetSchema = type({
-    content: type({
-        links: optional(
-            type({
-                external_url: optional(string()),
-                image: optional(string()),
-            }),
-        ),
-    }),
+    content: nullable(
+        type({
+            links: nullable(
+                optional(
+                    type({
+                        image: nullable(optional(string())),
+                    }),
+                ),
+            ),
+        }),
+    ),
     id: string(),
 });
 

--- a/app/entities/digital-asset/types.ts
+++ b/app/entities/digital-asset/types.ts
@@ -15,6 +15,10 @@ export const DigitalAssetSchema = type({
     id: string(),
 });
 
+export const GetAssetResponseSchema = type({
+    result: nullable(DigitalAssetSchema),
+});
+
 export const GetAssetBatchResponseSchema = type({
     result: array(nullable(DigitalAssetSchema)),
 });

--- a/app/entities/digital-asset/types.ts
+++ b/app/entities/digital-asset/types.ts
@@ -1,50 +1,15 @@
-import { array, boolean, Infer, number, optional, string, type } from 'superstruct';
+import { array, Infer, optional, string, type } from 'superstruct';
 
 export const DigitalAssetSchema = type({
-    burnt: boolean(),
     content: type({
-        $schema: string(),
-        files: optional(
-            array(
-                type({
-                    cdn_uri: optional(string()),
-                    mime: optional(string()),
-                    uri: optional(string()),
-                }),
-            ),
-        ),
-        json_uri: string(),
         links: optional(
             type({
                 external_url: optional(string()),
                 image: optional(string()),
             }),
         ),
-        metadata: type({
-            description: optional(string()),
-            name: optional(string()),
-            symbol: optional(string()),
-            token_standard: optional(string()),
-        }),
     }),
     id: string(),
-    interface: string(),
-    mutable: boolean(),
-    token_info: optional(
-        type({
-            decimals: optional(number()),
-            mint_authority: optional(string()),
-            price_info: optional(
-                type({
-                    currency: optional(string()),
-                    price_per_token: optional(number()),
-                }),
-            ),
-            supply: optional(number()),
-            symbol: optional(string()),
-            token_program: optional(string()),
-        }),
-    ),
 });
 
 export const GetAssetBatchResponseSchema = type({

--- a/app/entities/digital-asset/types.ts
+++ b/app/entities/digital-asset/types.ts
@@ -16,7 +16,7 @@ export const DigitalAssetSchema = type({
 });
 
 export const GetAssetBatchResponseSchema = type({
-    result: array(DigitalAssetSchema),
+    result: array(nullable(DigitalAssetSchema)),
 });
 
 export type DigitalAsset = Infer<typeof DigitalAssetSchema>;

--- a/app/entities/digital-asset/types.ts
+++ b/app/entities/digital-asset/types.ts
@@ -1,4 +1,4 @@
-import { array, Infer, nullable, optional, string, type } from 'superstruct';
+import { Infer, nullable, optional, string, type } from 'superstruct';
 
 export const DigitalAssetSchema = type({
     content: nullable(
@@ -17,10 +17,6 @@ export const DigitalAssetSchema = type({
 
 export const GetAssetResponseSchema = type({
     result: nullable(DigitalAssetSchema),
-});
-
-export const GetAssetBatchResponseSchema = type({
-    result: array(nullable(DigitalAssetSchema)),
 });
 
 export type DigitalAsset = Infer<typeof DigitalAssetSchema>;

--- a/app/features/search/api/resolve-search-tokens.ts
+++ b/app/features/search/api/resolve-search-tokens.ts
@@ -83,7 +83,7 @@ export async function resolveSearchTokens(
         clearTimeout(imageTimeout);
     }
 
-    const iconMap = new Map(assets?.map(a => [a.id, a.content.links?.image]) ?? []);
+    const iconMap = new Map(assets?.map(a => [a.id, a.content?.links?.image]) ?? []);
 
     return discovered.map(t => ({
         decimals: t.decimals,

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -39,6 +39,7 @@
 | Dynamic | `/api/search` | — | — |
 | Dynamic | `/api/security-txt` | — | — |
 | Dynamic | `/api/sns-domains/[address]` | — | — |
+| Dynamic | `/api/token-image/[mintAddress]` | — | — |
 | Dynamic | `/api/token-info` | — | — |
 | Dynamic | `/api/verification/bluprynt/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
@@ -53,7 +54,7 @@
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 1.04 MB |
-| Dynamic | `/tx/[signature]` | 440 kB | 1.46 MB |
-| Dynamic | `/tx/[signature]/inspect` | 360 kB | 1.38 MB |
-| Static | `/tx/inspector` | 360 kB | 1.38 MB |
+| Static | `/tos` | 890 B | 1.03 MB |
+| Dynamic | `/tx/[signature]` | 500 kB | 1.51 MB |
+| Dynamic | `/tx/[signature]/inspect` | 370 kB | 1.39 MB |
+| Static | `/tx/inspector` | 370 kB | 1.39 MB |


### PR DESCRIPTION
## Description
some addresses have image in metadata. image is showing in search, but not on page. so this fix adding das request to get image.

## Type of change
-   [x] Bug fix

## Screenshots
|before|after|
|--|--|
|<img width="828" height="446" alt="Screenshot 2026-06-05 at 11 29 20" src="https://github.com/user-attachments/assets/63aa3b50-1ab9-45d8-9f0d-4fc204a0c199" />|<img width="1224" height="627" alt="Screenshot 2026-06-05 at 11 27 16" src="https://github.com/user-attachments/assets/bf6f033a-abb5-4080-9d0b-fd190b957ef5" />|

## Testing
1. open [Jonas token](https://explorer-git-fork-hoodieshq-fix-hoo-57-013f4a-solana-foundation.vercel.app/address/9gKarRAB57A4336gxiHS77PfbCUnhwveBzkQmkeMBAGS)
2. see image

## Related Issues
[HOO-571](https://linear.app/solana-fndn/issue/HOO-571/token-image-missing-on-token-page)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes