### PR TITLE
fix: Show ZK ElGamal proof instruction names in account history

### DIFF
--- a/app/components/instruction/ZkElGamalProofDetailsCard.tsx
+++ b/app/components/instruction/ZkElGamalProofDetailsCard.tsx
@@ -1,34 +1,13 @@
 import { Address } from '@components/common/Address';
 import { SignatureResult, TransactionInstruction } from '@solana/web3.js';
 import { ZK_ELGAMAL_PROOF_PROGRAM_ID } from '@utils/programs';
+import { getZkElGamalProofInstructionName } from '@utils/zk-elgamal-proof';
 import React from 'react';
 
 import { InstructionCard } from './InstructionCard';
 
-// Indexed by the 1-byte discriminator (0..=12).
-const INSTRUCTION_NAMES: readonly string[] = [
-    'Close Context State',
-    'Verify Zero Ciphertext',
-    'Verify Ciphertext-Ciphertext Equality',
-    'Verify Ciphertext-Commitment Equality',
-    'Verify Pubkey Validity',
-    'Verify Percentage With Cap',
-    'Verify Batched Range Proof (U64)',
-    'Verify Batched Range Proof (U128)',
-    'Verify Batched Range Proof (U256)',
-    'Verify Grouped Ciphertext (2 handles)',
-    'Verify Batched Grouped Ciphertext (2 handles)',
-    'Verify Grouped Ciphertext (3 handles)',
-    'Verify Batched Grouped Ciphertext (3 handles)',
-];
-
 export function isZkElGamalProofInstruction(ix: TransactionInstruction): boolean {
     return ix.programId.toBase58() === ZK_ELGAMAL_PROOF_PROGRAM_ID;
-}
-
-// Maps the 1-byte instruction discriminator to a human-readable name.
-export function getZkElGamalProofInstructionName(discriminator: number): string {
-    return INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';
 }
 
 export function ZkElGamalProofDetailsCard({

--- a/app/components/instruction/ZkElGamalProofDetailsCard.tsx
+++ b/app/components/instruction/ZkElGamalProofDetailsCard.tsx
@@ -26,6 +26,11 @@ export function isZkElGamalProofInstruction(ix: TransactionInstruction): boolean
     return ix.programId.toBase58() === ZK_ELGAMAL_PROOF_PROGRAM_ID;
 }
 
+// Maps the 1-byte instruction discriminator to a human-readable name.
+export function getZkElGamalProofInstructionName(discriminator: number): string {
+    return INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';
+}
+
 export function ZkElGamalProofDetailsCard({
     ix,
     index,
@@ -46,7 +51,7 @@ export function ZkElGamalProofDetailsCard({
     // empty and the proof lives off-instruction; the row below stays hidden.
     const data = ix.data;
     const discriminator = data.length > 0 ? data[0] : -1;
-    const instructionName = INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';
+    const instructionName = getZkElGamalProofInstructionName(discriminator);
     const isClose = discriminator === 0;
     const proofBytes = data.length > 1 ? data.length - 1 : 0;
     const accountCount = ix.keys.length;

--- a/app/utils/__tests__/instruction.test.ts
+++ b/app/utils/__tests__/instruction.test.ts
@@ -88,6 +88,38 @@ describe('getTransactionInstructionNames', () => {
         });
     });
 
+    describe('ZK ElGamal proof instructions', () => {
+        const ZK_ELGAMAL_PROOF_PROGRAM_ID = new PublicKey('ZkE1Gama1Proof11111111111111111111111111111');
+
+        it('should resolve the instruction name from the discriminator', () => {
+            // discriminator 3 = Verify Ciphertext-Commitment Equality
+            const ix: PartiallyDecodedInstruction = {
+                accounts: [],
+                data: bs58.encode(new Uint8Array([3])),
+                programId: ZK_ELGAMAL_PROOF_PROGRAM_ID,
+            };
+
+            const [result] = getTransactionInstructionNames(makeTx([ix]));
+
+            expect(result).toEqual({
+                name: 'Verify Ciphertext-Commitment Equality',
+                program: 'ZK ElGamal Proof Program',
+            });
+        });
+
+        it('should fall back to Unknown Instruction for an out-of-range discriminator', () => {
+            const ix: PartiallyDecodedInstruction = {
+                accounts: [],
+                data: bs58.encode(new Uint8Array([99])),
+                programId: ZK_ELGAMAL_PROOF_PROGRAM_ID,
+            };
+
+            const [result] = getTransactionInstructionNames(makeTx([ix]));
+
+            expect(result).toEqual({ name: 'Unknown Instruction', program: 'ZK ElGamal Proof Program' });
+        });
+    });
+
     describe('multiple instructions', () => {
         it('should map each instruction in the transaction independently', () => {
             const transfer = {

--- a/app/utils/__tests__/instruction.test.ts
+++ b/app/utils/__tests__/instruction.test.ts
@@ -118,6 +118,18 @@ describe('getTransactionInstructionNames', () => {
 
             expect(result).toEqual({ name: 'Unknown Instruction', program: 'ZK ElGamal Proof Program' });
         });
+
+        it('should fall back to Unknown Instruction for empty instruction data', () => {
+            const ix: PartiallyDecodedInstruction = {
+                accounts: [],
+                data: bs58.encode(new Uint8Array([])),
+                programId: ZK_ELGAMAL_PROOF_PROGRAM_ID,
+            };
+
+            const [result] = getTransactionInstructionNames(makeTx([ix]));
+
+            expect(result).toEqual({ name: 'Unknown Instruction', program: 'ZK ElGamal Proof Program' });
+        });
     });
 
     describe('multiple instructions', () => {

--- a/app/utils/instruction.ts
+++ b/app/utils/instruction.ts
@@ -5,6 +5,7 @@ import {
     parseTokenLendingInstructionTitle,
 } from '@components/instruction/token-lending/types';
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
+import { getZkElGamalProofInstructionName } from '@components/instruction/ZkElGamalProofDetailsCard';
 import { isTokenProgramId } from '@providers/accounts/tokens';
 import {
     ComputeBudgetProgram,
@@ -14,9 +15,10 @@ import {
     PartiallyDecodedInstruction,
 } from '@solana/web3.js';
 import { camelToTitleCase } from '@utils/index';
-import { isTokenProgram } from '@utils/programs';
+import { isTokenProgram, ZK_ELGAMAL_PROOF_PROGRAM_ID } from '@utils/programs';
 import { intoTransactionInstruction } from '@utils/tx';
 import { ParsedInfo } from '@validators/index';
+import bs58 from 'bs58';
 import { create } from 'superstruct';
 
 import { getProgramName } from '@/app/entities/transaction-data';
@@ -139,6 +141,12 @@ export function getTransactionInstructionNames(
                     // ix.parsed is a string (e.g. memo text) — instruction name is the program name
                     return { name: 'Memo', program };
                 }
+            } else if (ix.programId.toBase58() === ZK_ELGAMAL_PROOF_PROGRAM_ID) {
+                // ZK ElGamal proof instructions aren't parsed by the RPC; the name lives
+                // in the 1-byte discriminator at the start of the base58-encoded data.
+                const data = bs58.decode(ix.data);
+                const discriminator = data.length > 0 ? data[0] : -1;
+                return { name: getZkElGamalProofInstructionName(discriminator), program };
             }
             return { name: 'Unknown Instruction', program: program === 'Unknown' ? 'Unknown Program' : program };
         });

--- a/app/utils/instruction.ts
+++ b/app/utils/instruction.ts
@@ -5,7 +5,6 @@ import {
     parseTokenLendingInstructionTitle,
 } from '@components/instruction/token-lending/types';
 import { isTokenSwapInstruction, parseTokenSwapInstructionTitle } from '@components/instruction/token-swap/types';
-import { getZkElGamalProofInstructionName } from '@components/instruction/ZkElGamalProofDetailsCard';
 import { isTokenProgramId } from '@providers/accounts/tokens';
 import {
     ComputeBudgetProgram,
@@ -17,6 +16,7 @@ import {
 import { camelToTitleCase } from '@utils/index';
 import { isTokenProgram, ZK_ELGAMAL_PROOF_PROGRAM_ID } from '@utils/programs';
 import { intoTransactionInstruction } from '@utils/tx';
+import { getZkElGamalProofInstructionName } from '@utils/zk-elgamal-proof';
 import { ParsedInfo } from '@validators/index';
 import bs58 from 'bs58';
 import { create } from 'superstruct';

--- a/app/utils/zk-elgamal-proof.ts
+++ b/app/utils/zk-elgamal-proof.ts
@@ -1,0 +1,21 @@
+// Human-readable names for ZK ElGamal Proof Program instructions, indexed by the
+// 1-byte discriminator (0..=12) at the start of the instruction data.
+const INSTRUCTION_NAMES: readonly string[] = [
+    'Close Context State',
+    'Verify Zero Ciphertext',
+    'Verify Ciphertext-Ciphertext Equality',
+    'Verify Ciphertext-Commitment Equality',
+    'Verify Pubkey Validity',
+    'Verify Percentage With Cap',
+    'Verify Batched Range Proof (U64)',
+    'Verify Batched Range Proof (U128)',
+    'Verify Batched Range Proof (U256)',
+    'Verify Grouped Ciphertext (2 handles)',
+    'Verify Batched Grouped Ciphertext (2 handles)',
+    'Verify Grouped Ciphertext (3 handles)',
+    'Verify Batched Grouped Ciphertext (3 handles)',
+];
+
+export function getZkElGamalProofInstructionName(discriminator: number): string {
+    return INSTRUCTION_NAMES[discriminator] ?? 'Unknown Instruction';
+}


### PR DESCRIPTION
The account transaction history summary was showing "Unknown Instruction" for ZK ElGamal Proof Program instructions, even though the individual transaction detail page rendered the correct name (e.g. "Verify Ciphertext-Commitment Equality").

The cause: `getTransactionInstructionNames` in `app/utils/instruction.ts` only resolved names for RPC parsed instructions that carry a `parsed.type`. ZK ElGamal proof instructions come back partially decoded, so they fell straight through to the "Unknown Instruction" fallback. The detail page works because it routes these to `ZkElGamalProofDetailsCard`, which decodes the name from the 1-byte discriminator.

The fix decodes that same discriminator in the summary path and resolves the name through a shared helper extracted from the detail card, so both views stay in sync. Added unit tests covering the resolved name and the out-of-range fallback.
