### PR TITLE
fix(storybook): VerifiedBuildCard story

### DIFF
--- a/app/components/account/__stories__/VerifiedBuildCard.stories.tsx
+++ b/app/components/account/__stories__/VerifiedBuildCard.stories.tsx
@@ -24,6 +24,7 @@ const VERIFIED_FIXTURE: OsecRegistryInfo = {
     last_verified_at: '2026-01-01T00:00:00.000Z',
     message: 'Verification information provided by a trusted signer.',
     on_chain_hash: '0000000000000000000000000000000000000000000000000000000000000000',
+    onchain_repo_url: 'https://github.com/example/verified-program',
     repo_url: 'https://github.com/example/verified-program',
     signer: '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r',
     verification_status: VerificationStatus.Verified,


### PR DESCRIPTION
## Description

New `onchain_repo_url` field is missing in `VerifiedBuildCard` component which makes ci/cd build [fail](https://github.com/solana-foundation/explorer/actions/runs/27136975546).

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): Fix storybook component

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

## Testing

CI/CD should pass.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] CI/CD checks pass on the PR

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->
