### PR TITLE
Remove vote program from builtin 4k list

### DIFF
--- a/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
+++ b/app/entities/compute-unit/lib/__tests__/compute-units-schedule.spec.ts
@@ -42,7 +42,7 @@ describe('getReservedComputeUnits', () => {
                     epoch: 1000n,
                     programId: 'Vote111111111111111111111111111111111111111', // Vote Program
                 }),
-            ).toEqual(3_000);
+            ).toEqual(200_000);
 
             expect(
                 getReservedComputeUnits({

--- a/app/entities/compute-unit/lib/compute-units-schedule.ts
+++ b/app/entities/compute-unit/lib/compute-units-schedule.ts
@@ -22,7 +22,6 @@ import bs58 from 'bs58';
 const BUILTIN_PROGRAMS_3K: readonly string[] = [
     '11111111111111111111111111111111', // System Program
     'Stake11111111111111111111111111111111111111', // Stake Program
-    'Vote111111111111111111111111111111111111111', // Vote Program
     'Config1111111111111111111111111111111111111', // Config Program
     'AddressLookupTab1e1111111111111111111111111', // Address Lookup Table Program
     'BPFLoaderUpgradeab1e11111111111111111111111', // BPF Loader Upgradeable


### PR DESCRIPTION
Because of SIMD-0458 vote program now uses more CU than 3k. So we will just show the standart 200k CU requested.

Result for a vote: 
<img width="1015" height="550" alt="image" src="https://github.com/user-attachments/assets/33e3830a-f84c-4910-b668-181b90ea7d2d" />
 
http://localhost:3000/tx/5kHQrpMk34NHdhXADLTcFYHqhRb8wPosBNnr9oF1RJa4tiELGB7jjR3DDP2KoaTJ8UxiiUMXPSZVSr42QEEese4g?cluster=testnet

Wrong 3k display from before the fix: 
<img width="1033" height="530" alt="image" src="https://github.com/user-attachments/assets/876dea64-0440-4e65-a1cb-a4ab9ef26d34" />
 
https://explorer.solana.com/tx/3fEi7sku5kEgeZmLw9evxY5if9TsFyxpUNsi84J3s1bAeQmKSAhBypuxgprSs15MYBmvvTCnVwoN36rCaoqq6oHd?cluster=testnet
