### PR TITLE
Feat: account row update

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -109,6 +109,17 @@ export const withTokenInfoBatch: Decorator = Story => (
     </MockTokenInfoBatchProvider>
 );
 
+/** Wraps stories with ClusterProvider, MockTokenInfoBatchProvider, and MockAccountsProvider. Usage: `decorators: [withClusterAccountsAndTokenInfo]` */
+export const withClusterAccountsAndTokenInfo: Decorator = Story => (
+    <ClusterProvider>
+        <MockTokenInfoBatchProvider>
+            <MockAccountsProvider>
+                <Story />
+            </MockAccountsProvider>
+        </MockTokenInfoBatchProvider>
+    </ClusterProvider>
+);
+
 /** Wraps stories with ClusterProvider and MockSupplyProvider. Usage: `decorators: [withSupply]` */
 export const withSupply: Decorator = Story => (
     <ClusterProvider>

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -71,7 +71,7 @@ const getEthAddress = (link?: string) => {
     return address;
 };
 
-const StatusBadge = ({ status }: { status: string }) => (
+export const StatusBadge = ({ status }: { status: string }) => (
     <Badge ui="dashkit" variant={status === 'initialized' ? 'success' : 'warning'}>
         {capitalCase(status)}
     </Badge>

--- a/app/components/account/TokenExtensionsSection.tsx
+++ b/app/components/account/TokenExtensionsSection.tsx
@@ -175,7 +175,7 @@ function ExtensionListItem({ ext }: { ext: ParsedTokenExtension }) {
             </div>
 
             {/* Description */}
-            <div className="flex-1 text-[0.75rem] text-[#8E9090] underline decoration-[#1e2423] max-lg:hidden">
+            <div className="max-lg:hidden flex-1 text-[0.75rem] text-[#8E9090] underline decoration-[#1e2423]">
                 {ext.description ?? null}
             </div>
         </div>

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -33,6 +33,7 @@ const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-
 type Props = {
     pubkey: PublicKey;
     alignRight?: boolean;
+    className?: string;
     link?: boolean;
     raw?: boolean;
     noTruncate?: boolean;
@@ -54,6 +55,7 @@ export function Address({
     useMetadata,
     overrideText,
     tokenLabelInfo,
+    className,
     fetchTokenLabelInfo,
     'aria-label': ariaLabel,
     noCopy,
@@ -134,7 +136,7 @@ export function Address({
             {nickname ? nicknameDisplay : visibleText}
         </Link>
     ) : (
-        <span className={innerTextClassName}>{nickname ? nicknameDisplay : visibleText}</span>
+        <span className={cn(innerTextClassName, className)}>{nickname ? nicknameDisplay : visibleText}</span>
     );
 
     const addressDisplay = isMidTruncateCandidate ? (
@@ -192,7 +194,7 @@ export function Address({
                         title="Edit nickname"
                         style={{ fontSize: '0.875rem', lineHeight: 1 }}
                     >
-                        <EditIcon />
+                        <EditIcon className="-e-mt-0.5" />
                     </button>
                 )}
                 {!noNicknameEditing && showNicknameEditor && (

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -176,7 +176,10 @@ export function Address({
                 <button
                     ref={editBtnRef}
                     className="ms-1.5 flex-none shrink-0 cursor-pointer border-0 bg-transparent p-0 text-muted"
-                    onClick={() => setShowNicknameEditor(true)}
+                    onClick={e => {
+                        e.stopPropagation();
+                        setShowNicknameEditor(true);
+                    }}
                     title="Edit nickname"
                     style={{ fontSize: '0.875rem', lineHeight: 1 }}
                 >

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -116,11 +116,7 @@ export function Address({
 
     const visibleText = isMidTruncated ? midTruncatedText : displayText;
 
-    const innerTextClassName = cn(
-        'font-mono',
-        !nickname && !noTruncate && 'truncate',
-        nickname && 'block min-w-0',
-    );
+    const innerTextClassName = cn('font-mono', !nickname && !noTruncate && 'truncate', nickname && 'block min-w-0');
 
     // When a nickname is set, render it and the address label as two stacked lines
     // so neither overflows on narrow (mobile) viewports.
@@ -144,7 +140,7 @@ export function Address({
             <TooltipTrigger asChild>
                 <span
                     data-address={address}
-                    className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                    className="relative min-w-0 overflow-hidden font-mono"
                     onMouseEnter={() => handleMouseEnter(address)}
                     onMouseLeave={() => handleMouseLeave(address)}
                 >
@@ -153,14 +149,14 @@ export function Address({
             </TooltipTrigger>
             {isMidTruncated && (
                 <TooltipContent>
-                    <span className="e-font-mono">{address}</span>
+                    <span className="font-mono">{address}</span>
                 </TooltipContent>
             )}
         </Tooltip>
     ) : (
         <span
             data-address={address}
-            className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+            className="relative min-w-0 overflow-hidden font-mono"
             onMouseEnter={() => handleMouseEnter(address)}
             onMouseLeave={() => handleMouseLeave(address)}
             title={nickname ? displayText : undefined}
@@ -194,7 +190,7 @@ export function Address({
                         title="Edit nickname"
                         style={{ fontSize: '0.875rem', lineHeight: 1 }}
                     >
-                        <EditIcon className="-e-mt-0.5" />
+                        <EditIcon className="-mt-0.5" />
                     </button>
                 )}
                 {!noNicknameEditing && showNicknameEditor && (

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -18,7 +18,7 @@ import { useVisibility } from '@/app/shared/lib/visibility';
 import { Copyable } from './Copyable';
 import { useMidTruncation } from './useMidTruncation';
 
-const rowVariants = cva('relative flex w-full min-w-0 items-baseline', {
+const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-hidden', {
     defaultVariants: {
         alignRight: false,
     },

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -41,6 +41,8 @@ type Props = {
     tokenLabelInfo?: TokenLabelInfo;
     fetchTokenLabelInfo?: boolean;
     'aria-label'?: string;
+    noCopy?: boolean;
+    noNicknameEditing?: boolean;
 };
 
 export function Address({
@@ -54,6 +56,8 @@ export function Address({
     tokenLabelInfo,
     fetchTokenLabelInfo,
     'aria-label': ariaLabel,
+    noCopy,
+    noNicknameEditing,
 }: Props) {
     const address = pubkey.toBase58();
     const { cluster, clusterInfo } = useCluster();
@@ -110,7 +114,11 @@ export function Address({
 
     const visibleText = isMidTruncated ? midTruncatedText : displayText;
 
-    const innerTextClassName = cn('font-mono', !nickname && 'truncate', nickname && 'block min-w-0');
+    const innerTextClassName = cn(
+        'font-mono',
+        !nickname && !noTruncate && 'truncate',
+        nickname && 'block min-w-0',
+    );
 
     // When a nickname is set, render it and the address label as two stacked lines
     // so neither overflows on narrow (mobile) viewports.
@@ -129,6 +137,36 @@ export function Address({
         <span className={innerTextClassName}>{nickname ? nicknameDisplay : visibleText}</span>
     );
 
+    const addressDisplay = isMidTruncateCandidate ? (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span
+                    data-address={address}
+                    className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+                    onMouseEnter={() => handleMouseEnter(address)}
+                    onMouseLeave={() => handleMouseLeave(address)}
+                >
+                    {innerContent}
+                </span>
+            </TooltipTrigger>
+            {isMidTruncated && (
+                <TooltipContent>
+                    <span className="e-font-mono">{address}</span>
+                </TooltipContent>
+            )}
+        </Tooltip>
+    ) : (
+        <span
+            data-address={address}
+            className="e-relative e-min-w-0 e-overflow-hidden e-font-mono"
+            onMouseEnter={() => handleMouseEnter(address)}
+            onMouseLeave={() => handleMouseLeave(address)}
+            title={nickname ? displayText : undefined}
+        >
+            {innerContent}
+        </span>
+    );
+
     return (
         <span ref={visibilityRef} className="block w-full">
             <div ref={rowRef} className={rowVariants({ alignRight: Boolean(alignRight) })} aria-label={ariaLabel}>
@@ -142,50 +180,22 @@ export function Address({
                         {addressLabel}
                     </span>
                 )}
-                <Copyable text={address}>
-                    {isMidTruncateCandidate ? (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <span
-                                    data-address={address}
-                                    className="relative min-w-0 overflow-hidden font-mono"
-                                    onMouseEnter={() => handleMouseEnter(address)}
-                                    onMouseLeave={() => handleMouseLeave(address)}
-                                >
-                                    {innerContent}
-                                </span>
-                            </TooltipTrigger>
-                            {isMidTruncated && (
-                                <TooltipContent>
-                                    <span className="font-mono">{address}</span>
-                                </TooltipContent>
-                            )}
-                        </Tooltip>
-                    ) : (
-                        <span
-                            data-address={address}
-                            className="relative min-w-0 overflow-hidden font-mono"
-                            onMouseEnter={() => handleMouseEnter(address)}
-                            onMouseLeave={() => handleMouseLeave(address)}
-                            title={nickname ? displayText : undefined}
-                        >
-                            {innerContent}
-                        </span>
-                    )}
-                </Copyable>
-                <button
-                    ref={editBtnRef}
-                    className="ms-1.5 flex-none shrink-0 cursor-pointer border-0 bg-transparent p-0 text-muted"
-                    onClick={e => {
-                        e.stopPropagation();
-                        setShowNicknameEditor(true);
-                    }}
-                    title="Edit nickname"
-                    style={{ fontSize: '0.875rem', lineHeight: 1 }}
-                >
-                    <EditIcon />
-                </button>
-                {showNicknameEditor && (
+                {noCopy ? addressDisplay : <Copyable text={address}>{addressDisplay}</Copyable>}
+                {!noNicknameEditing && (
+                    <button
+                        ref={editBtnRef}
+                        className="ms-1.5 flex-none shrink-0 cursor-pointer border-0 bg-transparent p-0 text-muted"
+                        onClick={e => {
+                            e.stopPropagation();
+                            setShowNicknameEditor(true);
+                        }}
+                        title="Edit nickname"
+                        style={{ fontSize: '0.875rem', lineHeight: 1 }}
+                    >
+                        <EditIcon />
+                    </button>
+                )}
+                {!noNicknameEditing && showNicknameEditor && (
                     <NicknameEditor address={address} onClose={() => setShowNicknameEditor(false)} />
                 )}
             </div>

--- a/app/components/common/Copyable.tsx
+++ b/app/components/common/Copyable.tsx
@@ -9,7 +9,8 @@ export function Copyable({ text, children }: { text: string | null; children?: R
     const [clipboardState, copy] = useCopyToClipboard(1000);
     const [loading, setLoading] = useState(false);
 
-    const handleClick = () => {
+    const handleClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
         if (typeof text !== 'string') {
             setLoading(true);
             return;

--- a/app/components/shared/ui/popover.tsx
+++ b/app/components/shared/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
             align={align}
             sideOffset={sideOffset}
             className={cn(
-                'z-50 rounded-md bg-outer-space-900 shadow-[0_4px_12px_rgba(0,0,0,0.5)] outline-none',
+                'z-[9999] rounded-md bg-outer-space-900 shadow-[0_4px_12px_rgba(0,0,0,0.5)] outline-none',
                 'border border-solid border-outer-space-800',
                 'data-[state=open]:animate-in data-[state=closed]:animate-out',
                 'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -65,7 +65,7 @@ export const WithFooter: Story = {
         const closeBtn = body.getByRole('button', { name: 'Close' });
         expect(closeBtn).toBeInTheDocument();
         await userEvent.click(closeBtn);
-        expect(body.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(body.queryByRole('dialog')).toHaveAttribute('data-state', 'closed');
     },
     render: function WithFooterSlideover() {
         const [open, setOpen] = useState(false);

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { Button } from './button';
+import {
+    Slideover,
+    SlideoverBody,
+    SlideoverClose,
+    SlideoverContent,
+    SlideoverHeader,
+    SlideoverTitle,
+    SlideoverTrigger,
+} from './slideover';
+
+const meta: Meta<typeof Slideover> = {
+    component: Slideover,
+    tags: ['autodocs'],
+    title: 'Components/Shared/UI/Slideover',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const trigger = canvas.getByRole('button', { name: 'Open Slideover' });
+        await userEvent.click(trigger);
+        const body = within(document.body);
+        const dialog = await body.findByRole('dialog');
+        expect(dialog).toBeInTheDocument();
+        expect(body.getByText('Slideover Title')).toBeInTheDocument();
+    },
+    render: function DefaultSlideover() {
+        const [open, setOpen] = useState(false);
+        return (
+            <Slideover open={open} onOpenChange={setOpen}>
+                <SlideoverTrigger asChild>
+                    <Button variant="outline" size="sm">
+                        Open Slideover
+                    </Button>
+                </SlideoverTrigger>
+                <SlideoverContent aria-describedby={undefined}>
+                    <SlideoverHeader>
+                        <SlideoverTitle>Slideover Title</SlideoverTitle>
+                    </SlideoverHeader>
+                    <SlideoverBody className="e-p-4">
+                        <p className="e-text-sm e-text-outer-space-300">
+                            This is the slideover body. It scrolls independently from the header and footer.
+                        </p>
+                    </SlideoverBody>
+                </SlideoverContent>
+            </Slideover>
+        );
+    },
+};
+
+export const WithFooter: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
+        const body = within(document.body);
+        await body.findByRole('dialog');
+        const closeBtn = body.getByRole('button', { name: 'Close' });
+        expect(closeBtn).toBeInTheDocument();
+        await userEvent.click(closeBtn);
+        expect(body.queryByRole('dialog')).not.toBeInTheDocument();
+    },
+    render: function WithFooterSlideover() {
+        const [open, setOpen] = useState(false);
+        return (
+            <Slideover open={open} onOpenChange={setOpen}>
+                <SlideoverTrigger asChild>
+                    <Button variant="outline" size="sm">
+                        Open
+                    </Button>
+                </SlideoverTrigger>
+                <SlideoverContent aria-describedby={undefined}>
+                    <SlideoverHeader>
+                        <SlideoverTitle>Account 1</SlideoverTitle>
+                    </SlideoverHeader>
+                    <SlideoverBody className="e-p-4">
+                        <p className="e-text-sm e-text-outer-space-300">Account details go here.</p>
+                    </SlideoverBody>
+                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3">
+                        <SlideoverClose asChild>
+                            <Button className="e-w-full" size="sm" variant="outline">
+                                Close
+                            </Button>
+                        </SlideoverClose>
+                    </div>
+                </SlideoverContent>
+            </Slideover>
+        );
+    },
+};

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -15,7 +15,7 @@ import {
 
 const meta: Meta<typeof Slideover> = {
     component: Slideover,
-    tags: ['autodocs'],
+    tags: ['autodocs', 'test'],
     title: 'Components/Shared/UI/Slideover',
 };
 

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -16,7 +16,7 @@ import {
 const meta: Meta<typeof Slideover> = {
     component: Slideover,
     tags: ['autodocs', 'test'],
-    title: 'Components/Shared/UI/Slideover',
+    title: 'Components/Shared/Slideover',
 };
 
 export default meta;

--- a/app/components/shared/ui/slideover.stories.tsx
+++ b/app/components/shared/ui/slideover.stories.tsx
@@ -45,8 +45,8 @@ export const Default: Story = {
                     <SlideoverHeader>
                         <SlideoverTitle>Slideover Title</SlideoverTitle>
                     </SlideoverHeader>
-                    <SlideoverBody className="e-p-4">
-                        <p className="e-text-sm e-text-outer-space-300">
+                    <SlideoverBody className="p-4">
+                        <p className="text-sm text-outer-space-300">
                             This is the slideover body. It scrolls independently from the header and footer.
                         </p>
                     </SlideoverBody>
@@ -80,12 +80,12 @@ export const WithFooter: Story = {
                     <SlideoverHeader>
                         <SlideoverTitle>Account 1</SlideoverTitle>
                     </SlideoverHeader>
-                    <SlideoverBody className="e-p-4">
-                        <p className="e-text-sm e-text-outer-space-300">Account details go here.</p>
+                    <SlideoverBody className="p-4">
+                        <p className="text-sm text-outer-space-300">Account details go here.</p>
                     </SlideoverBody>
-                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3">
+                    <div className="flex shrink-0 gap-2 p-3">
                         <SlideoverClose asChild>
-                            <Button className="e-w-full" size="sm" variant="outline">
+                            <Button className="w-full" size="sm" variant="outline">
                                 Close
                             </Button>
                         </SlideoverClose>

--- a/app/components/shared/ui/slideover.tsx
+++ b/app/components/shared/ui/slideover.tsx
@@ -15,7 +15,7 @@ const SlideoverOverlay = React.forwardRef<
     <Overlay
         ref={ref}
         className={cn(
-            'fixed inset-0 z-50 bg-black/60',
+            'fixed inset-0 z-[1201] bg-black/60',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',
             'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
             'duration-300',
@@ -35,7 +35,7 @@ const SlideoverContent = React.forwardRef<
         <Content
             ref={ref}
             className={cn(
-                'fixed inset-x-0 bottom-0 z-50',
+                'fixed inset-x-0 bottom-0 z-[1201]',
                 'flex max-h-[85dvh] flex-col',
                 'rounded-t-2xl bg-outer-space-950',
                 'shadow-[0_-4px_32px_rgba(0,0,0,0.6)]',

--- a/app/components/shared/ui/slideover.tsx
+++ b/app/components/shared/ui/slideover.tsx
@@ -65,7 +65,7 @@ function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEl
 }
 
 function SlideoverTitle({ className, ...props }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
-    return <DialogPrimitive.Title className={cn('e-text-md e-font-medium e-text-white', className)} {...props} />;
+    return <DialogPrimitive.Title className={cn('e-text-base e-font-medium e-text-white', className)} {...props} />;
 }
 
 function SlideoverBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/app/components/shared/ui/slideover.tsx
+++ b/app/components/shared/ui/slideover.tsx
@@ -1,0 +1,83 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import * as React from 'react';
+
+import { cn } from '@/app/components/shared/utils';
+
+const Slideover = DialogPrimitive.Root;
+const SlideoverTrigger = DialogPrimitive.Trigger;
+const SlideoverClose = DialogPrimitive.Close;
+const SlideoverPortal = DialogPrimitive.Portal;
+
+const SlideoverOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+            'e-fixed e-inset-0 e-z-50 e-bg-black/60',
+            'data-[state=open]:e-animate-in data-[state=closed]:e-animate-out',
+            'data-[state=closed]:e-fade-out-0 data-[state=open]:e-fade-in-0',
+            'e-duration-300',
+            className,
+        )}
+        {...props}
+    />
+));
+SlideoverOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const SlideoverContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <SlideoverPortal>
+        <SlideoverOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'e-fixed e-inset-x-0 e-bottom-0 e-z-50',
+                'e-flex e-max-h-[85dvh] e-flex-col',
+                'e-rounded-t-2xl e-bg-outer-space-950',
+                'e-shadow-[0_-4px_32px_rgba(0,0,0,0.6)]',
+                'data-[state=open]:e-animate-in data-[state=closed]:e-animate-out',
+                'data-[state=closed]:e-slide-out-to-bottom data-[state=open]:e-slide-in-from-bottom',
+                'e-duration-300 e-ease-in-out',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </DialogPrimitive.Content>
+    </SlideoverPortal>
+));
+SlideoverContent.displayName = DialogPrimitive.Content.displayName;
+
+function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn(
+                'e-flex e-shrink-0 e-items-center e-justify-between e-border-b e-border-solid e-border-white/10 e-px-4 e-py-3',
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function SlideoverTitle({ className, ...props }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+    return <DialogPrimitive.Title className={cn('e-text-md e-font-medium e-text-white', className)} {...props} />;
+}
+
+function SlideoverBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return <div className={cn('e-flex-1 e-overflow-y-auto e-overflow-x-hidden', className)} {...props} />;
+}
+
+export {
+    Slideover,
+    SlideoverBody,
+    SlideoverClose,
+    SlideoverContent,
+    SlideoverHeader,
+    SlideoverTitle,
+    SlideoverTrigger,
+};

--- a/app/components/shared/ui/slideover.tsx
+++ b/app/components/shared/ui/slideover.tsx
@@ -15,10 +15,10 @@ const SlideoverOverlay = React.forwardRef<
     <Overlay
         ref={ref}
         className={cn(
-            'e-fixed e-inset-0 e-z-50 e-bg-black/60',
-            'data-[state=open]:e-animate-in data-[state=closed]:e-animate-out',
-            'data-[state=closed]:e-fade-out-0 data-[state=open]:e-fade-in-0',
-            'e-duration-300',
+            'fixed inset-0 z-50 bg-black/60',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'duration-300',
             className,
         )}
         {...props}
@@ -35,13 +35,13 @@ const SlideoverContent = React.forwardRef<
         <Content
             ref={ref}
             className={cn(
-                'e-fixed e-inset-x-0 e-bottom-0 e-z-50',
-                'e-flex e-max-h-[85dvh] e-flex-col',
-                'e-rounded-t-2xl e-bg-outer-space-950',
-                'e-shadow-[0_-4px_32px_rgba(0,0,0,0.6)]',
-                'data-[state=open]:e-animate-in data-[state=closed]:e-animate-out',
-                'data-[state=closed]:e-slide-out-to-bottom data-[state=open]:e-slide-in-from-bottom',
-                'e-duration-300 e-ease-in-out',
+                'fixed inset-x-0 bottom-0 z-50',
+                'flex max-h-[85dvh] flex-col',
+                'rounded-t-2xl bg-outer-space-950',
+                'shadow-[0_-4px_32px_rgba(0,0,0,0.6)]',
+                'data-[state=open]:animate-in data-[state=closed]:animate-out',
+                'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+                'duration-300 ease-in-out',
                 className,
             )}
             {...props}
@@ -56,7 +56,7 @@ function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEl
     return (
         <div
             className={cn(
-                'e-flex e-shrink-0 e-items-center e-justify-between e-border-b e-border-solid e-border-white/10 e-px-4 e-py-3',
+                'flex shrink-0 items-center justify-between border-b border-solid border-white/10 px-4 py-3',
                 className,
             )}
             {...props}
@@ -65,11 +65,11 @@ function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEl
 }
 
 function SlideoverTitle({ className, ...props }: React.ComponentPropsWithoutRef<typeof Title>) {
-    return <Title className={cn('e-text-base e-font-medium e-text-white', className)} {...props} />;
+    return <Title className={cn('text-base font-medium text-white', className)} {...props} />;
 }
 
 function SlideoverBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-    return <div className={cn('e-flex-1 e-overflow-y-auto e-overflow-x-hidden', className)} {...props} />;
+    return <div className={cn('flex-1 overflow-y-auto overflow-x-hidden', className)} {...props} />;
 }
 
 export {

--- a/app/components/shared/ui/slideover.tsx
+++ b/app/components/shared/ui/slideover.tsx
@@ -1,18 +1,18 @@
-import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { Close, Content, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
 import * as React from 'react';
 
 import { cn } from '@/app/components/shared/utils';
 
-const Slideover = DialogPrimitive.Root;
-const SlideoverTrigger = DialogPrimitive.Trigger;
-const SlideoverClose = DialogPrimitive.Close;
-const SlideoverPortal = DialogPrimitive.Portal;
+const Slideover = Root;
+const SlideoverTrigger = Trigger;
+const SlideoverClose = Close;
+const SlideoverPortal = Portal;
 
 const SlideoverOverlay = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Overlay>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+    React.ElementRef<typeof Overlay>,
+    React.ComponentPropsWithoutRef<typeof Overlay>
 >(({ className, ...props }, ref) => (
-    <DialogPrimitive.Overlay
+    <Overlay
         ref={ref}
         className={cn(
             'e-fixed e-inset-0 e-z-50 e-bg-black/60',
@@ -24,15 +24,15 @@ const SlideoverOverlay = React.forwardRef<
         {...props}
     />
 ));
-SlideoverOverlay.displayName = DialogPrimitive.Overlay.displayName;
+SlideoverOverlay.displayName = Overlay.displayName;
 
 const SlideoverContent = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+    React.ElementRef<typeof Content>,
+    React.ComponentPropsWithoutRef<typeof Content>
 >(({ className, children, ...props }, ref) => (
     <SlideoverPortal>
         <SlideoverOverlay />
-        <DialogPrimitive.Content
+        <Content
             ref={ref}
             className={cn(
                 'e-fixed e-inset-x-0 e-bottom-0 e-z-50',
@@ -47,10 +47,10 @@ const SlideoverContent = React.forwardRef<
             {...props}
         >
             {children}
-        </DialogPrimitive.Content>
+        </Content>
     </SlideoverPortal>
 ));
-SlideoverContent.displayName = DialogPrimitive.Content.displayName;
+SlideoverContent.displayName = Content.displayName;
 
 function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
     return (
@@ -64,8 +64,8 @@ function SlideoverHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEl
     );
 }
 
-function SlideoverTitle({ className, ...props }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
-    return <DialogPrimitive.Title className={cn('e-text-base e-font-medium e-text-white', className)} {...props} />;
+function SlideoverTitle({ className, ...props }: React.ComponentPropsWithoutRef<typeof Title>) {
+    return <Title className={cn('e-text-base e-font-medium e-text-white', className)} {...props} />;
 }
 
 function SlideoverBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/app/components/shared/ui/tooltip.tsx
+++ b/app/components/shared/ui/tooltip.tsx
@@ -36,7 +36,7 @@ function TooltipContent({
                 data-slot="tooltip-content"
                 sideOffset={sideOffset}
                 className={cn(
-                    'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md bg-neutral-900 px-3 py-1.5 text-xs text-neutral-50',
+                    'origin-(--radix-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md bg-neutral-900 px-3 py-1.5 text-xs text-neutral-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
                     className,
                 )}
                 {...props}

--- a/app/entities/account/index.ts
+++ b/app/entities/account/index.ts
@@ -1,6 +1,7 @@
 export { toBigNumber } from './lib/toBigNumber';
 export { selectMintDecimals, selectTokenAccountMint } from './model/selectors';
 export { useAccountQuery } from './model/use-account-query';
+export { useAccountExpandedInfo } from './model/use-account-expanded-info';
 export { useAccountsInfo } from './model/use-accounts-info';
 export type { AccountInfo } from './model/use-accounts-info';
 export { useRawAccountData, useRawAccountDataOnMount } from './model/use-raw-account-data';

--- a/app/entities/account/model/__tests__/use-account-expanded-info.spec.ts
+++ b/app/entities/account/model/__tests__/use-account-expanded-info.spec.ts
@@ -1,0 +1,119 @@
+import { Account, FetchersContext, StateContext } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import { NATIVE_MINT } from '@solana/spl-token';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MAINNET_BETA_URL } from '@/app/utils/cluster';
+
+import { useAccountExpandedInfo } from '../use-account-expanded-info';
+
+const TEST_ADDRESS = NATIVE_MINT.toBase58();
+
+function makeAccount(pubkey: string): Account {
+    return {
+        data: {},
+        executable: false,
+        lamports: 1_000_000,
+        owner: SystemProgram.programId,
+        pubkey: new PublicKey(pubkey),
+    };
+}
+
+function createWrapper(entries: Record<string, { status: FetchStatus; data?: Account }> = {}) {
+    const parsedFetch = vi.fn();
+    const state = { entries, url: MAINNET_BETA_URL };
+    const fetchers = {
+        parsed: { fetch: parsedFetch },
+        raw: { fetch: vi.fn() },
+        skip: { fetch: vi.fn() },
+    };
+    return {
+        parsedFetch,
+        wrapper: ({ children }: { children: React.ReactNode }) =>
+            React.createElement(
+                StateContext.Provider,
+                { value: state },
+                React.createElement(FetchersContext.Provider, { value: fetchers as any }, children),
+            ),
+    };
+}
+
+describe('useAccountExpandedInfo', () => {
+    it('should return disabled state when enabled is false', () => {
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, false), { wrapper });
+
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('should not trigger a fetch when enabled is false', () => {
+        const { wrapper, parsedFetch } = createWrapper();
+        renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, false), { wrapper });
+
+        expect(parsedFetch).not.toHaveBeenCalled();
+    });
+
+    it('should trigger a parsed fetch when enabled and no cache entry exists', () => {
+        const { wrapper, parsedFetch } = createWrapper();
+        renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(parsedFetch).toHaveBeenCalledOnce();
+        expect(parsedFetch.mock.calls[0][0].toBase58()).toBe(TEST_ADDRESS);
+    });
+
+    it('should return isLoading true when enabled and no cache entry exists', () => {
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('should return the full Account object when cache entry is fetched', () => {
+        const account = makeAccount(TEST_ADDRESS);
+        const { wrapper } = createWrapper({
+            [TEST_ADDRESS]: { data: account, status: FetchStatus.Fetched },
+        });
+        const { result } = renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(result.current.data).toBe(account);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('should return isLoading true when cache entry is in Fetching status', () => {
+        const { wrapper } = createWrapper({
+            [TEST_ADDRESS]: { status: FetchStatus.Fetching },
+        });
+        const { result } = renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('should return isError true when fetch failed', () => {
+        const { wrapper } = createWrapper({
+            [TEST_ADDRESS]: { status: FetchStatus.FetchFailed },
+        });
+        const { result } = renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(result.current.isError).toBe(true);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('should not re-fetch when cache entry already exists', () => {
+        const account = makeAccount(TEST_ADDRESS);
+        const { wrapper, parsedFetch } = createWrapper({
+            [TEST_ADDRESS]: { data: account, status: FetchStatus.Fetched },
+        });
+        renderHook(() => useAccountExpandedInfo(TEST_ADDRESS, true), { wrapper });
+
+        expect(parsedFetch).not.toHaveBeenCalled();
+    });
+});

--- a/app/entities/account/model/use-account-expanded-info.ts
+++ b/app/entities/account/model/use-account-expanded-info.ts
@@ -1,0 +1,11 @@
+import { Account } from '@providers/accounts';
+
+import { useAccountQuery } from './use-account-query';
+
+export function useAccountExpandedInfo(address: string, enabled: boolean) {
+    const key = enabled ? ([address] as const) : undefined;
+    return useAccountQuery<Account>(key, {
+        dataMode: 'parsed',
+        select: account => account,
+    });
+}

--- a/app/entities/account/model/use-account-expanded-info.ts
+++ b/app/entities/account/model/use-account-expanded-info.ts
@@ -6,6 +6,5 @@ export function useAccountExpandedInfo(address: string, enabled: boolean) {
     const key = enabled ? ([address] as const) : undefined;
     return useAccountQuery<Account>(key, {
         dataMode: 'parsed',
-        select: account => account,
     });
 }

--- a/app/entities/account/model/use-account-query.ts
+++ b/app/entities/account/model/use-account-query.ts
@@ -7,7 +7,7 @@ import { PublicKey } from '@solana/web3.js';
 import { useContext, useEffect, useMemo } from 'react';
 
 type UseAccountQueryOptions<TData> = {
-    select: (account: Account) => TData | undefined;
+    select?: (account: Account) => TData | undefined;
     dataMode?: FetchAccountDataMode;
 };
 
@@ -44,7 +44,7 @@ export function useAccountQuery<TData>(
 
     const data = useMemo(() => {
         if (!cacheEntry?.data) return undefined;
-        return select(cacheEntry.data);
+        return select ? select(cacheEntry.data) : (cacheEntry.data as TData);
     }, [cacheEntry?.data, select]);
 
     if (!key) {

--- a/app/features/nicknames/ui/NicknameEditor.tsx
+++ b/app/features/nicknames/ui/NicknameEditor.tsx
@@ -44,6 +44,7 @@ export function NicknameEditor({ address, onClose }: Props) {
     // Support Enter to save, Escape to cancel
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === 'Enter') {
+            if (!nickname.trim()) return;
             handleSave();
         } else if (e.key === 'Escape') {
             onClose();

--- a/app/features/nicknames/ui/NicknameEditor.tsx
+++ b/app/features/nicknames/ui/NicknameEditor.tsx
@@ -60,7 +60,7 @@ export function NicknameEditor({ address, onClose }: Props) {
 
     return (
         <div
-            className="fixed left-0 top-0 flex h-full w-full items-center justify-center"
+            className="fixed left-0 top-0 flex h-full w-full max-w-[100vw] items-center justify-center"
             style={{
                 backgroundColor: 'rgba(0, 0, 0, 0.5)',
                 zIndex: 9999,

--- a/app/features/transaction/ui/AccountBadges.tsx
+++ b/app/features/transaction/ui/AccountBadges.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@components/shared/ui/badge';
 import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
 
 type Props = {
@@ -10,13 +11,31 @@ type Props = {
 export function AccountBadges({ account, index, pubkey, message }: Props) {
     return (
         <>
-            {index === 0 && <span className="badge bg-success-soft me-1">Fee Payer</span>}
-            {account.signer && <span className="badge bg-info-soft me-1">Signer</span>}
-            {account.writable && <span className="badge bg-danger-soft me-1">Writable</span>}
-            {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
-                <span className="badge bg-warning-soft me-1">Program</span>
+            {index === 0 && (
+                <Badge ui="dashkit" variant="success" className="me-1">
+                    Fee Payer
+                </Badge>
             )}
-            {account.source === 'lookupTable' && <span className="badge bg-gray-soft me-1">Address Table Lookup</span>}
+            {account.signer && (
+                <Badge ui="dashkit" variant="info" className="me-1">
+                    Signer
+                </Badge>
+            )}
+            {account.writable && (
+                <Badge ui="dashkit" variant="danger" className="me-1">
+                    Writable
+                </Badge>
+            )}
+            {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
+                <Badge ui="dashkit" variant="warning" className="me-1">
+                    Program
+                </Badge>
+            )}
+            {account.source === 'lookupTable' && (
+                <Badge ui="dashkit" variant="gray" className="me-1">
+                    Address Table Lookup
+                </Badge>
+            )}
         </>
     );
 }

--- a/app/features/transaction/ui/AccountBadges.tsx
+++ b/app/features/transaction/ui/AccountBadges.tsx
@@ -1,0 +1,22 @@
+import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
+
+type Props = {
+    account: ParsedMessageAccount;
+    index: number;
+    pubkey: PublicKey;
+    message: ParsedMessage;
+};
+
+export function AccountBadges({ account, index, pubkey, message }: Props) {
+    return (
+        <>
+            {index === 0 && <span className="badge bg-success-soft me-1">Fee Payer</span>}
+            {account.signer && <span className="badge bg-info-soft me-1">Signer</span>}
+            {account.writable && <span className="badge bg-danger-soft me-1">Writable</span>}
+            {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
+                <span className="badge bg-warning-soft me-1">Program</span>
+            )}
+            {account.source === 'lookupTable' && <span className="badge bg-gray-soft me-1">Address Table Lookup</span>}
+        </>
+    );
+}

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -46,7 +46,13 @@ export function AccountDetailSlideover({
     const addressPath = useClusterPath({ pathname: `/address/${address}` });
 
     return (
-        <Slideover open={open} onOpenChange={onOpenChange}>
+        <Slideover
+            open={open}
+            onOpenChange={v => {
+                if (!v) setNicknameOpen(false);
+                onOpenChange(v);
+            }}
+        >
             <SlideoverContent aria-describedby={undefined}>
                 <div className="space-y-2 px-4 pb-3 pt-4">
                     <div className="min-w-0 flex-1">

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import type { AccountInfo } from '@entities/account';
+import { Button } from '@shared/ui/button';
+import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
+import { useClusterPath } from '@utils/url';
+import Link from 'next/link';
+import React, { useState } from 'react';
+import { CheckCircle, Copy, ExternalLink, Tag, X } from 'react-feather';
+
+import {
+    Slideover,
+    SlideoverBody,
+    SlideoverClose,
+    SlideoverContent,
+    SlideoverTitle,
+} from '@/app/components/shared/ui/slideover';
+import { NicknameEditor, useNickname } from '@/app/features/nicknames';
+import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
+
+import { AccountBadges } from './AccountBadges';
+import { AccountExpandedContent } from './AccountExpandedContent';
+
+type Props = {
+    account: ParsedMessageAccount;
+    accountInfo?: AccountInfo;
+    accountInfoLoading: boolean;
+    index: number;
+    message: ParsedMessage;
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+};
+
+export function AccountDetailSlideover({
+    account,
+    accountInfo,
+    accountInfoLoading,
+    index,
+    message,
+    onOpenChange,
+    open,
+}: Props) {
+    const pubkey = account.pubkey;
+    const address = pubkey.toBase58();
+    const nickname = useNickname(address);
+    const [nicknameOpen, setNicknameOpen] = useState(false);
+    const [copyState, copy] = useCopyToClipboard(1500);
+    const addressPath = useClusterPath({ pathname: `/address/${address}` });
+
+    return (
+        <>
+            <Slideover open={open} onOpenChange={onOpenChange}>
+                <SlideoverContent aria-describedby={undefined}>
+                    <div className="e-space-y-2 e-px-4 e-pb-3 e-pt-4">
+                        <div className="e-min-w-0 e-flex-1">
+                            <SlideoverTitle className="e-mb-1.5 e-tracking-wide !e-text-outer-space-300">
+                                Account {index + 1}
+                            </SlideoverTitle>
+                            <div className="e-break-all e-font-mono e-text-xl e-leading-snug e-text-white">
+                                {nickname ?? address}
+                            </div>
+                        </div>
+                        <div className="e-flex">
+                            <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />
+                        </div>
+                    </div>
+
+                    {/* Scrollable body */}
+                    <SlideoverBody className="e-border-t e-border-white/10 e-pt-2 [border-top-style:solid]">
+                        <AccountExpandedContent
+                            accountInfo={accountInfo}
+                            accountInfoLoading={accountInfoLoading}
+                            address={address}
+                            enabled={open}
+                            flat
+                        />
+                    </SlideoverBody>
+
+                    {/* Footer action bar */}
+                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3">
+                        <Button
+                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            onClick={() => setNicknameOpen(true)}
+                            size="sm"
+                            variant="outline"
+                        >
+                            <Tag size={13} />
+                            Nickname
+                        </Button>
+                        <Button
+                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            onClick={() => copy(address)}
+                            size="sm"
+                            variant="outline"
+                        >
+                            {copyState === 'copied' ? <CheckCircle size={13} /> : <Copy size={13} />}
+                            Copy
+                        </Button>
+                        <Button
+                            asChild
+                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            size="sm"
+                            variant="accent"
+                        >
+                            <Link href={addressPath} target="_blank">
+                                <ExternalLink size={13} />
+                                Open
+                            </Link>
+                        </Button>
+                        <SlideoverClose asChild>
+                            <Button className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
+                                <X size={13} />
+                                Close
+                            </Button>
+                        </SlideoverClose>
+                    </div>
+                    {nicknameOpen && <NicknameEditor address={address} onClose={() => setNicknameOpen(false)} />}
+                </SlideoverContent>
+            </Slideover>
+        </>
+    );
+}

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -1,5 +1,5 @@
+import { Button } from '@components/shared/ui/button';
 import type { AccountInfo } from '@entities/account';
-import { Button } from '@shared/ui/button';
 import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
@@ -48,23 +48,21 @@ export function AccountDetailSlideover({
     return (
         <Slideover open={open} onOpenChange={onOpenChange}>
             <SlideoverContent aria-describedby={undefined}>
-                <div className="e-space-y-2 e-px-4 e-pb-3 e-pt-4">
-                    <div className="e-min-w-0 e-flex-1">
-                        <SlideoverTitle className="e-mb-1.5 e-tracking-wide !e-text-outer-space-300">
+                <div className="space-y-2 px-4 pb-3 pt-4">
+                    <div className="min-w-0 flex-1">
+                        <SlideoverTitle className="mb-1.5 tracking-wide !text-outer-space-300">
                             Account {index + 1}
                         </SlideoverTitle>
-                        <div className="e-break-all e-font-mono e-text-xl e-leading-snug e-text-white">
-                            {nickname ?? address}
-                        </div>
-                        {nickname && <span className="e-break-all e-text-sm e-text-outer-space-300">{address}</span>}
+                        <div className="break-all font-mono text-xl leading-snug text-white">{nickname ?? address}</div>
+                        {nickname && <span className="break-all text-sm text-outer-space-300">{address}</span>}
                     </div>
-                    <div className="e-flex">
+                    <div className="flex">
                         <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />
                     </div>
                 </div>
 
                 {/* Scrollable body */}
-                <SlideoverBody className="e-border-t e-border-white/10 e-pt-2 [border-top-style:solid]">
+                <SlideoverBody className="border-t border-white/10 pt-2 [border-top-style:solid]">
                     <AccountExpandedContent
                         accountInfo={accountInfo}
                         accountInfoLoading={accountInfoLoading}
@@ -75,9 +73,9 @@ export function AccountDetailSlideover({
                 </SlideoverBody>
 
                 {/* Footer action bar */}
-                <div className="e-flex e-shrink-0 e-gap-2 e-p-3 e-pb-6">
+                <div className="flex shrink-0 gap-2 p-3 pb-6">
                     <Button
-                        className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                        className="flex !h-16 w-1/4 flex-col gap-1.5"
                         onClick={() => setNicknameOpen(true)}
                         size="sm"
                         variant="outline"
@@ -86,7 +84,7 @@ export function AccountDetailSlideover({
                         Nickname
                     </Button>
                     <Button
-                        className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                        className="flex !h-16 w-1/4 flex-col gap-1.5"
                         onClick={() => copy(address)}
                         size="sm"
                         variant="outline"
@@ -94,14 +92,14 @@ export function AccountDetailSlideover({
                         {copyState === 'copied' ? <CheckCircle size={13} /> : <Copy size={13} />}
                         Copy
                     </Button>
-                    <Button asChild className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="accent">
+                    <Button asChild className="flex !h-16 w-1/4 flex-col gap-1.5" size="sm" variant="accent">
                         <Link href={addressPath} target="_blank">
                             <ExternalLink size={13} />
                             Open
                         </Link>
                     </Button>
                     <SlideoverClose asChild>
-                        <Button className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
+                        <Button className="flex !h-16 w-1/4 flex-col gap-1.5" size="sm" variant="outline">
                             <X size={13} />
                             Close
                         </Button>

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AccountInfo } from '@entities/account';
 import { Button } from '@shared/ui/button';
 import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -79,7 +79,7 @@ export function AccountDetailSlideover({
                     {/* Footer action bar */}
                     <div className="e-flex e-shrink-0 e-gap-2 e-p-3">
                         <Button
-                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
                             onClick={() => setNicknameOpen(true)}
                             size="sm"
                             variant="outline"
@@ -88,7 +88,7 @@ export function AccountDetailSlideover({
                             Nickname
                         </Button>
                         <Button
-                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
                             onClick={() => copy(address)}
                             size="sm"
                             variant="outline"
@@ -98,7 +98,7 @@ export function AccountDetailSlideover({
                         </Button>
                         <Button
                             asChild
-                            className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
                             size="sm"
                             variant="accent"
                         >
@@ -108,7 +108,7 @@ export function AccountDetailSlideover({
                             </Link>
                         </Button>
                         <SlideoverClose asChild>
-                            <Button className="e-flex e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
+                            <Button className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
                                 <X size={13} />
                                 Close
                             </Button>

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -44,16 +44,21 @@ export function AccountDetailSlideover({
     const [nicknameOpen, setNicknameOpen] = useState(false);
     const [copyState, copy] = useCopyToClipboard(1500);
     const addressPath = useClusterPath({ pathname: `/address/${address}` });
+    const handleOpenChange = (nextOpen: boolean) => {
+        if (!nextOpen) setNicknameOpen(false);
+        onOpenChange(nextOpen);
+    };
+    const handleEscapeKeyDown = (event: KeyboardEvent) => {
+        if (!nicknameOpen) return;
+
+        // NicknameEditor uses Escape to cancel editing. Prevent Radix from also
+        // dismissing the parent slideover from its capture-phase document listener.
+        event.preventDefault();
+    };
 
     return (
-        <Slideover
-            open={open}
-            onOpenChange={v => {
-                if (!v) setNicknameOpen(false);
-                onOpenChange(v);
-            }}
-        >
-            <SlideoverContent aria-describedby={undefined}>
+        <Slideover open={open} onOpenChange={handleOpenChange}>
+            <SlideoverContent aria-describedby={undefined} onEscapeKeyDown={handleEscapeKeyDown}>
                 <div className="space-y-2 px-4 pb-3 pt-4">
                     <div className="min-w-0 flex-1">
                         <SlideoverTitle className="mb-1.5 tracking-wide !text-outer-space-300">

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -77,7 +77,7 @@ export function AccountDetailSlideover({
                     </SlideoverBody>
 
                     {/* Footer action bar */}
-                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3">
+                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3 e-pb-6">
                         <Button
                             className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
                             onClick={() => setNicknameOpen(true)}

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -58,6 +58,7 @@ export function AccountDetailSlideover({
                         <div className="e-break-all e-font-mono e-text-xl e-leading-snug e-text-white">
                             {nickname ?? address}
                         </div>
+                        {nickname && <span className="e-break-all e-text-sm e-text-outer-space-300">{address}</span>}
                     </div>
                     <div className="e-flex">
                         <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />

--- a/app/features/transaction/ui/AccountDetailSlideover.tsx
+++ b/app/features/transaction/ui/AccountDetailSlideover.tsx
@@ -48,75 +48,68 @@ export function AccountDetailSlideover({
     const addressPath = useClusterPath({ pathname: `/address/${address}` });
 
     return (
-        <>
-            <Slideover open={open} onOpenChange={onOpenChange}>
-                <SlideoverContent aria-describedby={undefined}>
-                    <div className="e-space-y-2 e-px-4 e-pb-3 e-pt-4">
-                        <div className="e-min-w-0 e-flex-1">
-                            <SlideoverTitle className="e-mb-1.5 e-tracking-wide !e-text-outer-space-300">
-                                Account {index + 1}
-                            </SlideoverTitle>
-                            <div className="e-break-all e-font-mono e-text-xl e-leading-snug e-text-white">
-                                {nickname ?? address}
-                            </div>
-                        </div>
-                        <div className="e-flex">
-                            <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />
+        <Slideover open={open} onOpenChange={onOpenChange}>
+            <SlideoverContent aria-describedby={undefined}>
+                <div className="e-space-y-2 e-px-4 e-pb-3 e-pt-4">
+                    <div className="e-min-w-0 e-flex-1">
+                        <SlideoverTitle className="e-mb-1.5 e-tracking-wide !e-text-outer-space-300">
+                            Account {index + 1}
+                        </SlideoverTitle>
+                        <div className="e-break-all e-font-mono e-text-xl e-leading-snug e-text-white">
+                            {nickname ?? address}
                         </div>
                     </div>
-
-                    {/* Scrollable body */}
-                    <SlideoverBody className="e-border-t e-border-white/10 e-pt-2 [border-top-style:solid]">
-                        <AccountExpandedContent
-                            accountInfo={accountInfo}
-                            accountInfoLoading={accountInfoLoading}
-                            address={address}
-                            enabled={open}
-                            flat
-                        />
-                    </SlideoverBody>
-
-                    {/* Footer action bar */}
-                    <div className="e-flex e-shrink-0 e-gap-2 e-p-3 e-pb-6">
-                        <Button
-                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
-                            onClick={() => setNicknameOpen(true)}
-                            size="sm"
-                            variant="outline"
-                        >
-                            <Tag size={13} />
-                            Nickname
-                        </Button>
-                        <Button
-                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
-                            onClick={() => copy(address)}
-                            size="sm"
-                            variant="outline"
-                        >
-                            {copyState === 'copied' ? <CheckCircle size={13} /> : <Copy size={13} />}
-                            Copy
-                        </Button>
-                        <Button
-                            asChild
-                            className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
-                            size="sm"
-                            variant="accent"
-                        >
-                            <Link href={addressPath} target="_blank">
-                                <ExternalLink size={13} />
-                                Open
-                            </Link>
-                        </Button>
-                        <SlideoverClose asChild>
-                            <Button className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
-                                <X size={13} />
-                                Close
-                            </Button>
-                        </SlideoverClose>
+                    <div className="e-flex">
+                        <AccountBadges index={index} account={account} message={message} pubkey={pubkey} />
                     </div>
-                    {nicknameOpen && <NicknameEditor address={address} onClose={() => setNicknameOpen(false)} />}
-                </SlideoverContent>
-            </Slideover>
-        </>
+                </div>
+
+                {/* Scrollable body */}
+                <SlideoverBody className="e-border-t e-border-white/10 e-pt-2 [border-top-style:solid]">
+                    <AccountExpandedContent
+                        accountInfo={accountInfo}
+                        accountInfoLoading={accountInfoLoading}
+                        address={address}
+                        enabled={open}
+                        flat
+                    />
+                </SlideoverBody>
+
+                {/* Footer action bar */}
+                <div className="e-flex e-shrink-0 e-gap-2 e-p-3 e-pb-6">
+                    <Button
+                        className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                        onClick={() => setNicknameOpen(true)}
+                        size="sm"
+                        variant="outline"
+                    >
+                        <Tag size={13} />
+                        Nickname
+                    </Button>
+                    <Button
+                        className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5"
+                        onClick={() => copy(address)}
+                        size="sm"
+                        variant="outline"
+                    >
+                        {copyState === 'copied' ? <CheckCircle size={13} /> : <Copy size={13} />}
+                        Copy
+                    </Button>
+                    <Button asChild className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="accent">
+                        <Link href={addressPath} target="_blank">
+                            <ExternalLink size={13} />
+                            Open
+                        </Link>
+                    </Button>
+                    <SlideoverClose asChild>
+                        <Button className="e-flex !e-h-16 e-w-1/4 e-flex-col e-gap-1.5" size="sm" variant="outline">
+                            <X size={13} />
+                            Close
+                        </Button>
+                    </SlideoverClose>
+                </div>
+                {nicknameOpen && <NicknameEditor address={address} onClose={() => setNicknameOpen(false)} />}
+            </SlideoverContent>
+        </Slideover>
     );
 }

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { Address } from '@components/common/Address';
+import { SolBalance } from '@components/common/SolBalance';
+import { cn } from '@components/shared/utils';
+import { AccountInfo, useAccountExpandedInfo } from '@entities/account';
+import {
+    isTokenProgramData,
+    isUpgradeableLoaderAccountData,
+    ParsedData,
+    StakeProgramData,
+    UpgradeableLoaderAccountData,
+} from '@providers/accounts';
+
+type StakeAccount = StakeProgramData['parsed'];
+import { RawDataField } from '@shared/RawDataField';
+import { Button } from '@shared/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@shared/ui/popover';
+import { PublicKey } from '@solana/web3.js';
+import { ParsedAddressLookupTableAccount } from '@validators/accounts/address-lookup-table';
+import { NonceAccount } from '@validators/accounts/nonce';
+import { MintAccountInfo, MultisigAccountInfo, TokenAccountInfo } from '@validators/accounts/token';
+import { ProgramAccountInfo } from '@validators/accounts/upgradeable-program';
+import { VoteAccount } from '@validators/accounts/vote';
+import { capitalCase } from 'change-case';
+import React from 'react';
+import { Code, Info } from 'react-feather';
+
+// ── Layout primitives ─────────────────────────────────────────────────────────
+
+type DetailRowProps = {
+    children: React.ReactNode;
+    className?: string;
+    label: string;
+};
+
+function DetailRow({ children, className, label }: DetailRowProps) {
+    return (
+        <div
+            className={cn(
+                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5 e-pr-3 md:e-pr-4',
+                className,
+            )}
+        >
+            <div className="e-text-sm e-text-outer-space-300">{label}</div>
+            <div className="e-text-sm">{children}</div>
+        </div>
+    );
+}
+
+function AddressRow({ label, value }: { label: string; value: PublicKey | string | undefined }) {
+    if (!value) return undefined;
+    const pubkey = typeof value === 'string' ? new PublicKey(value) : value;
+    return (
+        <DetailRow label={label}>
+            <Address pubkey={pubkey} link />
+        </DetailRow>
+    );
+}
+
+// ── Type-specific sections ────────────────────────────────────────────────────
+
+function TokenAccountSection({ info }: { info: TokenAccountInfo }) {
+    return (
+        <>
+            <AddressRow label="Mint" value={info.mint} />
+            <AddressRow label="Owner" value={info.owner} />
+            <DetailRow label="Token Balance">{info.tokenAmount.uiAmountString}</DetailRow>
+            <DetailRow label="Status">
+                <span
+                    className={cn(
+                        info.state === 'frozen' && 'e-text-warning',
+                        info.state === 'initialized' && 'e-text-success',
+                    )}
+                >
+                    {capitalCase(info.state)}
+                </span>
+            </DetailRow>
+            {info.isNative && <DetailRow label="Native Wrapped SOL">Yes</DetailRow>}
+            {info.rentExemptReserve && (
+                <DetailRow label="Rent-Exempt Reserve">{info.rentExemptReserve.uiAmountString}</DetailRow>
+            )}
+            <AddressRow label="Delegate" value={info.delegate} />
+            {info.delegatedAmount && (
+                <DetailRow label="Delegated Amount">{info.delegatedAmount.uiAmountString}</DetailRow>
+            )}
+            <AddressRow label="Close Authority" value={info.closeAuthority} />
+        </>
+    );
+}
+
+function MintAccountSection({ info }: { info: MintAccountInfo }) {
+    return (
+        <>
+            <DetailRow label="Supply">{info.supply}</DetailRow>
+            <DetailRow label="Decimals">{info.decimals}</DetailRow>
+            {info.mintAuthority !== null ? (
+                <AddressRow label="Mint Authority" value={info.mintAuthority} />
+            ) : (
+                <DetailRow label="Mint Authority">Fixed supply</DetailRow>
+            )}
+            {info.freezeAuthority !== null ? (
+                <AddressRow label="Freeze Authority" value={info.freezeAuthority} />
+            ) : (
+                <DetailRow label="Freeze Authority">None</DetailRow>
+            )}
+            {!info.isInitialized && <DetailRow label="Status">Uninitialized</DetailRow>}
+        </>
+    );
+}
+
+function MultisigAccountSection({ info }: { info: MultisigAccountInfo }) {
+    return (
+        <>
+            <DetailRow label="Required Signers">{info.numRequiredSigners}</DetailRow>
+            <DetailRow label="Valid Signers">{info.numValidSigners}</DetailRow>
+            {info.signers.map((signer, i) => (
+                <AddressRow key={signer.toBase58()} label={`Signer ${i + 1}`} value={signer} />
+            ))}
+        </>
+    );
+}
+
+function UpgradeableLoaderSection({ data }: { data: UpgradeableLoaderAccountData }) {
+    const account = data.parsed;
+    if (account.type === 'program') {
+        const programAccount = account.info as unknown as ProgramAccountInfo;
+        return (
+            <>
+                <AddressRow label="Program Data" value={programAccount.programData} />
+                {data.programData && (
+                    <>
+                        {data.programData.authority !== null ? (
+                            <AddressRow label="Upgrade Authority" value={data.programData.authority} />
+                        ) : (
+                            <DetailRow label="Upgrade Authority">Immutable</DetailRow>
+                        )}
+                        {data.programData.slot > 0 && (
+                            <DetailRow label="Last Deploy Slot">
+                                {data.programData.slot.toLocaleString('en-US')}
+                            </DetailRow>
+                        )}
+                    </>
+                )}
+            </>
+        );
+    }
+    if (account.type === 'programData') {
+        return (
+            <>
+                {account.info.authority !== null ? (
+                    <AddressRow label="Upgrade Authority" value={account.info.authority} />
+                ) : (
+                    <DetailRow label="Upgrade Authority">Immutable</DetailRow>
+                )}
+                {account.info.slot > 0 && (
+                    <DetailRow label="Last Deploy Slot">{account.info.slot.toLocaleString('en-US')}</DetailRow>
+                )}
+            </>
+        );
+    }
+    if (account.type === 'buffer') {
+        return account.info.authority !== null ? (
+            <AddressRow label="Buffer Authority" value={account.info.authority} />
+        ) : undefined;
+    }
+    return undefined;
+}
+
+function StakeAccountSection({ account }: { account: StakeAccount }) {
+    const { type, info } = account;
+    return (
+        <>
+            <DetailRow label="Stake Type">{capitalCase(type)}</DetailRow>
+            <AddressRow label="Staker Authority" value={info.meta.authorized.staker} />
+            <AddressRow label="Withdrawer Authority" value={info.meta.authorized.withdrawer} />
+            {info.stake && (
+                <>
+                    <AddressRow label="Vote Account" value={info.stake.delegation.voter} />
+                    <DetailRow label="Activation Epoch">{info.stake.delegation.activationEpoch.toString()}</DetailRow>
+                    {info.stake.delegation.deactivationEpoch.toString() !== '18446744073709551615' && (
+                        <DetailRow label="Deactivation Epoch">
+                            {info.stake.delegation.deactivationEpoch.toString()}
+                        </DetailRow>
+                    )}
+                </>
+            )}
+        </>
+    );
+}
+
+function VoteAccountSection({ account }: { account: VoteAccount }) {
+    const { info } = account;
+    return (
+        <>
+            <AddressRow label="Node Pubkey" value={info.nodePubkey} />
+            <AddressRow label="Authorized Withdrawer" value={info.authorizedWithdrawer} />
+            <DetailRow label="Commission">{info.commission}%</DetailRow>
+            {info.authorizedVoters.length > 0 && (
+                <AddressRow label="Authorized Voter" value={info.authorizedVoters[0].authorizedVoter} />
+            )}
+        </>
+    );
+}
+
+function NonceAccountSection({ account }: { account: NonceAccount }) {
+    if (account.type === 'uninitialized') {
+        return <DetailRow label="Status">Uninitialized</DetailRow>;
+    }
+    return (
+        <>
+            <AddressRow label="Nonce Authority" value={account.info.authority} />
+            <DetailRow label="Nonce">{account.info.blockhash}</DetailRow>
+            <DetailRow label="Fee (lamports/sig)">{account.info.feeCalculator.lamportsPerSignature}</DetailRow>
+        </>
+    );
+}
+
+function AddressLookupTableSection({ account }: { account: ParsedAddressLookupTableAccount }) {
+    const { info } = account;
+    return (
+        <>
+            {info.authority !== undefined ? (
+                <AddressRow label="Authority" value={info.authority} />
+            ) : (
+                <DetailRow label="Authority">Frozen</DetailRow>
+            )}
+            <DetailRow label="Last Extended Slot">{info.lastExtendedSlot.toLocaleString('en-US')}</DetailRow>
+            <DetailRow label="Addresses">{info.addresses.length} address(es)</DetailRow>
+        </>
+    );
+}
+
+function ParsedSection({ parsed }: { parsed: ParsedData }) {
+    if (isTokenProgramData(parsed)) {
+        const account = parsed.parsed;
+        if (account.type === 'account') {
+            return <TokenAccountSection info={account.info as TokenAccountInfo} />;
+        }
+        if (account.type === 'mint') {
+            return <MintAccountSection info={account.info as MintAccountInfo} />;
+        }
+        if (account.type === 'multisig') {
+            return <MultisigAccountSection info={account.info as MultisigAccountInfo} />;
+        }
+        return undefined;
+    }
+    if (isUpgradeableLoaderAccountData(parsed)) {
+        return <UpgradeableLoaderSection data={parsed} />;
+    }
+    if (parsed.program === 'stake') {
+        return <StakeAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'vote') {
+        return <VoteAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'nonce') {
+        return <NonceAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'address-lookup-table') {
+        return <AddressLookupTableSection account={parsed.parsed} />;
+    }
+    return undefined;
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+type Props = {
+    accountInfo?: AccountInfo;
+    accountInfoLoading?: boolean;
+    address: string;
+    enabled: boolean;
+};
+
+export function AccountExpandedContent({ accountInfo, accountInfoLoading, address, enabled }: Props) {
+    const { data, isError, isLoading } = useAccountExpandedInfo(address, enabled);
+
+    if (enabled && isLoading) {
+        return <div className="e-ml-10 e-px-3 e-py-3 e-text-sm e-text-outer-space-300 md:e-px-4">Loading…</div>;
+    }
+
+    if (enabled && isError) {
+        return (
+            <div className="e-ml-10 e-px-3 e-py-3 e-text-sm e-text-outer-space-300 md:e-px-4">
+                Failed to load account info
+            </div>
+        );
+    }
+
+    if (!data) return undefined;
+
+    const dataSizeCell =
+        accountInfo && accountInfo.size > 0 ? (
+            <Popover>
+                <PopoverTrigger asChild>
+                    <Button variant="ghost" className="e-h-auto !e-p-1 !e-text-sm">
+                        <Code size={11} />
+                        <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
+                    </Button>
+                </PopoverTrigger>
+                <PopoverContent className="e-mx-4 e-w-auto !e-rounded-lg e-border-none e-p-0" align="end">
+                    <RawDataField data={accountInfo.data} filename={address} loading={accountInfoLoading} />
+                </PopoverContent>
+            </Popover>
+        ) : (
+            <span>{(data.space ?? 0).toLocaleString('en-US')} byte(s)</span>
+        );
+
+    return (
+        <div className="e-ml-14 e-pb-2.5">
+            {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
+            <DetailRow label="Assigned Program Id">
+                <Address pubkey={data.owner} link />
+            </DetailRow>
+            <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
+            <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
+            <DetailRow label="Balance">
+                <SolBalance lamports={data.lamports} />
+            </DetailRow>
+
+            <div className="e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300">
+                <Info size={13} />
+                <span>Current account data. This data may have been different at the time of the transaction.</span>
+            </div>
+        </div>
+    );
+}

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -1,12 +1,12 @@
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
+import { RawDataField } from '@components/shared/RawDataField';
+import { Button } from '@components/shared/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@components/shared/ui/popover';
+import { Skeleton } from '@components/shared/ui/skeleton';
 import { cn } from '@components/shared/utils';
 import { AccountInfo, useAccountExpandedInfo } from '@entities/account';
 import { Account } from '@providers/accounts';
-import { RawDataField } from '@shared/RawDataField';
-import { Button } from '@shared/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@shared/ui/popover';
-import { Skeleton } from '@shared/ui/skeleton';
 import React from 'react';
 import { Code, Info } from 'react-feather';
 
@@ -26,12 +26,12 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
         accountInfo && accountInfo.size > 0 ? (
             <Popover>
                 <PopoverTrigger asChild>
-                    <Button variant="ghost" className="e-h-auto !e-p-0 !e-text-sm">
+                    <Button variant="ghost" className="h-auto !p-0 !text-sm">
                         <Code size={11} />
                         <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
                     </Button>
                 </PopoverTrigger>
-                <PopoverContent className="e-mx-4 e-w-auto !e-rounded-lg e-border-none e-p-0" align="end">
+                <PopoverContent className="mx-4 w-auto !rounded-lg border-none p-0" align="end">
                     <RawDataField data={accountInfo.data} filename={address} loading={accountInfoLoading} />
                 </PopoverContent>
             </Popover>
@@ -40,7 +40,7 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
         );
 
     return (
-        <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-10')}>
+        <div className={cn(flat ? 'pb-2.5' : 'ml-14 pb-10')}>
             {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
             <DetailRow label="Assigned Program Id">
                 <Address pubkey={data.owner} link />
@@ -53,8 +53,8 @@ export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, a
 
             <div
                 className={cn(
-                    'e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300',
-                    flat && '!e-items-start e-px-4',
+                    'mt-3 flex items-center gap-1.5 text-xs text-outer-space-300',
+                    flat && '!items-start px-4',
                 )}
             >
                 <Info size={13} />
@@ -77,17 +77,17 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
 
     if (enabled && isLoading) {
         return (
-            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-2.5')}>
+            <div className={cn(flat ? 'pb-2.5' : 'ml-14 pb-2.5')}>
                 {[120, 160, 100, 80].map((w, i) => (
                     <div
                         key={i}
                         className={cn(
-                            'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
-                            flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
+                            'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 py-1.5',
+                            flat ? 'px-4' : 'pr-3 md:pr-4',
                         )}
                     >
-                        <Skeleton className="e-h-3.5 e-w-24" />
-                        <Skeleton className="e-h-3.5" style={{ width: w }} />
+                        <Skeleton className="h-3.5 w-24" />
+                        <Skeleton className="h-3.5" style={{ width: w }} />
                     </div>
                 ))}
             </div>
@@ -96,12 +96,7 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
 
     if (enabled && isError) {
         return (
-            <div
-                className={cn(
-                    flat ? 'e-px-4 e-py-3' : 'e-ml-10 e-px-3 e-py-3 md:e-px-4',
-                    'e-text-sm e-text-outer-space-300',
-                )}
-            >
+            <div className={cn(flat ? 'px-4 py-3' : 'ml-10 px-3 py-3 md:px-4', 'text-sm text-outer-space-300')}>
                 Failed to load account info
             </div>
         );

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -1,270 +1,68 @@
-'use client';
-
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
 import { cn } from '@components/shared/utils';
 import { AccountInfo, useAccountExpandedInfo } from '@entities/account';
-import {
-    isTokenProgramData,
-    isUpgradeableLoaderAccountData,
-    ParsedData,
-    StakeProgramData,
-    UpgradeableLoaderAccountData,
-} from '@providers/accounts';
+import { Account } from '@providers/accounts';
 import { RawDataField } from '@shared/RawDataField';
 import { Button } from '@shared/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@shared/ui/popover';
 import { Skeleton } from '@shared/ui/skeleton';
-import { PublicKey } from '@solana/web3.js';
-import { ParsedAddressLookupTableAccount } from '@validators/accounts/address-lookup-table';
-import { NonceAccount } from '@validators/accounts/nonce';
-import { MintAccountInfo, MultisigAccountInfo, TokenAccountInfo } from '@validators/accounts/token';
-import { ProgramAccountInfo } from '@validators/accounts/upgradeable-program';
-import { VoteAccount } from '@validators/accounts/vote';
-import { capitalCase } from 'change-case';
 import React from 'react';
 import { Code, Info } from 'react-feather';
 
-import { StatusBadge } from '@/app/components/account/TokenAccountSection';
+import { DetailRow, FlatContext } from './AccountExpandedLayout';
+import { ParsedSection } from './AccountExpandedSections';
 
-const FlatContext = React.createContext(false);
-
-type StakeAccount = StakeProgramData['parsed'];
-
-// ── Layout primitives ─────────────────────────────────────────────────────────
-
-type DetailRowProps = {
-    children: React.ReactNode;
-    className?: string;
-    label: string;
+type InnerProps = {
+    accountInfo?: AccountInfo;
+    accountInfoLoading?: boolean;
+    address: string;
+    data: Account;
+    flat?: boolean;
 };
 
-function DetailRow({ children, className, label }: DetailRowProps) {
-    const flat = React.useContext(FlatContext);
+export function AccountExpandedContentInner({ accountInfo, accountInfoLoading, address, data, flat }: InnerProps) {
+    const dataSizeCell =
+        accountInfo && accountInfo.size > 0 ? (
+            <Popover>
+                <PopoverTrigger asChild>
+                    <Button variant="ghost" className="e-h-auto !e-p-0 !e-text-sm">
+                        <Code size={11} />
+                        <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
+                    </Button>
+                </PopoverTrigger>
+                <PopoverContent className="e-mx-4 e-w-auto !e-rounded-lg e-border-none e-p-0" align="end">
+                    <RawDataField data={accountInfo.data} filename={address} loading={accountInfoLoading} />
+                </PopoverContent>
+            </Popover>
+        ) : (
+            <span>{(data.space ?? 0).toLocaleString('en-US')} byte(s)</span>
+        );
+
     return (
-        <div
-            className={cn(
-                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
-                flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
-                className,
-            )}
-        >
-            <div className="e-text-sm e-text-outer-space-300">{label}</div>
-            <div className="e-text-sm">{children}</div>
+        <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-10')}>
+            {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
+            <DetailRow label="Assigned Program Id">
+                <Address pubkey={data.owner} link />
+            </DetailRow>
+            <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
+            <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
+            <DetailRow label="Balance">
+                <SolBalance lamports={data.lamports} />
+            </DetailRow>
+
+            <div
+                className={cn(
+                    'e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300',
+                    flat && '!e-items-start e-px-4',
+                )}
+            >
+                <Info size={13} />
+                <span>Current account data. This data may have been different at the time of the transaction.</span>
+            </div>
         </div>
     );
 }
-
-function AddressRow({ label, value }: { label: string; value: PublicKey | string | undefined }) {
-    if (!value) return undefined;
-    const pubkey = typeof value === 'string' ? new PublicKey(value) : value;
-    return (
-        <DetailRow label={label}>
-            <Address pubkey={pubkey} link />
-        </DetailRow>
-    );
-}
-
-// ── Type-specific sections ────────────────────────────────────────────────────
-
-function TokenAccountSection({ info }: { info: TokenAccountInfo }) {
-    return (
-        <>
-            <AddressRow label="Mint" value={info.mint} />
-            <AddressRow label="Owner" value={info.owner} />
-            <DetailRow label="Token Balance">{info.tokenAmount.uiAmountString}</DetailRow>
-            {/* "active" = account can transfer tokens; "inactive" = frozen by the mint's freeze authority */}
-            <DetailRow label="Status">
-                <StatusBadge status={info.state} />
-            </DetailRow>
-            {info.isNative && <DetailRow label="Native Wrapped SOL">Yes</DetailRow>}
-            {info.rentExemptReserve && (
-                <DetailRow label="Rent-Exempt Reserve">{info.rentExemptReserve.uiAmountString}</DetailRow>
-            )}
-            <AddressRow label="Delegate" value={info.delegate} />
-            {info.delegatedAmount && (
-                <DetailRow label="Delegated Amount">{info.delegatedAmount.uiAmountString}</DetailRow>
-            )}
-            <AddressRow label="Close Authority" value={info.closeAuthority} />
-        </>
-    );
-}
-
-function MintAccountSection({ info }: { info: MintAccountInfo }) {
-    return (
-        <>
-            <DetailRow label="Supply">{info.supply}</DetailRow>
-            <DetailRow label="Decimals">{info.decimals}</DetailRow>
-            {info.mintAuthority !== null ? (
-                <AddressRow label="Mint Authority" value={info.mintAuthority} />
-            ) : (
-                <DetailRow label="Mint Authority">Fixed supply</DetailRow>
-            )}
-            {info.freezeAuthority !== null ? (
-                <AddressRow label="Freeze Authority" value={info.freezeAuthority} />
-            ) : (
-                <DetailRow label="Freeze Authority">None</DetailRow>
-            )}
-            {!info.isInitialized && <DetailRow label="Status">Uninitialized</DetailRow>}
-        </>
-    );
-}
-
-function MultisigAccountSection({ info }: { info: MultisigAccountInfo }) {
-    return (
-        <>
-            <DetailRow label="Required Signers">{info.numRequiredSigners}</DetailRow>
-            <DetailRow label="Valid Signers">{info.numValidSigners}</DetailRow>
-            {info.signers.map((signer, i) => (
-                <AddressRow key={signer.toBase58()} label={`Signer ${i + 1}`} value={signer} />
-            ))}
-        </>
-    );
-}
-
-function UpgradeableLoaderSection({ data }: { data: UpgradeableLoaderAccountData }) {
-    const account = data.parsed;
-    if (account.type === 'program') {
-        const programAccount = account.info as unknown as ProgramAccountInfo;
-        return (
-            <>
-                <AddressRow label="Program Data" value={programAccount.programData} />
-                {data.programData && (
-                    <>
-                        {data.programData.authority !== null ? (
-                            <AddressRow label="Upgrade Authority" value={data.programData.authority} />
-                        ) : (
-                            <DetailRow label="Upgrade Authority">Immutable</DetailRow>
-                        )}
-                        {data.programData.slot > 0 && (
-                            <DetailRow label="Last Deploy Slot">
-                                {data.programData.slot.toLocaleString('en-US')}
-                            </DetailRow>
-                        )}
-                    </>
-                )}
-            </>
-        );
-    }
-    if (account.type === 'programData') {
-        return (
-            <>
-                {account.info.authority !== null ? (
-                    <AddressRow label="Upgrade Authority" value={account.info.authority} />
-                ) : (
-                    <DetailRow label="Upgrade Authority">Immutable</DetailRow>
-                )}
-                {account.info.slot > 0 && (
-                    <DetailRow label="Last Deploy Slot">{account.info.slot.toLocaleString('en-US')}</DetailRow>
-                )}
-            </>
-        );
-    }
-    if (account.type === 'buffer') {
-        return account.info.authority !== null ? (
-            <AddressRow label="Buffer Authority" value={account.info.authority} />
-        ) : undefined;
-    }
-    return undefined;
-}
-
-function StakeAccountSection({ account }: { account: StakeAccount }) {
-    const { type, info } = account;
-    return (
-        <>
-            <DetailRow label="Stake Type">{capitalCase(type)}</DetailRow>
-            <AddressRow label="Staker Authority" value={info.meta.authorized.staker} />
-            <AddressRow label="Withdrawer Authority" value={info.meta.authorized.withdrawer} />
-            {info.stake && (
-                <>
-                    <AddressRow label="Vote Account" value={info.stake.delegation.voter} />
-                    <DetailRow label="Activation Epoch">{info.stake.delegation.activationEpoch.toString()}</DetailRow>
-                    {info.stake.delegation.deactivationEpoch.toString() !== '18446744073709551615' && (
-                        <DetailRow label="Deactivation Epoch">
-                            {info.stake.delegation.deactivationEpoch.toString()}
-                        </DetailRow>
-                    )}
-                </>
-            )}
-        </>
-    );
-}
-
-function VoteAccountSection({ account }: { account: VoteAccount }) {
-    const { info } = account;
-    return (
-        <>
-            <AddressRow label="Node Pubkey" value={info.nodePubkey} />
-            <AddressRow label="Authorized Withdrawer" value={info.authorizedWithdrawer} />
-            <DetailRow label="Commission">{info.commission}%</DetailRow>
-            {info.authorizedVoters.length > 0 && (
-                <AddressRow label="Authorized Voter" value={info.authorizedVoters[0].authorizedVoter} />
-            )}
-        </>
-    );
-}
-
-function NonceAccountSection({ account }: { account: NonceAccount }) {
-    if (account.type === 'uninitialized') {
-        return <DetailRow label="Status">Uninitialized</DetailRow>;
-    }
-    return (
-        <>
-            <AddressRow label="Nonce Authority" value={account.info.authority} />
-            <DetailRow label="Nonce">{account.info.blockhash}</DetailRow>
-            <DetailRow label="Fee (lamports/sig)">{account.info.feeCalculator.lamportsPerSignature}</DetailRow>
-        </>
-    );
-}
-
-function AddressLookupTableSection({ account }: { account: ParsedAddressLookupTableAccount }) {
-    const { info } = account;
-    return (
-        <>
-            {info.authority !== undefined ? (
-                <AddressRow label="Authority" value={info.authority} />
-            ) : (
-                <DetailRow label="Authority">Frozen</DetailRow>
-            )}
-            <DetailRow label="Last Extended Slot">{info.lastExtendedSlot.toLocaleString('en-US')}</DetailRow>
-            <DetailRow label="Addresses">{info.addresses.length} address(es)</DetailRow>
-        </>
-    );
-}
-
-function ParsedSection({ parsed }: { parsed: ParsedData }) {
-    if (isTokenProgramData(parsed)) {
-        const account = parsed.parsed;
-        if (account.type === 'account') {
-            return <TokenAccountSection info={account.info as TokenAccountInfo} />;
-        }
-        if (account.type === 'mint') {
-            return <MintAccountSection info={account.info as MintAccountInfo} />;
-        }
-        if (account.type === 'multisig') {
-            return <MultisigAccountSection info={account.info as MultisigAccountInfo} />;
-        }
-        return undefined;
-    }
-    if (isUpgradeableLoaderAccountData(parsed)) {
-        return <UpgradeableLoaderSection data={parsed} />;
-    }
-    if (parsed.program === 'stake') {
-        return <StakeAccountSection account={parsed.parsed} />;
-    }
-    if (parsed.program === 'vote') {
-        return <VoteAccountSection account={parsed.parsed} />;
-    }
-    if (parsed.program === 'nonce') {
-        return <NonceAccountSection account={parsed.parsed} />;
-    }
-    if (parsed.program === 'address-lookup-table') {
-        return <AddressLookupTableSection account={parsed.parsed} />;
-    }
-    return undefined;
-}
-
-// ── Main component ────────────────────────────────────────────────────────────
 
 type Props = {
     accountInfo?: AccountInfo;
@@ -311,46 +109,15 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
 
     if (!data) return undefined;
 
-    const dataSizeCell =
-        accountInfo && accountInfo.size > 0 ? (
-            <Popover>
-                <PopoverTrigger asChild>
-                    <Button variant="ghost" className="e-h-auto !e-p-0 !e-text-sm">
-                        <Code size={11} />
-                        <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
-                    </Button>
-                </PopoverTrigger>
-                <PopoverContent className="e-mx-4 e-w-auto !e-rounded-lg e-border-none e-p-0" align="end">
-                    <RawDataField data={accountInfo.data} filename={address} loading={accountInfoLoading} />
-                </PopoverContent>
-            </Popover>
-        ) : (
-            <span>{(data.space ?? 0).toLocaleString('en-US')} byte(s)</span>
-        );
-
     return (
         <FlatContext.Provider value={flat ?? false}>
-            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-10')}>
-                {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
-                <DetailRow label="Assigned Program Id">
-                    <Address pubkey={data.owner} link />
-                </DetailRow>
-                <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
-                <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
-                <DetailRow label="Balance">
-                    <SolBalance lamports={data.lamports} />
-                </DetailRow>
-
-                <div
-                    className={cn(
-                        'e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300',
-                        flat && '!e-items-start e-px-4',
-                    )}
-                >
-                    <Info size={13} />
-                    <span>Current account data. This data may have been different at the time of the transaction.</span>
-                </div>
-            </div>
+            <AccountExpandedContentInner
+                accountInfo={accountInfo}
+                accountInfoLoading={accountInfoLoading}
+                address={address}
+                data={data}
+                flat={flat}
+            />
         </FlatContext.Provider>
     );
 }

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -25,6 +25,8 @@ import { capitalCase } from 'change-case';
 import React from 'react';
 import { Code, Info } from 'react-feather';
 
+import { StatusBadge } from '@/app/components/account/TokenAccountSection';
+
 const FlatContext = React.createContext(false);
 
 type StakeAccount = StakeProgramData['parsed'];
@@ -71,15 +73,9 @@ function TokenAccountSection({ info }: { info: TokenAccountInfo }) {
             <AddressRow label="Mint" value={info.mint} />
             <AddressRow label="Owner" value={info.owner} />
             <DetailRow label="Token Balance">{info.tokenAmount.uiAmountString}</DetailRow>
+            {/* "active" = account can transfer tokens; "inactive" = frozen by the mint's freeze authority */}
             <DetailRow label="Status">
-                <span
-                    className={cn(
-                        info.state === 'frozen' && 'e-text-warning',
-                        info.state === 'initialized' && 'e-text-success',
-                    )}
-                >
-                    {capitalCase(info.state)}
-                </span>
+                <StatusBadge status={info.state} />
             </DetailRow>
             {info.isNative && <DetailRow label="Native Wrapped SOL">Yes</DetailRow>}
             {info.rentExemptReserve && (
@@ -319,7 +315,7 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
         accountInfo && accountInfo.size > 0 ? (
             <Popover>
                 <PopoverTrigger asChild>
-                    <Button variant="ghost" className="e-h-auto !e-p-1 !e-text-sm">
+                    <Button variant="ghost" className="e-h-auto !e-p-0 !e-text-sm">
                         <Code size={11} />
                         <span>{accountInfo.size.toLocaleString('en-US')} byte(s)</span>
                     </Button>
@@ -334,7 +330,7 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
 
     return (
         <FlatContext.Provider value={flat ?? false}>
-            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-2.5')}>
+            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-10')}>
                 {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
                 <DetailRow label="Assigned Program Id">
                     <Address pubkey={data.owner} link />

--- a/app/features/transaction/ui/AccountExpandedContent.tsx
+++ b/app/features/transaction/ui/AccountExpandedContent.tsx
@@ -11,11 +11,10 @@ import {
     StakeProgramData,
     UpgradeableLoaderAccountData,
 } from '@providers/accounts';
-
-type StakeAccount = StakeProgramData['parsed'];
 import { RawDataField } from '@shared/RawDataField';
 import { Button } from '@shared/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@shared/ui/popover';
+import { Skeleton } from '@shared/ui/skeleton';
 import { PublicKey } from '@solana/web3.js';
 import { ParsedAddressLookupTableAccount } from '@validators/accounts/address-lookup-table';
 import { NonceAccount } from '@validators/accounts/nonce';
@@ -26,6 +25,10 @@ import { capitalCase } from 'change-case';
 import React from 'react';
 import { Code, Info } from 'react-feather';
 
+const FlatContext = React.createContext(false);
+
+type StakeAccount = StakeProgramData['parsed'];
+
 // ── Layout primitives ─────────────────────────────────────────────────────────
 
 type DetailRowProps = {
@@ -35,10 +38,12 @@ type DetailRowProps = {
 };
 
 function DetailRow({ children, className, label }: DetailRowProps) {
+    const flat = React.useContext(FlatContext);
     return (
         <div
             className={cn(
-                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5 e-pr-3 md:e-pr-4',
+                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
+                flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
                 className,
             )}
         >
@@ -270,18 +275,39 @@ type Props = {
     accountInfoLoading?: boolean;
     address: string;
     enabled: boolean;
+    flat?: boolean;
 };
 
-export function AccountExpandedContent({ accountInfo, accountInfoLoading, address, enabled }: Props) {
+export function AccountExpandedContent({ accountInfo, accountInfoLoading, address, enabled, flat }: Props) {
     const { data, isError, isLoading } = useAccountExpandedInfo(address, enabled);
 
     if (enabled && isLoading) {
-        return <div className="e-ml-10 e-px-3 e-py-3 e-text-sm e-text-outer-space-300 md:e-px-4">Loading…</div>;
+        return (
+            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-2.5')}>
+                {[120, 160, 100, 80].map((w, i) => (
+                    <div
+                        key={i}
+                        className={cn(
+                            'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
+                            flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
+                        )}
+                    >
+                        <Skeleton className="e-h-3.5 e-w-24" />
+                        <Skeleton className="e-h-3.5" style={{ width: w }} />
+                    </div>
+                ))}
+            </div>
+        );
     }
 
     if (enabled && isError) {
         return (
-            <div className="e-ml-10 e-px-3 e-py-3 e-text-sm e-text-outer-space-300 md:e-px-4">
+            <div
+                className={cn(
+                    flat ? 'e-px-4 e-py-3' : 'e-ml-10 e-px-3 e-py-3 md:e-px-4',
+                    'e-text-sm e-text-outer-space-300',
+                )}
+            >
                 Failed to load account info
             </div>
         );
@@ -307,21 +333,28 @@ export function AccountExpandedContent({ accountInfo, accountInfoLoading, addres
         );
 
     return (
-        <div className="e-ml-14 e-pb-2.5">
-            {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
-            <DetailRow label="Assigned Program Id">
-                <Address pubkey={data.owner} link />
-            </DetailRow>
-            <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
-            <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
-            <DetailRow label="Balance">
-                <SolBalance lamports={data.lamports} />
-            </DetailRow>
+        <FlatContext.Provider value={flat ?? false}>
+            <div className={cn(flat ? 'e-pb-2.5' : 'e-ml-14 e-pb-2.5')}>
+                {data.data.parsed && <ParsedSection parsed={data.data.parsed} />}
+                <DetailRow label="Assigned Program Id">
+                    <Address pubkey={data.owner} link />
+                </DetailRow>
+                <DetailRow label="Allocated Data Size">{dataSizeCell}</DetailRow>
+                <DetailRow label="Executable">{data.executable ? 'Yes' : 'No'}</DetailRow>
+                <DetailRow label="Balance">
+                    <SolBalance lamports={data.lamports} />
+                </DetailRow>
 
-            <div className="e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300">
-                <Info size={13} />
-                <span>Current account data. This data may have been different at the time of the transaction.</span>
+                <div
+                    className={cn(
+                        'e-mt-3 e-flex e-items-center e-gap-1.5 e-text-xs e-text-outer-space-300',
+                        flat && '!e-items-start e-px-4',
+                    )}
+                >
+                    <Info size={13} />
+                    <span>Current account data. This data may have been different at the time of the transaction.</span>
+                </div>
             </div>
-        </div>
+        </FlatContext.Provider>
     );
 }

--- a/app/features/transaction/ui/AccountExpandedLayout.tsx
+++ b/app/features/transaction/ui/AccountExpandedLayout.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Address } from '@components/common/Address';
+import { cn } from '@components/shared/utils';
+import { PublicKey } from '@solana/web3.js';
+import React from 'react';
+
+export const FlatContext = React.createContext(false);
+
+type DetailRowProps = {
+    children: React.ReactNode;
+    className?: string;
+    label: string;
+};
+
+export function DetailRow({ children, className, label }: DetailRowProps) {
+    const flat = React.useContext(FlatContext);
+    return (
+        <div
+            className={cn(
+                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
+                flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
+                className,
+            )}
+        >
+            <div className="e-text-sm e-text-outer-space-300">{label}</div>
+            <div className="e-text-sm">{children}</div>
+        </div>
+    );
+}
+
+export function AddressRow({ label, value }: { label: string; value: PublicKey | string | undefined }) {
+    if (!value) return undefined;
+    const pubkey = typeof value === 'string' ? new PublicKey(value) : value;
+    return (
+        <DetailRow label={label}>
+            <Address pubkey={pubkey} link />
+        </DetailRow>
+    );
+}

--- a/app/features/transaction/ui/AccountExpandedLayout.tsx
+++ b/app/features/transaction/ui/AccountExpandedLayout.tsx
@@ -18,13 +18,13 @@ export function DetailRow({ children, className, label }: DetailRowProps) {
     return (
         <div
             className={cn(
-                'e-grid e-grid-cols-[clamp(100px,25%,200px)_1fr] e-items-baseline e-gap-2 e-py-1.5',
-                flat ? 'e-px-4' : 'e-pr-3 md:e-pr-4',
+                'grid grid-cols-[clamp(100px,25%,200px)_1fr] items-baseline gap-2 py-1.5',
+                flat ? 'px-4' : 'pr-3 md:pr-4',
                 className,
             )}
         >
-            <div className="e-text-sm e-text-outer-space-300">{label}</div>
-            <div className="e-text-sm">{children}</div>
+            <div className="text-sm text-outer-space-300">{label}</div>
+            <div className="text-sm">{children}</div>
         </div>
     );
 }

--- a/app/features/transaction/ui/AccountExpandedSections.tsx
+++ b/app/features/transaction/ui/AccountExpandedSections.tsx
@@ -1,0 +1,217 @@
+import {
+    isTokenProgramData,
+    isUpgradeableLoaderAccountData,
+    ParsedData,
+    StakeProgramData,
+    UpgradeableLoaderAccountData,
+} from '@providers/accounts';
+import { ParsedAddressLookupTableAccount } from '@validators/accounts/address-lookup-table';
+import { NonceAccount } from '@validators/accounts/nonce';
+import { MintAccountInfo, MultisigAccountInfo, TokenAccountInfo } from '@validators/accounts/token';
+import { ProgramAccountInfo } from '@validators/accounts/upgradeable-program';
+import { VoteAccount } from '@validators/accounts/vote';
+import { capitalCase } from 'change-case';
+import React from 'react';
+
+import { StatusBadge } from '@/app/components/account/TokenAccountSection';
+
+import { AddressRow, DetailRow } from './AccountExpandedLayout';
+
+type StakeAccount = StakeProgramData['parsed'];
+
+export function TokenAccountSection({ info }: { info: TokenAccountInfo }) {
+    return (
+        <>
+            <AddressRow label="Mint" value={info.mint} />
+            <AddressRow label="Owner" value={info.owner} />
+            <DetailRow label="Token Balance">{info.tokenAmount.uiAmountString}</DetailRow>
+            {/* "active" = account can transfer tokens; "inactive" = frozen by the mint's freeze authority */}
+            <DetailRow label="Status">
+                <StatusBadge status={info.state} />
+            </DetailRow>
+            {info.isNative && <DetailRow label="Native Wrapped SOL">Yes</DetailRow>}
+            {info.rentExemptReserve && (
+                <DetailRow label="Rent-Exempt Reserve">{info.rentExemptReserve.uiAmountString}</DetailRow>
+            )}
+            <AddressRow label="Delegate" value={info.delegate} />
+            {info.delegatedAmount && (
+                <DetailRow label="Delegated Amount">{info.delegatedAmount.uiAmountString}</DetailRow>
+            )}
+            <AddressRow label="Close Authority" value={info.closeAuthority} />
+        </>
+    );
+}
+
+export function MintAccountSection({ info }: { info: MintAccountInfo }) {
+    return (
+        <>
+            <DetailRow label="Supply">{info.supply}</DetailRow>
+            <DetailRow label="Decimals">{info.decimals}</DetailRow>
+            {info.mintAuthority !== null ? (
+                <AddressRow label="Mint Authority" value={info.mintAuthority} />
+            ) : (
+                <DetailRow label="Mint Authority">Fixed supply</DetailRow>
+            )}
+            {info.freezeAuthority !== null ? (
+                <AddressRow label="Freeze Authority" value={info.freezeAuthority} />
+            ) : (
+                <DetailRow label="Freeze Authority">None</DetailRow>
+            )}
+            {!info.isInitialized && <DetailRow label="Status">Uninitialized</DetailRow>}
+        </>
+    );
+}
+
+export function MultisigAccountSection({ info }: { info: MultisigAccountInfo }) {
+    return (
+        <>
+            <DetailRow label="Required Signers">{info.numRequiredSigners}</DetailRow>
+            <DetailRow label="Valid Signers">{info.numValidSigners}</DetailRow>
+            {info.signers.map((signer, i) => (
+                <AddressRow key={signer.toBase58()} label={`Signer ${i + 1}`} value={signer} />
+            ))}
+        </>
+    );
+}
+
+export function UpgradeableLoaderSection({ data }: { data: UpgradeableLoaderAccountData }) {
+    const account = data.parsed;
+    if (account.type === 'program') {
+        const programAccount = account.info as unknown as ProgramAccountInfo;
+        return (
+            <>
+                <AddressRow label="Program Data" value={programAccount.programData} />
+                {data.programData && (
+                    <>
+                        {data.programData.authority !== null ? (
+                            <AddressRow label="Upgrade Authority" value={data.programData.authority} />
+                        ) : (
+                            <DetailRow label="Upgrade Authority">Immutable</DetailRow>
+                        )}
+                        {data.programData.slot > 0 && (
+                            <DetailRow label="Last Deploy Slot">
+                                {data.programData.slot.toLocaleString('en-US')}
+                            </DetailRow>
+                        )}
+                    </>
+                )}
+            </>
+        );
+    }
+    if (account.type === 'programData') {
+        return (
+            <>
+                {account.info.authority !== null ? (
+                    <AddressRow label="Upgrade Authority" value={account.info.authority} />
+                ) : (
+                    <DetailRow label="Upgrade Authority">Immutable</DetailRow>
+                )}
+                {account.info.slot > 0 && (
+                    <DetailRow label="Last Deploy Slot">{account.info.slot.toLocaleString('en-US')}</DetailRow>
+                )}
+            </>
+        );
+    }
+    if (account.type === 'buffer') {
+        return account.info.authority !== null ? (
+            <AddressRow label="Buffer Authority" value={account.info.authority} />
+        ) : undefined;
+    }
+    return undefined;
+}
+
+export function StakeAccountSection({ account }: { account: StakeAccount }) {
+    const { type, info } = account;
+    return (
+        <>
+            <DetailRow label="Stake Type">{capitalCase(type)}</DetailRow>
+            <AddressRow label="Staker Authority" value={info.meta.authorized.staker} />
+            <AddressRow label="Withdrawer Authority" value={info.meta.authorized.withdrawer} />
+            {info.stake && (
+                <>
+                    <AddressRow label="Vote Account" value={info.stake.delegation.voter} />
+                    <DetailRow label="Activation Epoch">{info.stake.delegation.activationEpoch.toString()}</DetailRow>
+                    {info.stake.delegation.deactivationEpoch.toString() !== '18446744073709551615' && (
+                        <DetailRow label="Deactivation Epoch">
+                            {info.stake.delegation.deactivationEpoch.toString()}
+                        </DetailRow>
+                    )}
+                </>
+            )}
+        </>
+    );
+}
+
+export function VoteAccountSection({ account }: { account: VoteAccount }) {
+    const { info } = account;
+    return (
+        <>
+            <AddressRow label="Node Pubkey" value={info.nodePubkey} />
+            <AddressRow label="Authorized Withdrawer" value={info.authorizedWithdrawer} />
+            <DetailRow label="Commission">{info.commission}%</DetailRow>
+            {info.authorizedVoters.length > 0 && (
+                <AddressRow label="Authorized Voter" value={info.authorizedVoters[0].authorizedVoter} />
+            )}
+        </>
+    );
+}
+
+export function NonceAccountSection({ account }: { account: NonceAccount }) {
+    if (account.type === 'uninitialized') {
+        return <DetailRow label="Status">Uninitialized</DetailRow>;
+    }
+    return (
+        <>
+            <AddressRow label="Nonce Authority" value={account.info.authority} />
+            <DetailRow label="Nonce">{account.info.blockhash}</DetailRow>
+            <DetailRow label="Fee (lamports/sig)">{account.info.feeCalculator.lamportsPerSignature}</DetailRow>
+        </>
+    );
+}
+
+export function AddressLookupTableSection({ account }: { account: ParsedAddressLookupTableAccount }) {
+    const { info } = account;
+    return (
+        <>
+            {info.authority !== undefined ? (
+                <AddressRow label="Authority" value={info.authority} />
+            ) : (
+                <DetailRow label="Authority">Frozen</DetailRow>
+            )}
+            <DetailRow label="Last Extended Slot">{info.lastExtendedSlot.toLocaleString('en-US')}</DetailRow>
+            <DetailRow label="Addresses">{info.addresses.length} address(es)</DetailRow>
+        </>
+    );
+}
+
+export function ParsedSection({ parsed }: { parsed: ParsedData }) {
+    if (isTokenProgramData(parsed)) {
+        const account = parsed.parsed;
+        if (account.type === 'account') {
+            return <TokenAccountSection info={account.info as TokenAccountInfo} />;
+        }
+        if (account.type === 'mint') {
+            return <MintAccountSection info={account.info as MintAccountInfo} />;
+        }
+        if (account.type === 'multisig') {
+            return <MultisigAccountSection info={account.info as MultisigAccountInfo} />;
+        }
+        return undefined;
+    }
+    if (isUpgradeableLoaderAccountData(parsed)) {
+        return <UpgradeableLoaderSection data={parsed} />;
+    }
+    if (parsed.program === 'stake') {
+        return <StakeAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'vote') {
+        return <VoteAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'nonce') {
+        return <NonceAccountSection account={parsed.parsed} />;
+    }
+    if (parsed.program === 'address-lookup-table') {
+        return <AddressLookupTableSection account={parsed.parsed} />;
+    }
+    return undefined;
+}

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -9,9 +9,9 @@ import { cn } from '@components/shared/utils';
 import { AccountInfo, useAccountsInfo } from '@entities/account';
 import { useCluster } from '@providers/cluster';
 import { useTransactionDetails } from '@providers/transactions';
+import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
 import { SignatureProps } from '@utils/index';
 import { BigNumber } from 'bignumber.js';
-import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
 import React, { useMemo, useState } from 'react';
 import { ChevronDown } from 'react-feather';
 
@@ -66,23 +66,23 @@ function TransactionAccountRow({
 
     return (
         <>
-            <div className="e-border-1 e-border-b e-border-white/10 [border-bottom-style:solid] last:e-border-b-0">
+            <div className="border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0">
                 {/* Main row */}
                 <div
                     className={cn(
-                        'e-min-h-9 e-px-3 e-py-2.5 md:e-px-4',
-                        'e-grid e-items-start e-gap-x-0 e-gap-y-0.5 e-whitespace-nowrap e-text-sm md:e-gap-y-0 lg:e-gap-x-5',
-                        'e-grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:e-grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:e-grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
+                        'min-h-9 px-3 py-2.5 md:px-4',
+                        'grid items-start gap-x-0 gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0 lg:gap-x-5',
+                        'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
                         "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand']",
-                        'e-cursor-pointer',
+                        'cursor-pointer',
                     )}
                     onClick={handleRowClick}
                 >
-                    <div className="e-mr-2 e-text-outer-space-300 [grid-area:number] lg:e-mr-0">{index + 1}</div>
+                    <div className="mr-2 text-outer-space-300 [grid-area:number] lg:mr-0">{index + 1}</div>
                     <div className="[grid-area:address]">
-                        <div className="e-flex e-items-center e-justify-between e-gap-1 lg:e-justify-normal">
+                        <div className="flex items-center justify-between gap-1 lg:justify-normal">
                             <Address
-                                className={!isLg ? 'e-text-[#33a382]' : ''}
+                                className={!isLg ? 'text-[#33a382]' : ''}
                                 pubkey={pubkey}
                                 link={isLg}
                                 fetchTokenLabelInfo
@@ -91,24 +91,24 @@ function TransactionAccountRow({
                             />
                         </div>
                         {hasBadges && (
-                            <span className="e-mt-1 e-inline-flex e-flex-wrap e-gap-1">
+                            <span className="mt-1 inline-flex flex-wrap gap-1">
                                 <AccountBadges index={index} message={message} pubkey={pubkey} account={account} />
                             </span>
                         )}
                     </div>
-                    <div className="e-justify-self-end [grid-area:delta]">
+                    <div className="justify-self-end [grid-area:delta]">
                         <BalanceDelta delta={delta} isSol />
                     </div>
-                    <div className="e-justify-self-end [grid-area:balance]">
+                    <div className="justify-self-end [grid-area:balance]">
                         <SolBalance lamports={post} />
                     </div>
 
                     {/* Desktop: expand button */}
-                    <div className="e-hidden e-items-center e-justify-center [grid-area:expand] lg:e-flex">
+                    <div className="hidden items-center justify-center [grid-area:expand] lg:flex">
                         <Button
                             aria-expanded={expanded}
                             aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
-                            className="!e-h-5 e-w-6"
+                            className="!h-5 w-6"
                             onClick={e => {
                                 e.stopPropagation();
                                 setExpanded(v => !v);
@@ -119,8 +119,8 @@ function TransactionAccountRow({
                             <ChevronDown
                                 size={16}
                                 className={cn(
-                                    'e-text-outer-space-300 e-transition-transform e-duration-200 e-ease-in-out [transform:rotate(90deg)]',
-                                    expanded && '[transform:rotate(0deg)]',
+                                    'text-outer-space-300 transition-transform duration-200 ease-in-out',
+                                    expanded ? 'rotate-0' : 'rotate-90',
                                 )}
                             />
                         </Button>
@@ -130,12 +130,12 @@ function TransactionAccountRow({
                 {/* Desktop: animated expanded content */}
                 <div
                     className={cn(
-                        'e-hidden lg:e-grid',
-                        'e-transition-[grid-template-rows] e-duration-200 e-ease-in-out',
-                        expanded ? 'e-grid-rows-[1fr]' : 'e-grid-rows-[0fr]',
+                        'hidden lg:grid',
+                        'transition-[grid-template-rows,opacity] duration-200 ease-in-out',
+                        expanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
                     )}
                 >
-                    <div className="e-overflow-hidden">
+                    <div className="min-h-0 overflow-hidden">
                         <AccountExpandedContent
                             accountInfo={accountInfo}
                             accountInfoLoading={accountInfoLoading}

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -82,14 +82,16 @@ function TransactionAccountRow({
                     <div className="mr-2 text-outer-space-300 [grid-area:number] lg:mr-0">{index + 1}</div>
                     <div className="[grid-area:address]">
                         <div className="flex items-center justify-between gap-1 lg:justify-normal landscape:justify-normal">
-                            <Address
-                                className={!isDesktop ? 'text-[#33a382]' : ''}
-                                pubkey={pubkey}
-                                link={isDesktop}
-                                fetchTokenLabelInfo
-                                noNicknameEditing={!isDesktop}
-                                noCopy={!isDesktop}
-                            />
+                            <div onClick={e => isDesktop && e.stopPropagation()}>
+                                <Address
+                                    className={!isDesktop ? 'text-[#33a382]' : ''}
+                                    pubkey={pubkey}
+                                    link={isDesktop}
+                                    fetchTokenLabelInfo
+                                    noNicknameEditing={!isDesktop}
+                                    noCopy={!isDesktop}
+                                />
+                            </div>
                         </div>
                         {hasBadges && (
                             <span className="mt-1 inline-flex flex-wrap gap-1">

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -43,7 +43,8 @@ function TransactionAccountRow({
 }: TransactionAccountRowProps) {
     const [expanded, setExpanded] = useState(false);
     const [slideoverOpen, setSlideoverOpen] = useState(false);
-    const { isLg } = useBreakpoint();
+    const { isLandscape, isLg } = useBreakpoint();
+    const isDesktop = isLg || isLandscape;
 
     const pubkey = account.pubkey;
     const key = pubkey.toBase58();
@@ -57,7 +58,7 @@ function TransactionAccountRow({
         account.source === 'lookupTable';
 
     const handleRowClick = () => {
-        if (isLg) {
+        if (isDesktop) {
             setExpanded(v => !v);
         } else {
             setSlideoverOpen(true);
@@ -71,23 +72,23 @@ function TransactionAccountRow({
                 <div
                     className={cn(
                         'min-h-9 px-3 py-2.5 md:px-4',
-                        'grid items-start gap-x-0 gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0 lg:gap-x-5',
-                        'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
-                        "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand']",
+                        'grid items-start gap-x-0 gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0 lg:gap-x-5 landscape:gap-x-5',
+                        'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem] landscape:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
+                        "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand'] landscape:[grid-template-areas:'number_address_delta_balance_expand']",
                         'cursor-pointer',
                     )}
                     onClick={handleRowClick}
                 >
                     <div className="mr-2 text-outer-space-300 [grid-area:number] lg:mr-0">{index + 1}</div>
                     <div className="[grid-area:address]">
-                        <div className="flex items-center justify-between gap-1 lg:justify-normal">
+                        <div className="flex items-center justify-between gap-1 lg:justify-normal landscape:justify-normal">
                             <Address
-                                className={!isLg ? 'text-[#33a382]' : ''}
+                                className={!isDesktop ? 'text-[#33a382]' : ''}
                                 pubkey={pubkey}
-                                link={isLg}
+                                link={isDesktop}
                                 fetchTokenLabelInfo
-                                noNicknameEditing={!isLg}
-                                noCopy={!isLg}
+                                noNicknameEditing={!isDesktop}
+                                noCopy={!isDesktop}
                             />
                         </div>
                         {hasBadges && (
@@ -104,7 +105,7 @@ function TransactionAccountRow({
                     </div>
 
                     {/* Desktop: expand button */}
-                    <div className="hidden items-center justify-center [grid-area:expand] lg:flex">
+                    <div className="hidden items-center justify-center [grid-area:expand] lg:flex landscape:flex">
                         <Button
                             aria-expanded={expanded}
                             aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
@@ -130,7 +131,7 @@ function TransactionAccountRow({
                 {/* Desktop: animated expanded content */}
                 <div
                     className={cn(
-                        'hidden lg:grid',
+                        'hidden lg:grid landscape:grid',
                         'transition-[grid-template-rows,opacity] duration-200 ease-in-out',
                         expanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
                     )}
@@ -209,7 +210,7 @@ export function AccountsCard({ signature }: SignatureProps) {
         <CollapsibleSection id="accounts" title="Accounts &amp; SOL balance">
             <div
                 className={cn(
-                    'hidden px-3 py-1.5 md:px-4 lg:grid',
+                    'hidden px-3 py-1.5 md:px-4 lg:grid landscape:grid',
                     'grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_2rem] gap-5 text-xs uppercase text-outer-space-300',
                     'border-1 border-b border-white/10 [border-bottom-style:solid]',
                 )}

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -4,7 +4,6 @@ import { Address } from '@components/common/Address';
 import { BalanceDelta } from '@components/common/BalanceDelta';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { SolBalance } from '@components/common/SolBalance';
-import { Badge } from '@components/shared/ui/badge';
 import { Button } from '@components/shared/ui/button';
 import { cn } from '@components/shared/utils';
 import { AccountInfo, useAccountsInfo } from '@entities/account';
@@ -16,6 +15,10 @@ import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
 import React, { useMemo, useState } from 'react';
 import { ChevronDown } from 'react-feather';
 
+import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
+
+import { AccountBadges } from './AccountBadges';
+import { AccountDetailSlideover } from './AccountDetailSlideover';
 import { AccountExpandedContent } from './AccountExpandedContent';
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -39,6 +42,8 @@ function TransactionAccountRow({
     pre,
 }: TransactionAccountRowProps) {
     const [expanded, setExpanded] = useState(false);
+    const [slideoverOpen, setSlideoverOpen] = useState(false);
+    const { isLg } = useBreakpoint();
 
     const pubkey = account.pubkey;
     const key = pubkey.toBase58();
@@ -51,105 +56,106 @@ function TransactionAccountRow({
         message.instructions.some(ix => ix.programId.equals(pubkey)) ||
         account.source === 'lookupTable';
 
-    const badges = (
-        <>
-            {index === 0 && (
-                <Badge ui="dashkit" variant="success" className="me-1">
-                    Fee Payer
-                </Badge>
-            )}
-            {account.signer && (
-                <Badge ui="dashkit" variant="info" className="me-1">
-                    Signer
-                </Badge>
-            )}
-            {account.writable && (
-                <Badge ui="dashkit" variant="danger" className="me-1">
-                    Writable
-                </Badge>
-            )}
-            {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
-                <Badge ui="dashkit" variant="warning" className="me-1">
-                    Program
-                </Badge>
-            )}
-            {account.source === 'lookupTable' && (
-                <Badge ui="dashkit" variant="gray" className="me-1">
-                    Address Table Lookup
-                </Badge>
-            )}
-        </>
-    );
+    const handleRowClick = () => {
+        if (isLg) {
+            setExpanded(v => !v);
+        } else {
+            setSlideoverOpen(true);
+        }
+    };
 
     return (
-        <div className="e-border-1 e-border-b e-border-white/10 [border-bottom-style:solid] last:e-border-b-0">
-            {/* Main row */}
-            <div
-                className={cn(
-                    'e-min-h-9 e-px-3 e-py-2.5 md:e-px-4',
-                    'e-grid e-items-start e-gap-x-0 e-gap-y-0.5 e-whitespace-nowrap e-text-sm md:e-gap-y-0 lg:e-gap-x-5',
-                    'e-grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:e-grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:e-grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
-                    "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand']",
-                    'e-cursor-pointer',
-                )}
-                onClick={() => setExpanded(v => !v)}
-            >
-                <div className="e-mr-2 e-text-outer-space-300 [grid-area:number] lg:e-mr-0">{index + 1}</div>
-                <div className="[grid-area:address]">
-                    <div className="e-flex e-items-center e-justify-between e-gap-1 lg:e-justify-normal">
-                        <Address pubkey={pubkey} link fetchTokenLabelInfo />
+        <>
+            <div className="e-border-1 e-border-b e-border-white/10 [border-bottom-style:solid] last:e-border-b-0">
+                {/* Main row */}
+                <div
+                    className={cn(
+                        'e-min-h-9 e-px-3 e-py-2.5 md:e-px-4',
+                        'e-grid e-items-start e-gap-x-0 e-gap-y-0.5 e-whitespace-nowrap e-text-sm md:e-gap-y-0 lg:e-gap-x-5',
+                        'e-grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:e-grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:e-grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
+                        "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand']",
+                        'e-cursor-pointer',
+                    )}
+                    onClick={handleRowClick}
+                >
+                    <div className="e-mr-2 e-text-outer-space-300 [grid-area:number] lg:e-mr-0">{index + 1}</div>
+                    <div className="[grid-area:address]">
+                        <div className="e-flex e-items-center e-justify-between e-gap-1 lg:e-justify-normal">
+                            <Address
+                                pubkey={pubkey}
+                                link
+                                fetchTokenLabelInfo
+                                noNicknameEditing={!isLg}
+                                noCopy={!isLg}
+                            />
+                        </div>
+                        {hasBadges && (
+                            <span className="e-mt-1 e-inline-flex e-flex-wrap e-gap-1">
+                                <AccountBadges index={index} message={message} pubkey={pubkey} account={account} />
+                            </span>
+                        )}
                     </div>
-                    {hasBadges && <span className="e-mt-1 e-inline-flex e-flex-wrap e-gap-1">{badges}</span>}
-                </div>
-                <div className="e-justify-self-end [grid-area:delta]">
-                    <BalanceDelta delta={delta} isSol />
-                </div>
-                <div className="e-justify-self-end [grid-area:balance]">
-                    <SolBalance lamports={post} />
+                    <div className="e-justify-self-end [grid-area:delta]">
+                        <BalanceDelta delta={delta} isSol />
+                    </div>
+                    <div className="e-justify-self-end [grid-area:balance]">
+                        <SolBalance lamports={post} />
+                    </div>
+
+                    {/* Desktop: expand button */}
+                    <div className="e-hidden e-items-center e-justify-center [grid-area:expand] lg:e-flex">
+                        <Button
+                            aria-expanded={expanded}
+                            aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
+                            className="-e-mt-1 e-h-6 e-w-6"
+                            onClick={e => {
+                                e.stopPropagation();
+                                setExpanded(v => !v);
+                            }}
+                            size="icon"
+                            variant="ghost"
+                        >
+                            <ChevronDown
+                                size={16}
+                                className={cn(
+                                    'e-text-outer-space-300 e-transition-transform e-duration-200 e-ease-in-out [transform:rotate(90deg)]',
+                                    expanded && '[transform:rotate(0deg)]',
+                                )}
+                            />
+                        </Button>
+                    </div>
                 </div>
 
-                {/* Desktop: expand button */}
-                <div className="e-hidden e-items-center e-justify-center [grid-area:expand] lg:e-flex">
-                    <Button
-                        aria-expanded={expanded}
-                        aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
-                        className="-e-mt-1 e-h-6 e-w-6"
-                        onClick={e => {
-                            e.stopPropagation();
-                            setExpanded(v => !v);
-                        }}
-                        size="icon"
-                        variant="ghost"
-                    >
-                        <ChevronDown
-                            size={16}
-                            className={cn(
-                                'e-text-outer-space-300 e-transition-transform e-duration-200 e-ease-in-out [transform:rotate(90deg)]',
-                                expanded && '[transform:rotate(0deg)]',
-                            )}
+                {/* Desktop: animated expanded content */}
+                <div
+                    className={cn(
+                        'e-hidden lg:e-grid',
+                        'e-transition-[grid-template-rows] e-duration-200 e-ease-in-out',
+                        expanded ? 'e-grid-rows-[1fr]' : 'e-grid-rows-[0fr]',
+                    )}
+                >
+                    <div className="e-overflow-hidden">
+                        <AccountExpandedContent
+                            accountInfo={accountInfo}
+                            accountInfoLoading={accountInfoLoading}
+                            address={key}
+                            enabled={expanded}
                         />
-                    </Button>
+                    </div>
                 </div>
             </div>
 
-            {/* Desktop: animated expanded content */}
-            <div
-                className={cn(
-                    'e-hidden lg:e-grid',
-                    'e-transition-[grid-template-rows] e-duration-200 e-ease-in-out',
-                    expanded ? 'e-grid-rows-[1fr]' : 'e-grid-rows-[0fr]',
-                )}
-            >
-                <div className="e-overflow-hidden">
-                    <AccountExpandedContent
-                        accountInfo={accountInfo}
-                        accountInfoLoading={accountInfoLoading}
-                        address={key}
-                        enabled={expanded}
-                    />
-                </div>
-            </div>
-        </div>
+            {/* Mobile: slideover */}
+            <AccountDetailSlideover
+                account={account}
+                accountInfo={accountInfo}
+                accountInfoLoading={accountInfoLoading}
+                index={index}
+                message={message}
+                onOpenChange={setSlideoverOpen}
+                open={slideoverOpen}
+            />
+        </>
     );
 }
 

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -82,8 +82,9 @@ function TransactionAccountRow({
                     <div className="[grid-area:address]">
                         <div className="e-flex e-items-center e-justify-between e-gap-1 lg:e-justify-normal">
                             <Address
+                                className={!isLg ? 'e-text-[#33a382]' : ''}
                                 pubkey={pubkey}
-                                link
+                                link={isLg}
                                 fetchTokenLabelInfo
                                 noNicknameEditing={!isLg}
                                 noCopy={!isLg}
@@ -107,7 +108,7 @@ function TransactionAccountRow({
                         <Button
                             aria-expanded={expanded}
                             aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
-                            className="-e-mt-1 e-h-6 e-w-6"
+                            className="!e-h-5 e-w-6"
                             onClick={e => {
                                 e.stopPropagation();
                                 setExpanded(v => !v);

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -1,28 +1,161 @@
+'use client';
+
 import { Address } from '@components/common/Address';
 import { BalanceDelta } from '@components/common/BalanceDelta';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { SolBalance } from '@components/common/SolBalance';
-import { RawDataField } from '@components/shared/RawDataField';
 import { Badge } from '@components/shared/ui/badge';
 import { Button } from '@components/shared/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@components/shared/ui/popover';
 import { cn } from '@components/shared/utils';
-import { useAccountsInfo } from '@entities/account';
+import { AccountInfo, useAccountsInfo } from '@entities/account';
 import { useCluster } from '@providers/cluster';
 import { useTransactionDetails } from '@providers/transactions';
 import { SignatureProps } from '@utils/index';
 import { BigNumber } from 'bignumber.js';
-import React, { useMemo } from 'react';
-import { Code } from 'react-feather';
+import type { ParsedMessage, ParsedMessageAccount } from '@solana/web3.js';
+import React, { useMemo, useState } from 'react';
+import { ChevronDown } from 'react-feather';
 
-import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
-
+import { AccountExpandedContent } from './AccountExpandedContent';
 import { CollapsibleSection } from './CollapsibleSection';
+
+type TransactionAccountRowProps = {
+    account: ParsedMessageAccount;
+    accountInfo?: AccountInfo;
+    accountInfoLoading: boolean;
+    index: number;
+    message: ParsedMessage;
+    post: number;
+    pre: number;
+};
+
+function TransactionAccountRow({
+    account,
+    accountInfo,
+    accountInfoLoading,
+    index,
+    message,
+    post,
+    pre,
+}: TransactionAccountRowProps) {
+    const [expanded, setExpanded] = useState(false);
+
+    const pubkey = account.pubkey;
+    const key = pubkey.toBase58();
+    const delta = new BigNumber(post).minus(new BigNumber(pre));
+
+    const hasBadges =
+        index === 0 ||
+        account.signer ||
+        account.writable ||
+        message.instructions.some(ix => ix.programId.equals(pubkey)) ||
+        account.source === 'lookupTable';
+
+    const badges = (
+        <>
+            {index === 0 && (
+                <Badge ui="dashkit" variant="success" className="me-1">
+                    Fee Payer
+                </Badge>
+            )}
+            {account.signer && (
+                <Badge ui="dashkit" variant="info" className="me-1">
+                    Signer
+                </Badge>
+            )}
+            {account.writable && (
+                <Badge ui="dashkit" variant="danger" className="me-1">
+                    Writable
+                </Badge>
+            )}
+            {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
+                <Badge ui="dashkit" variant="warning" className="me-1">
+                    Program
+                </Badge>
+            )}
+            {account.source === 'lookupTable' && (
+                <Badge ui="dashkit" variant="gray" className="me-1">
+                    Address Table Lookup
+                </Badge>
+            )}
+        </>
+    );
+
+    return (
+        <div className="e-border-1 e-border-b e-border-white/10 [border-bottom-style:solid] last:e-border-b-0">
+            {/* Main row */}
+            <div
+                className={cn(
+                    'e-min-h-9 e-px-3 e-py-2.5 md:e-px-4',
+                    'e-grid e-items-start e-gap-x-0 e-gap-y-0.5 e-whitespace-nowrap e-text-sm md:e-gap-y-0 lg:e-gap-x-5',
+                    'e-grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:e-grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:e-grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_1.5rem]',
+                    "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance_expand']",
+                    'e-cursor-pointer',
+                )}
+                onClick={() => setExpanded(v => !v)}
+            >
+                <div className="e-mr-2 e-text-outer-space-300 [grid-area:number] lg:e-mr-0">{index + 1}</div>
+                <div className="[grid-area:address]">
+                    <div className="e-flex e-items-center e-justify-between e-gap-1 lg:e-justify-normal">
+                        <Address pubkey={pubkey} link fetchTokenLabelInfo />
+                    </div>
+                    {hasBadges && <span className="e-mt-1 e-inline-flex e-flex-wrap e-gap-1">{badges}</span>}
+                </div>
+                <div className="e-justify-self-end [grid-area:delta]">
+                    <BalanceDelta delta={delta} isSol />
+                </div>
+                <div className="e-justify-self-end [grid-area:balance]">
+                    <SolBalance lamports={post} />
+                </div>
+
+                {/* Desktop: expand button */}
+                <div className="e-hidden e-items-center e-justify-center [grid-area:expand] lg:e-flex">
+                    <Button
+                        aria-expanded={expanded}
+                        aria-label={expanded ? 'Collapse account details' : 'Expand account details'}
+                        className="-e-mt-1 e-h-6 e-w-6"
+                        onClick={e => {
+                            e.stopPropagation();
+                            setExpanded(v => !v);
+                        }}
+                        size="icon"
+                        variant="ghost"
+                    >
+                        <ChevronDown
+                            size={16}
+                            className={cn(
+                                'e-text-outer-space-300 e-transition-transform e-duration-200 e-ease-in-out [transform:rotate(90deg)]',
+                                expanded && '[transform:rotate(0deg)]',
+                            )}
+                        />
+                    </Button>
+                </div>
+            </div>
+
+            {/* Desktop: animated expanded content */}
+            <div
+                className={cn(
+                    'e-hidden lg:e-grid',
+                    'e-transition-[grid-template-rows] e-duration-200 e-ease-in-out',
+                    expanded ? 'e-grid-rows-[1fr]' : 'e-grid-rows-[0fr]',
+                )}
+            >
+                <div className="e-overflow-hidden">
+                    <AccountExpandedContent
+                        accountInfo={accountInfo}
+                        accountInfoLoading={accountInfoLoading}
+                        address={key}
+                        enabled={expanded}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}
 
 export function AccountsCard({ signature }: SignatureProps) {
     const details = useTransactionDetails(signature);
     const { url } = useCluster();
-    const { isLg } = useBreakpoint();
 
     const transactionWithMeta = details?.data?.transactionWithMeta;
     const message = transactionWithMeta?.transaction.message;
@@ -50,97 +183,18 @@ export function AccountsCard({ signature }: SignatureProps) {
     }
 
     const accountRows = message.accountKeys.map((account, index) => {
-        const pre = meta.preBalances[index];
-        const post = meta.postBalances[index];
-        const pubkey = account.pubkey;
-        const key = pubkey.toBase58();
-        const delta = new BigNumber(post).minus(new BigNumber(pre));
-        const accountInfo = accounts.get(key);
-
-        const hasBadges =
-            index === 0 ||
-            account.signer ||
-            account.writable ||
-            message.instructions.some(ix => ix.programId.equals(pubkey)) ||
-            account.source === 'lookupTable';
-
-        const badges = (
-            <>
-                {index === 0 && (
-                    <Badge ui="dashkit" variant="success" className="me-1">
-                        Fee Payer
-                    </Badge>
-                )}
-                {account.signer && (
-                    <Badge ui="dashkit" variant="info" className="me-1">
-                        Signer
-                    </Badge>
-                )}
-                {account.writable && (
-                    <Badge ui="dashkit" variant="danger" className="me-1">
-                        Writable
-                    </Badge>
-                )}
-                {message.instructions.find(ix => ix.programId.equals(pubkey)) && (
-                    <Badge ui="dashkit" variant="warning" className="me-1">
-                        Program
-                    </Badge>
-                )}
-                {account.source === 'lookupTable' && (
-                    <Badge ui="dashkit" variant="gray" className="me-1">
-                        Address Table Lookup
-                    </Badge>
-                )}
-            </>
-        );
-
-        const dataCell = loading ? (
-            <span className="text-xs text-outer-space-300">Loading…</span>
-        ) : accountInfo && accountInfo.size > 0 ? (
-            <Popover>
-                <PopoverTrigger asChild>
-                    <Button variant="ghost" className="h-auto !px-1 !py-0 text-xs">
-                        <Code size={11} />
-                        <span>{accountInfo.size.toLocaleString('en-US')}</span>
-                    </Button>
-                </PopoverTrigger>
-                <PopoverContent className="mx-4 w-auto !rounded-lg border-none p-0" align="end">
-                    <RawDataField data={accountInfo.data} filename={key} />
-                </PopoverContent>
-            </Popover>
-        ) : null;
-
+        const pubkeyStr = account.pubkey.toBase58();
         return (
-            <div
-                key={key}
-                className={cn(
-                    'min-h-9 px-3 py-2.5 md:px-4',
-                    'grid items-start gap-x-0 gap-y-0.5 whitespace-nowrap text-sm md:gap-y-0 lg:gap-x-5',
-                    'grid-cols-[minmax(auto,1.75rem)_minmax(100px,auto)_1fr] sm:grid-cols-[minmax(auto,1.75rem)_1fr_auto] lg:grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)]',
-                    "[grid-template-areas:'number_address_delta'_'number_address_balance'_'number_address_size'] lg:[grid-template-areas:'number_address_delta_balance']",
-                    'border-1 border-b border-white/10 [border-bottom-style:solid] last:border-b-0',
-                )}
-            >
-                <div className="mr-2 text-outer-space-300 [grid-area:number] lg:mr-0">{index + 1}</div>
-                <div className="[grid-area:address]">
-                    <div className="flex items-center justify-between gap-1 lg:justify-normal">
-                        <Address pubkey={pubkey} link fetchTokenLabelInfo />
-                    </div>
-                    {hasBadges && (
-                        <span className="mt-1 inline-flex flex-wrap gap-1">
-                            {badges}
-                            {isLg && dataCell}
-                        </span>
-                    )}
-                </div>
-                <div className="justify-self-end [grid-area:delta]">
-                    <BalanceDelta delta={delta} isSol />
-                </div>
-                <div className="justify-self-end [grid-area:balance]">
-                    <SolBalance lamports={post} />
-                </div>
-                {!isLg && <div className="justify-self-end [grid-area:size]">{dataCell}</div>}
-            </div>
+            <TransactionAccountRow
+                key={pubkeyStr}
+                account={account}
+                accountInfo={accounts.get(pubkeyStr)}
+                accountInfoLoading={loading}
+                index={index}
+                message={message}
+                post={meta.postBalances[index]}
+                pre={meta.preBalances[index]}
+            />
         );
     });
 
@@ -149,7 +203,7 @@ export function AccountsCard({ signature }: SignatureProps) {
             <div
                 className={cn(
                     'hidden px-3 py-1.5 md:px-4 lg:grid',
-                    'grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)] gap-5 text-xs uppercase text-outer-space-300',
+                    'grid-cols-[minmax(auto,1.25rem)_1fr_minmax(auto,170px)_minmax(auto,180px)_2rem] gap-5 text-xs uppercase text-outer-space-300',
                     'border-1 border-b border-white/10 [border-bottom-style:solid]',
                 )}
             >
@@ -157,6 +211,7 @@ export function AccountsCard({ signature }: SignatureProps) {
                 <div>Address</div>
                 <div className="text-right">Change (SOL)</div>
                 <div className="text-right">Post Balance (SOL)</div>
+                <div />
             </div>
             {accountRows}
             {!loading && totalAccountSize > 0 && (

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -216,7 +216,11 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
                             <span className="d-none d-md-inline">Inspect</span>
                         </Link>
                     </Button>
-                    <RefreshButton fetching={autoRefresh === AutoRefresh.Active} analyticsSection="transaction_card" onClick={() => fetchStatus(signature)} />
+                    <RefreshButton
+                        fetching={autoRefresh === AutoRefresh.Active}
+                        analyticsSection="transaction_card"
+                        onClick={() => fetchStatus(signature)}
+                    />
                     <DownloadDropdown
                         filename={signature}
                         data={serializedRawData}

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -216,11 +216,7 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
                             <span className="d-none d-md-inline">Inspect</span>
                         </Link>
                     </Button>
-                    {autoRefresh === AutoRefresh.Active ? (
-                        <span className="spinner-grow spinner-grow-sm"></span>
-                    ) : (
-                        <RefreshButton analyticsSection="transaction_card" onClick={() => fetchStatus(signature)} />
-                    )}
+                    <RefreshButton fetching={autoRefresh === AutoRefresh.Active} analyticsSection="transaction_card" onClick={() => fetchStatus(signature)} />
                     <DownloadDropdown
                         filename={signature}
                         data={serializedRawData}

--- a/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { expect, within } from 'storybook/test';
 
 import { AccountBadges } from '../AccountBadges';

--- a/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 import { expect, within } from 'storybook/test';
 
 import { AccountBadges } from '../AccountBadges';

--- a/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
@@ -1,10 +1,11 @@
+import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from 'storybook/test';
 
 import { AccountBadges } from '../AccountBadges';
 
-const PUBKEY = new PublicKey('9noXzpXnkyEcKF3AeXqUHTdR59V5uvrRBUZ9bwfQwxNq');
+const PUBKEY = new PublicKey(gen.blockhash(1));
 
 const baseAccount: ParsedMessageAccount = {
     pubkey: PUBKEY,

--- a/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
@@ -1,0 +1,110 @@
+import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { AccountBadges } from '../AccountBadges';
+
+const PUBKEY = new PublicKey('9noXzpXnkyEcKF3AeXqUHTdR59V5uvrRBUZ9bwfQwxNq');
+
+const baseAccount: ParsedMessageAccount = {
+    pubkey: PUBKEY,
+    signer: false,
+    source: 'transaction',
+    writable: false,
+};
+
+const baseMessage = {
+    accountKeys: [],
+    addressTableLookups: [],
+    instructions: [],
+    recentBlockhash: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+} as unknown as ParsedMessage;
+
+const meta: Meta<typeof AccountBadges> = {
+    args: {
+        account: baseAccount,
+        index: 1,
+        message: baseMessage,
+        pubkey: PUBKEY,
+    },
+    component: AccountBadges,
+    tags: ['autodocs', 'test'],
+    title: 'Features/Transaction/AccountBadges',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FeePayer: Story = {
+    args: { index: 0 },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Fee Payer')).toBeInTheDocument();
+    },
+};
+
+export const Signer: Story = {
+    args: { account: { ...baseAccount, signer: true } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Signer')).toBeInTheDocument();
+    },
+};
+
+export const Writable: Story = {
+    args: { account: { ...baseAccount, writable: true } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Writable')).toBeInTheDocument();
+    },
+};
+
+export const Program: Story = {
+    args: {
+        message: {
+            ...baseMessage,
+            instructions: [{ programId: PUBKEY } as unknown as ParsedMessage['instructions'][0]],
+        },
+        pubkey: PUBKEY,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Program')).toBeInTheDocument();
+    },
+};
+
+export const LookupTable: Story = {
+    args: { account: { ...baseAccount, source: 'lookupTable' } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Address Table Lookup')).toBeInTheDocument();
+    },
+};
+
+export const AllBadges: Story = {
+    args: {
+        account: { ...baseAccount, signer: true, writable: true },
+        index: 0,
+        message: {
+            ...baseMessage,
+            instructions: [{ programId: PUBKEY } as unknown as ParsedMessage['instructions'][0]],
+        },
+        pubkey: PUBKEY,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Fee Payer')).toBeInTheDocument();
+        expect(canvas.getByText('Signer')).toBeInTheDocument();
+        expect(canvas.getByText('Writable')).toBeInTheDocument();
+        expect(canvas.getByText('Program')).toBeInTheDocument();
+    },
+};
+
+export const NoBadges: Story = {
+    args: { index: 1 },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.queryByText('Fee Payer')).not.toBeInTheDocument();
+        expect(canvas.queryByText('Signer')).not.toBeInTheDocument();
+    },
+};

--- a/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountBadges.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from 'storybook/test';
 
 import { AccountBadges } from '../AccountBadges';

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -1,0 +1,81 @@
+import { ClusterProvider } from '@providers/cluster';
+import { ParsedMessage, ParsedMessageAccount, PublicKey, SystemProgram } from '@solana/web3.js';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
+import { MockTokenInfoBatchProvider } from '@storybook-config/__mocks__/MockTokenInfoBatchProvider';
+import { nextjsParameters } from '@storybook-config/decorators';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { AccountDetailSlideover } from '../AccountDetailSlideover';
+
+const FEE_PAYER = new PublicKey('9noXzpXnkyEcKF3AeXqUHTdR59V5uvrRBUZ9bwfQwxNq');
+
+const mockAccount: ParsedMessageAccount = {
+    pubkey: FEE_PAYER,
+    signer: true,
+    source: 'transaction',
+    writable: true,
+};
+
+const mockMessage = {
+    accountKeys: [mockAccount],
+    addressTableLookups: [],
+    instructions: [],
+    recentBlockhash: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+} as unknown as ParsedMessage;
+
+const meta: Meta<typeof AccountDetailSlideover> = {
+    args: {
+        account: mockAccount,
+        accountInfoLoading: false,
+        index: 0,
+        message: mockMessage,
+        onOpenChange: fn(),
+        open: true,
+    },
+    component: AccountDetailSlideover,
+    decorators: [
+        Story => (
+            <ClusterProvider>
+                <MockTokenInfoBatchProvider>
+                    <MockAccountsProvider>
+                        <Story />
+                    </MockAccountsProvider>
+                </MockTokenInfoBatchProvider>
+            </ClusterProvider>
+        ),
+    ],
+    parameters: {
+        ...nextjsParameters,
+        // Render at mobile viewport to match intended use case
+        viewport: { defaultViewport: 'mobile1' },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Features/Transaction/AccountDetailSlideover',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        account: {
+            pubkey: new PublicKey(SystemProgram.programId),
+            signer: false,
+            source: 'transaction',
+            writable: false,
+        },
+        index: 3,
+        message: {
+            ...mockMessage,
+            instructions: [
+                { programId: new PublicKey(SystemProgram.programId) } as unknown as ParsedMessage['instructions'][0],
+            ],
+        },
+    },
+    play: async () => {
+        const body = within(document.body);
+        await body.findByRole('dialog');
+        expect(body.getByText('Account 4')).toBeInTheDocument();
+    },
+};

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, fn, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
 import { MockTokenInfoBatchProvider } from '@storybook-config/__mocks__/MockTokenInfoBatchProvider';
 import { nextjsParameters } from '@storybook-config/decorators';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 
 import { AccountDetailSlideover } from '../AccountDetailSlideover';
 

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, fn, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -1,6 +1,6 @@
 import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { Meta, StoryObj } from '@storybook/react';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, fn, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountDetailSlideover.stories.tsx
@@ -1,14 +1,12 @@
-import { ClusterProvider } from '@providers/cluster';
+import { gen } from '@__fixtures__/gen';
 import { ParsedMessage, ParsedMessageAccount, PublicKey, SystemProgram } from '@solana/web3.js';
 import type { Meta, StoryObj } from '@storybook/react';
-import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
-import { MockTokenInfoBatchProvider } from '@storybook-config/__mocks__/MockTokenInfoBatchProvider';
-import { nextjsParameters } from '@storybook-config/decorators';
+import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, fn, within } from 'storybook/test';
 
 import { AccountDetailSlideover } from '../AccountDetailSlideover';
 
-const FEE_PAYER = new PublicKey('9noXzpXnkyEcKF3AeXqUHTdR59V5uvrRBUZ9bwfQwxNq');
+const FEE_PAYER = new PublicKey(gen.blockhash(2));
 
 const mockAccount: ParsedMessageAccount = {
     pubkey: FEE_PAYER,
@@ -21,7 +19,7 @@ const mockMessage = {
     accountKeys: [mockAccount],
     addressTableLookups: [],
     instructions: [],
-    recentBlockhash: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+    recentBlockhash: gen.blockhash(0),
 } as unknown as ParsedMessage;
 
 const meta: Meta<typeof AccountDetailSlideover> = {
@@ -34,24 +32,14 @@ const meta: Meta<typeof AccountDetailSlideover> = {
         open: true,
     },
     component: AccountDetailSlideover,
-    decorators: [
-        Story => (
-            <ClusterProvider>
-                <MockTokenInfoBatchProvider>
-                    <MockAccountsProvider>
-                        <Story />
-                    </MockAccountsProvider>
-                </MockTokenInfoBatchProvider>
-            </ClusterProvider>
-        ),
-    ],
+    decorators: [withClusterAccountsAndTokenInfo],
     parameters: {
         ...nextjsParameters,
         // Render at mobile viewport to match intended use case
         viewport: { defaultViewport: 'mobile1' },
     },
     tags: ['autodocs', 'test'],
-    title: 'Features/Transaction/AccountDetailSlideover',
+    title: 'Features/Transaction/AccountDetailSlideover@Media',
 };
 
 export default meta;

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -1,5 +1,5 @@
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -59,10 +59,10 @@ export const Loading: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
         // Shows skeleton loaders while fetching
-        const skeletons = canvasElement.querySelectorAll('[class*="skeleton"], [class*="Skeleton"]');
+        const skeletons = canvasElement.querySelectorAll('[class*="e-animate-pulse"]');
         // No account data labels while loading
         expect(canvas.queryByText('Assigned Program Id')).not.toBeInTheDocument();
-        expect(skeletons.length).toBeGreaterThanOrEqual(0);
+        expect(skeletons.length).toBeGreaterThan(0);
     },
 };
 

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -1,5 +1,5 @@
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -1,9 +1,6 @@
-import { ClusterProvider } from '@providers/cluster';
 import { PublicKey, SystemProgram } from '@solana/web3.js';
 import type { Meta, StoryObj } from '@storybook/react';
-import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
-import { MockTokenInfoBatchProvider } from '@storybook-config/__mocks__/MockTokenInfoBatchProvider';
-import { nextjsParameters } from '@storybook-config/decorators';
+import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, within } from 'storybook/test';
 
 import { AccountExpandedContent } from '../AccountExpandedContent';
@@ -17,17 +14,7 @@ const meta: Meta<typeof AccountExpandedContent> = {
         enabled: true,
     },
     component: AccountExpandedContent,
-    decorators: [
-        Story => (
-            <ClusterProvider>
-                <MockTokenInfoBatchProvider>
-                    <MockAccountsProvider>
-                        <Story />
-                    </MockAccountsProvider>
-                </MockTokenInfoBatchProvider>
-            </ClusterProvider>
-        ),
-    ],
+    decorators: [withClusterAccountsAndTokenInfo],
     parameters: {
         ...nextjsParameters,
     },

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -46,7 +46,7 @@ export const Loading: Story = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
         // Shows skeleton loaders while fetching
-        const skeletons = canvasElement.querySelectorAll('[class*="e-animate-pulse"]');
+        const skeletons = canvasElement.querySelectorAll('[class*="animate-pulse"]');
         // No account data labels while loading
         expect(canvas.queryByText('Assigned Program Id')).not.toBeInTheDocument();
         expect(skeletons.length).toBeGreaterThan(0);

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -1,0 +1,103 @@
+import { ClusterProvider } from '@providers/cluster';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockAccountsProvider } from '@storybook-config/__mocks__/MockAccountsProvider';
+import { MockTokenInfoBatchProvider } from '@storybook-config/__mocks__/MockTokenInfoBatchProvider';
+import { nextjsParameters } from '@storybook-config/decorators';
+import { expect, within } from 'storybook/test';
+
+import { AccountExpandedContent } from '../AccountExpandedContent';
+
+const SYSTEM_PROGRAM_ADDRESS = SystemProgram.programId.toBase58();
+const UNKNOWN_ADDRESS = new PublicKey('So11111111111111111111111111111111111111112').toBase58();
+
+const meta: Meta<typeof AccountExpandedContent> = {
+    args: {
+        address: SYSTEM_PROGRAM_ADDRESS,
+        enabled: true,
+    },
+    component: AccountExpandedContent,
+    decorators: [
+        Story => (
+            <ClusterProvider>
+                <MockTokenInfoBatchProvider>
+                    <MockAccountsProvider>
+                        <Story />
+                    </MockAccountsProvider>
+                </MockTokenInfoBatchProvider>
+            </ClusterProvider>
+        ),
+    ],
+    parameters: {
+        ...nextjsParameters,
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Features/Transaction/AccountExpandedContent',
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loaded: Story = {
+    args: {
+        address: SYSTEM_PROGRAM_ADDRESS,
+        enabled: true,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Assigned Program Id')).toBeInTheDocument();
+        expect(canvas.getByText('Executable')).toBeInTheDocument();
+        expect(canvas.getByText('Balance')).toBeInTheDocument();
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        address: UNKNOWN_ADDRESS,
+        enabled: true,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        // Shows skeleton loaders while fetching
+        const skeletons = canvasElement.querySelectorAll('[class*="skeleton"], [class*="Skeleton"]');
+        // No account data labels while loading
+        expect(canvas.queryByText('Assigned Program Id')).not.toBeInTheDocument();
+        expect(skeletons.length).toBeGreaterThanOrEqual(0);
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        address: SYSTEM_PROGRAM_ADDRESS,
+        enabled: false,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.queryByText('Assigned Program Id')).not.toBeInTheDocument();
+    },
+};
+
+export const FlatLayout: Story = {
+    args: {
+        address: SYSTEM_PROGRAM_ADDRESS,
+        enabled: true,
+        flat: true,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Assigned Program Id')).toBeInTheDocument();
+    },
+};
+
+export const WithAccountInfo: Story = {
+    args: {
+        accountInfo: { data: new Uint8Array(0), size: 1024 },
+        address: SYSTEM_PROGRAM_ADDRESS,
+        enabled: true,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Assigned Program Id')).toBeInTheDocument();
+        expect(canvas.getByText('1,024 byte(s)')).toBeInTheDocument();
+    },
+};

--- a/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
+++ b/app/features/transaction/ui/__stories__/AccountExpandedContent.stories.tsx
@@ -1,5 +1,5 @@
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { Meta, StoryObj } from '@storybook/react';
 import { nextjsParameters, withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import { expect, within } from 'storybook/test';
 

--- a/app/features/transaction/ui/__tests__/AccountDetailSlideover.test.tsx
+++ b/app/features/transaction/ui/__tests__/AccountDetailSlideover.test.tsx
@@ -1,0 +1,93 @@
+import { type ParsedMessage, PublicKey } from '@solana/web3.js';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AccountDetailSlideover } from '../AccountDetailSlideover';
+
+vi.mock('next/link', () => ({
+    default: ({ children, href, ...props }: ComponentProps<'a'> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/app/features/nicknames', () => ({
+    NicknameEditor: ({ address, onClose }: { address: string; onClose: () => void }) => (
+        <div>
+            <input
+                aria-label={`Nickname input for ${address}`}
+                autoFocus
+                onKeyDown={event => {
+                    if (event.key === 'Escape') onClose();
+                }}
+            />
+        </div>
+    ),
+    useNickname: vi.fn(() => null),
+}));
+
+vi.mock('@/app/shared/lib/useCopyToClipboard', () => ({
+    useCopyToClipboard: () => ['idle', vi.fn()] as const,
+}));
+
+vi.mock('@utils/url', () => ({
+    useClusterPath: () => '/address/test',
+}));
+
+vi.mock('../AccountBadges', () => ({
+    AccountBadges: () => <div>Account badges</div>,
+}));
+
+vi.mock('../AccountExpandedContent', () => ({
+    AccountExpandedContent: () => <div>Account expanded content</div>,
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+const pubkey = new PublicKey('11111111111111111111111111111111');
+
+describe('AccountDetailSlideover', () => {
+    it('should close the slideover on Escape when the nickname editor is closed', () => {
+        const onOpenChange = vi.fn();
+
+        renderSlideover({ onOpenChange });
+        fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should keep the slideover open when Escape closes the nickname editor', () => {
+        const onOpenChange = vi.fn();
+
+        renderSlideover({ onOpenChange });
+        fireEvent.click(screen.getByRole('button', { name: 'Nickname' }));
+
+        const input = screen.getByLabelText(`Nickname input for ${pubkey.toBase58()}`);
+        fireEvent.keyDown(input, { key: 'Escape' });
+
+        expect(screen.queryByLabelText(`Nickname input for ${pubkey.toBase58()}`)).not.toBeInTheDocument();
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+});
+
+function renderSlideover({ onOpenChange = vi.fn() }: { onOpenChange?: (open: boolean) => void } = {}) {
+    render(
+        <AccountDetailSlideover
+            account={{
+                pubkey,
+                signer: false,
+                source: 'transaction',
+                writable: false,
+            }}
+            accountInfoLoading={false}
+            index={0}
+            message={{} as ParsedMessage}
+            onOpenChange={onOpenChange}
+            open
+        />,
+    );
+}

--- a/app/shared/lib/__tests__/use-breakpoint.spec.ts
+++ b/app/shared/lib/__tests__/use-breakpoint.spec.ts
@@ -6,16 +6,22 @@ import { useBreakpoint } from '../use-breakpoint';
 // Breakpoint pixel values from tailwind.config.ts
 const BP = { lg: 992, md: 768, sm: 576, xl: 1200, xs: 375, xxl: 1400 } as const;
 
-function mockMatchMedia(width: number) {
+function mockMatchMedia(width: number, isLandscape = false) {
     vi.spyOn(globalThis, 'matchMedia').mockImplementation((query: string) => {
-        // eslint-disable-next-line no-restricted-syntax -- need regex to parse CSS media query string from matchMedia
-        const m = query.match(/\(min-width:\s*(\d+)px\)/);
-        const minWidth = m ? parseInt(m[1], 10) : 0;
+        let matches: boolean;
+        if (query.includes('orientation: landscape')) {
+            matches = isLandscape;
+        } else {
+            // eslint-disable-next-line no-restricted-syntax -- need regex to parse CSS media query string from matchMedia
+            const m = query.match(/\(min-width:\s*(\d+)px\)/);
+            const minWidth = m ? parseInt(m[1], 10) : 0;
+            matches = width >= minWidth;
+        }
         return {
             addEventListener: vi.fn(),
             addListener: vi.fn(),
             dispatchEvent: vi.fn(),
-            matches: width >= minWidth,
+            matches,
             media: query,
             onchange: null,
             removeEventListener: vi.fn(),
@@ -33,6 +39,7 @@ describe('useBreakpoint', () => {
         mockMatchMedia(BP.xs - 1);
         const { result } = renderHook(() => useBreakpoint());
         expect(result.current).toEqual({
+            isLandscape: false,
             isLg: false,
             isMd: false,
             isSm: false,
@@ -87,6 +94,7 @@ describe('useBreakpoint', () => {
         mockMatchMedia(BP.xxl);
         const { result } = renderHook(() => useBreakpoint());
         expect(result.current).toEqual({
+            isLandscape: false,
             isLg: true,
             isMd: true,
             isSm: true,
@@ -141,7 +149,7 @@ describe('useBreakpoint', () => {
         const { unmount } = renderHook(() => useBreakpoint());
         unmount();
 
-        // 6 queries (xs, sm, md, lg, xl, 2xl) × 1 removeEventListener each
-        expect(removeEventListener).toHaveBeenCalledTimes(6);
+        // 7 queries (xs, sm, md, lg, xl, 2xl, landscape) × 1 removeEventListener each
+        expect(removeEventListener).toHaveBeenCalledTimes(7);
     });
 });

--- a/app/shared/lib/use-breakpoint.ts
+++ b/app/shared/lib/use-breakpoint.ts
@@ -32,6 +32,7 @@ export function useBreakpoint() {
     const isLg = useMediaQuery(`(min-width: ${bp('lg')}px)`);
     const isXl = useMediaQuery(`(min-width: ${bp('xl')}px)`);
     const isXxl = useMediaQuery(`(min-width: ${bp('xxl')}px)`);
+    const isLandscape = useMediaQuery('(orientation: landscape)');
 
-    return { isLg, isMd, isSm, isXl, isXs, isXxl };
+    return { isLandscape, isLg, isMd, isSm, isXl, isXs, isXxl };
 }

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -54,6 +54,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 600 kB | 1.61 MB |
-| Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.40 MB |
-| Static | `/tx/inspector` | 390 kB | 1.40 MB |
+| Dynamic | `/tx/[signature]` | 610 kB | 1.62 MB |
+| Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.41 MB |
+| Static | `/tx/inspector` | 390 kB | 1.41 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -54,6 +54,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 560 kB | 1.57 MB |
-| Dynamic | `/tx/[signature]/inspect` | 350 kB | 1.36 MB |
-| Static | `/tx/inspector` | 350 kB | 1.36 MB |
+| Dynamic | `/tx/[signature]` | 600 kB | 1.61 MB |
+| Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.40 MB |
+| Static | `/tx/inspector` | 390 kB | 1.40 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -54,6 +54,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 610 kB | 1.62 MB |
+| Dynamic | `/tx/[signature]` | 610 kB | 1.63 MB |
 | Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.41 MB |
 | Static | `/tx/inspector` | 390 kB | 1.41 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -54,6 +54,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 610 kB | 1.63 MB |
+| Dynamic | `/tx/[signature]` | 610 kB | 1.62 MB |
 | Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.41 MB |
 | Static | `/tx/inspector` | 390 kB | 1.41 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -25,7 +25,7 @@
 | Dynamic | `/address/[address]/slot-hashes` | 320 kB | 1.34 MB |
 | Dynamic | `/address/[address]/stake-history` | 320 kB | 1.34 MB |
 | Dynamic | `/address/[address]/token-extensions` | 320 kB | 1.34 MB |
-| Dynamic | `/address/[address]/tokens` | 450 kB | 1.47 MB |
+| Dynamic | `/address/[address]/tokens` | 460 kB | 1.47 MB |
 | Dynamic | `/address/[address]/transfers` | 370 kB | 1.38 MB |
 | Dynamic | `/address/[address]/verified-build` | 320 kB | 1.34 MB |
 | Dynamic | `/address/[address]/vote-history` | 320 kB | 1.34 MB |
@@ -54,6 +54,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 610 kB | 1.62 MB |
-| Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.41 MB |
-| Static | `/tx/inspector` | 390 kB | 1.41 MB |
+| Dynamic | `/tx/[signature]` | 570 kB | 1.59 MB |
+| Dynamic | `/tx/[signature]/inspect` | 350 kB | 1.36 MB |
+| Static | `/tx/inspector` | 350 kB | 1.36 MB |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -390,7 +390,6 @@ export default tseslint.config(
             'app/features/search/api/discover-with-utl.ts',
             'app/features/search/api/resolve-search-tokens.ts',
             'app/features/stake/ui/StakeAccountSection.tsx',
-            'app/features/transaction/ui/AccountDetailSheet.tsx',
             'app/features/transaction/ui/AccountDetailSlideover.tsx',
             'app/features/transaction/ui/InstructionsSection.tsx',
             'app/features/transaction/ui/SummaryCard.tsx',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -390,6 +390,8 @@ export default tseslint.config(
             'app/features/search/api/discover-with-utl.ts',
             'app/features/search/api/resolve-search-tokens.ts',
             'app/features/stake/ui/StakeAccountSection.tsx',
+            'app/features/transaction/ui/AccountDetailSheet.tsx',
+            'app/features/transaction/ui/AccountDetailSlideover.tsx',
             'app/features/transaction/ui/InstructionsSection.tsx',
             'app/features/transaction/ui/SummaryCard.tsx',
 

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
         "storybook": "catalog:storybook",
         "styled-jsx": "5.1.6",
         "tailwindcss": "3.4.17",
+        "tailwindcss-animate": "^1.0.7",
         "tsx": "4.21.0",
         "typescript-eslint": "8.57.1",
         "vite-plugin-node-polyfills": "0.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,9 @@ importers:
       tailwindcss:
         specifier: 3.4.17
         version: 3.4.17
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.17)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -10392,6 +10395,11 @@ packages:
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -23880,6 +23888,10 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tailwind-merge@2.6.1: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
+    dependencies:
+      tailwindcss: 3.4.17
 
   tailwindcss@3.4.17:
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from 'tailwindcss';
 import plugin from 'tailwindcss/plugin';
+import tailwindcssAnimate from 'tailwindcss-animate';
 
 export const breakpoints = new Map([
     ['xxs', 320],
@@ -59,6 +60,7 @@ export const dkColors = {
 const config: Config = {
     content: ['./app/**/*.{ts,tsx}'],
     plugins: [
+        tailwindcssAnimate,
         plugin(({ addUtilities }) => {
             addUtilities({
                 '.scrollbar-hide': {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -221,6 +221,7 @@ const config: Config = {
             tablet: getScreenDim('md'),
             laptop: getScreenDim('lg'),
             desktop: getScreenDim('xl'),
+            landscape: { raw: '(orientation: landscape)' },
         },
     },
 };


### PR DESCRIPTION
## Description
- adding extra information for account row on tx page

## Type of change
-   [x] New feature

## Screenshots
<img width="408" height="697" alt="Screenshot 2026-06-11 at 18 54 05" src="https://github.com/user-attachments/assets/78393238-a030-4979-aa50-ba1762f8fc89" />

<img width="400" height="696" alt="Screenshot 2026-06-11 at 18 45 42" src="https://github.com/user-attachments/assets/db816351-c874-40e3-b6c8-db5270ad2f17" />
<img width="404" height="688" alt="Screenshot 2026-06-11 at 18 47 43" src="https://github.com/user-attachments/assets/8559bf56-501d-4785-be8f-52f9c894b5f3" />
<img width="1101" height="838" alt="Screenshot 2026-06-11 at 18 48 33" src="https://github.com/user-attachments/assets/c5dfdbba-50a3-4a4f-a87f-8e7c8e3c750f" />

## Testing
- open [tx page](https://explorer-aaav8qvqc-solana-foundation.vercel.app/tx/4arxSRyYA9gzuyXA6EJN4ab49yC2fe8FG9vcNki26nUd1YGiN3ZcghHizq9NEyiPzeoDgZjymZfqRo4PhaW3aA1P)
- check mobile and desktop

## Related Issues
[HOO-595](https://linear.app/solana-fndn/issue/HOO-595/account-row-update)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes