### PR TITLE
Feat lookup for signatures at other clusters

### DIFF
--- a/app/features/transaction/model/__tests__/use-cluster-transaction-search.spec.ts
+++ b/app/features/transaction/model/__tests__/use-cluster-transaction-search.spec.ts
@@ -1,0 +1,116 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Cluster } from '@/app/utils/cluster';
+
+const mockSend = vi.fn();
+
+vi.mock('next/navigation', () => ({
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
+    return {
+        ...actual,
+        createSolanaRpc: vi.fn(() => ({
+            getSignatureStatuses: vi.fn(() => ({ send: mockSend })),
+        })),
+    };
+});
+
+const TEST_SIGNATURE = '5UfDuX7hXbPjSUQPBfRBLRYoy4SZJvfP18VpoYz75Y4P6yCWNxbEq1RCfxGvod7U1PArBAkQbE4yLrdaAiZBmGEs';
+
+const NOT_FOUND = { value: [null] };
+const FOUND = { value: [{ confirmationStatus: 'finalized', confirmations: null, err: null, slot: 100 }] };
+
+describe('useClusterTransactionSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.clearAllMocks();
+        mockSend.mockResolvedValue(NOT_FOUND);
+        vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as ReturnType<typeof useSearchParams>);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should start in the searching state', async () => {
+        // Keep probes pending so the hook stays in "searching"
+        mockSend.mockReturnValue(new Promise(() => {}));
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        const { result } = renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.MainnetBeta));
+
+        await waitFor(() => expect(result.current.status).toBe('searching'));
+        expect(result.current.searchingCluster).toBe(Cluster.Devnet);
+    });
+
+    it('should report the cluster where the signature is found', async () => {
+        mockSend.mockResolvedValueOnce(FOUND);
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        const { result } = renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.Devnet));
+
+        await waitFor(() => expect(result.current.status).toBe('found'));
+        // Devnet is the current cluster and excluded, so MainnetBeta is probed first
+        expect(result.current.foundCluster).toBe(Cluster.MainnetBeta);
+    });
+
+    it('should report not-found after probing every public cluster', async () => {
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        const { result } = renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.MainnetBeta));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        await waitFor(() => expect(result.current.status).toBe('not-found'));
+        expect(result.current.foundCluster).toBeUndefined();
+        expect(result.current.searchingCluster).toBeUndefined();
+    });
+
+    it('should exclude the current cluster from the probe list', async () => {
+        const { createSolanaRpc } = await import('@solana/kit');
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.MainnetBeta));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        // MainnetBeta is current, so only Devnet + Testnet are probed
+        expect(vi.mocked(createSolanaRpc)).toHaveBeenCalledTimes(2);
+    });
+
+    it('should probe the custom RPC URL when customUrl is present', async () => {
+        vi.mocked(useSearchParams).mockReturnValue(
+            new URLSearchParams('customUrl=https://my.custom.rpc') as ReturnType<typeof useSearchParams>,
+        );
+        const { createSolanaRpc } = await import('@solana/kit');
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.MainnetBeta));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(vi.mocked(createSolanaRpc)).toHaveBeenCalledWith('https://my.custom.rpc');
+    });
+
+    it('should continue probing when a cluster errors', async () => {
+        mockSend.mockRejectedValueOnce(new Error('RPC unreachable')).mockResolvedValueOnce(FOUND);
+        const { useClusterTransactionSearch } = await import('../use-cluster-transaction-search');
+
+        const { result } = renderHook(() => useClusterTransactionSearch(TEST_SIGNATURE, Cluster.MainnetBeta));
+
+        await waitFor(() => expect(result.current.status).toBe('found'));
+        // First probe (Devnet) rejects, second probe (Testnet) resolves as found
+        expect(result.current.foundCluster).toBe(Cluster.Testnet);
+    });
+});

--- a/app/features/transaction/model/use-cluster-transaction-search.ts
+++ b/app/features/transaction/model/use-cluster-transaction-search.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+import { Cluster, clusterUrl } from '@utils/cluster';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+export type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
+
+export interface ClusterTransactionSearch {
+    status: SearchStatus;
+    searchingCluster: Cluster | undefined;
+    foundCluster: Cluster | undefined;
+}
+
+// Canonical, durable public clusters. Cluster.Simd296 is a temporary surfnet, so matches there
+// aren't linkable later; Cluster.Custom is appended only when a custom RPC URL is configured.
+const PUBLIC_CLUSTERS = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet];
+const PROBE_DELAY_MS = 700;
+
+/**
+ * Probes the other public clusters (and an optional custom RPC) for a signature that was not
+ * found on the current cluster, reporting which cluster is being checked and where it was found.
+ */
+export function useClusterTransactionSearch(signature: string, currentCluster: Cluster): ClusterTransactionSearch {
+    const searchParams = useSearchParams();
+    const customUrl = searchParams?.get('customUrl');
+
+    const [status, setStatus] = useState<SearchStatus>('idle');
+    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
+    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
+
+    // Monotonic id used to cancel a search whose inputs changed before it finished.
+    const searchIdRef = useRef(0);
+
+    useEffect(() => {
+        const searchId = ++searchIdRef.current;
+        const isStale = () => searchIdRef.current !== searchId;
+        const clusters = getClustersToProbe(currentCluster, customUrl);
+
+        async function searchClusters() {
+            setStatus('searching');
+            setFoundCluster(undefined);
+
+            for (const [index, cluster] of clusters.entries()) {
+                if (isStale()) return;
+                setSearchingCluster(cluster);
+
+                let found: boolean;
+                try {
+                    found = await probeClusterForSignature(signature, cluster, customUrl);
+                } catch {
+                    // Ignore probe errors (unreachable RPC, etc.) and try the next cluster
+                    continue;
+                }
+
+                if (isStale()) return;
+
+                if (found) {
+                    setFoundCluster(cluster);
+                    setStatus('found');
+                    return;
+                }
+
+                // Only pace between checks; skip the trailing delay so not-found shows immediately
+                const isLastCluster = index === clusters.length - 1;
+                if (!isLastCluster) await sleep(PROBE_DELAY_MS);
+            }
+
+            if (isStale()) return;
+            setStatus('not-found');
+            setSearchingCluster(undefined);
+        }
+
+        searchClusters();
+
+        return () => {
+            // Invalidate this run so an in-flight probe cannot commit stale state after cleanup.
+            if (!isStale()) searchIdRef.current += 1;
+        };
+    }, [signature, currentCluster, customUrl]);
+
+    return { foundCluster, searchingCluster, status };
+}
+
+function getClustersToProbe(currentCluster: Cluster, customUrl: string | null | undefined): Cluster[] {
+    const clusters = PUBLIC_CLUSTERS.filter(cluster => cluster !== currentCluster);
+    if (customUrl) {
+        clusters.push(Cluster.Custom);
+    }
+    return clusters;
+}
+
+async function probeClusterForSignature(
+    signature: string,
+    cluster: Cluster,
+    customUrl: string | null | undefined,
+): Promise<boolean> {
+    const url = customUrl && cluster === Cluster.Custom ? customUrl : clusterUrl(cluster, '');
+    const rpc = createSolanaRpc(url);
+    const { value } = await rpc
+        .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
+        .send();
+
+    // RPC returns literal null for missing signatures per JSON-RPC spec
+    return value[0] !== null;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/app/features/transaction/ui/BaseTransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/BaseTransactionNotFoundCard.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@components/shared/ui/button';
+import React from 'react';
+
+import { Card, CardBody } from '@/app/shared/ui/Card';
+
+interface BaseTransactionNotFoundCardProps {
+    retry?: () => void;
+    subtext?: React.ReactNode;
+    buttonText?: string;
+}
+
+export function BaseTransactionNotFoundCard({
+    retry,
+    subtext,
+    buttonText = 'Try Again',
+}: BaseTransactionNotFoundCardProps) {
+    return (
+        <Card ui="dashkit">
+            <CardBody ui="dashkit" className="text-center">
+                Not Found
+                {retry && (
+                    <>
+                        <Button ui="dashkit" variant="white" className="ml-3 hidden md:inline" onClick={retry} asChild>
+                            <span>{buttonText}</span>
+                        </Button>
+                        <div className="mt-6 block md:hidden">
+                            <Button ui="dashkit" variant="white" className="w-full" onClick={retry} asChild>
+                                <span>{buttonText}</span>
+                            </Button>
+                        </div>
+                    </>
+                )}
+                {subtext && (
+                    <div className="text-dk-gray-700">
+                        <hr />
+                        {subtext}
+                    </div>
+                )}
+            </CardBody>
+        </Card>
+    );
+}

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -36,6 +36,8 @@ import { AUTO_REFRESH_INTERVAL, AutoRefresh, WithAutoRefreshProp } from '@/app/s
 import { Card } from '@/app/shared/ui/Card';
 import { getEpochForSlot } from '@/app/utils/epoch-schedule';
 
+import { TransactionNotFoundCard } from './TransactionNotFoundCard';
+
 type RowProps = React.HTMLAttributes<HTMLDivElement> & { divider?: boolean };
 export function Row({ children, className, divider, ...props }: RowProps) {
     return (
@@ -139,16 +141,17 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
     } else if (status.status === FetchStatus.FetchFailed) {
         return <ErrorCard retry={() => fetchStatus(signature)} text="Fetch Failed" />;
     } else if (!status.data?.info) {
-        if (clusterInfo && clusterInfo.firstAvailableBlock > 0) {
-            return (
-                <ErrorCard
-                    retry={() => fetchStatus(signature)}
-                    text="Not Found"
-                    subtext={`Note: Transactions processed before block ${clusterInfo.firstAvailableBlock} are not available at this time`}
-                />
-            );
-        }
-        return <ErrorCard retry={() => fetchStatus(signature)} text="Not Found" />;
+        return (
+            <TransactionNotFoundCard
+                signature={signature}
+                retry={() => fetchStatus(signature)}
+                firstAvailableBlock={
+                    clusterInfo?.firstAvailableBlock && clusterInfo.firstAvailableBlock > 0n
+                        ? clusterInfo.firstAvailableBlock
+                        : undefined
+                }
+            />
+        );
     }
 
     const { info } = status.data;

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -10,116 +10,6 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { Card, CardBody } from '@/app/shared/ui/Card';
 
-type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
-
-function useClusterTransactionSearch(signature: string, currentCluster: Cluster) {
-    const searchParams = useSearchParams();
-    const [status, setStatus] = useState<SearchStatus>('idle');
-    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
-    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
-    const searchIdRef = useRef(0);
-
-    const sleep = () => new Promise(res => setTimeout(res, 700));
-
-    const customUrl = searchParams?.get('customUrl');
-
-    useEffect(() => {
-        const currentSearchId = ++searchIdRef.current;
-
-        const clusters = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet].filter(c => c !== currentCluster);
-        const hasCustomUrlEnabled = Boolean(customUrl);
-
-        if (hasCustomUrlEnabled) {
-            clusters.push(Cluster.Custom);
-        }
-
-        const searchClusters = async () => {
-            if (searchIdRef.current !== currentSearchId) return;
-
-            setStatus('searching');
-
-            for (const cluster of clusters) {
-                if (searchIdRef.current !== currentSearchId) return;
-
-                setSearchingCluster(cluster);
-
-                try {
-                    let url = clusterUrl(cluster, '');
-
-                    if (customUrl && cluster === Cluster.Custom) {
-                        url = customUrl;
-                    }
-
-                    const rpc = createSolanaRpc(url);
-                    const statusRes = await rpc
-                        .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
-                        .send();
-
-                    if (searchIdRef.current !== currentSearchId) return;
-
-                    if (statusRes.value[0] !== null) {
-                        setFoundCluster(cluster);
-                        setStatus('found');
-                        return;
-                    } else {
-                        await sleep();
-                    }
-                } catch (_error) {
-                    if (searchIdRef.current !== currentSearchId) return;
-                }
-            }
-
-            if (searchIdRef.current === currentSearchId) {
-                setStatus('not-found');
-                setSearchingCluster(undefined);
-            }
-        };
-
-        searchClusters();
-
-        return () => {
-            if (searchIdRef.current === currentSearchId) {
-                searchIdRef.current += 1;
-            }
-        };
-    }, [signature, currentCluster, customUrl]);
-
-    return { foundCluster, searchingCluster, status };
-}
-
-function AdjacentTransactionLink({ signature, foundCluster }: { signature: string; foundCluster: Cluster }) {
-    const moniker = clusterSlug(foundCluster);
-    const foundClusterPath = useClusterPath({
-        additionalParams: new URLSearchParams(`cluster=${moniker}`),
-        pathname: `/tx/${signature}`,
-    });
-
-    return (
-        <a href={foundClusterPath} className="e-align-middle e-text-dk-info" style={{ marginRight: '5px' }}>
-            Found on {clusterName(foundCluster)}
-        </a>
-    );
-}
-
-function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
-    const spinnerCls = 'spinner-grow spinner-grow-sm';
-
-    return (
-        <>
-            <span
-                style={{ height: '10px', marginRight: '5px', width: '10px' }}
-                className={`${spinnerCls} e-inline-block e-align-middle`}
-            />
-            <span
-                className="e-align-middle e-text-dk-gray-700"
-                style={{ marginRight: '10px', verticalAlign: 'middle' }}
-            >
-                checking {clusterName(searchingCluster).toLowerCase()}
-            </span>
-        </>
-    );
-}
-
 export function TransactionNotFoundCard({
     signature,
     retry,
@@ -185,5 +75,116 @@ export function TransactionNotFoundCard({
                 )}
             </CardBody>
         </Card>
+    );
+}
+
+type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
+
+function useClusterTransactionSearch(signature: string, currentCluster: Cluster) {
+    const searchParams = useSearchParams();
+    const [status, setStatus] = useState<SearchStatus>('idle');
+    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
+    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
+    const searchIdRef = useRef(0);
+
+    const sleep = () => new Promise(res => setTimeout(res, 700));
+
+    const customUrl = searchParams?.get('customUrl');
+
+    useEffect(() => {
+        const currentSearchId = ++searchIdRef.current;
+
+        const clusters = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet].filter(c => c !== currentCluster);
+        const hasCustomUrlEnabled = Boolean(customUrl);
+
+        if (hasCustomUrlEnabled) {
+            clusters.push(Cluster.Custom);
+        }
+
+        const searchClusters = async () => {
+            if (searchIdRef.current !== currentSearchId) return;
+
+            setStatus('searching');
+
+            for (const cluster of clusters) {
+                if (searchIdRef.current !== currentSearchId) return;
+
+                setSearchingCluster(cluster);
+
+                try {
+                    let url = clusterUrl(cluster, '');
+
+                    if (customUrl && cluster === Cluster.Custom) {
+                        url = customUrl;
+                    }
+
+                    const rpc = createSolanaRpc(url);
+                    const statusRes = await rpc
+                        .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
+                        .send();
+
+                    if (searchIdRef.current !== currentSearchId) return;
+
+                    // RPC returns literal null for missing signatures per JSON-RPC spec
+                    if (statusRes.value[0] !== null) {
+                        setFoundCluster(cluster);
+                        setStatus('found');
+                        return;
+                    } else {
+                        await sleep();
+                    }
+                } catch (_error) {
+                    if (searchIdRef.current !== currentSearchId) return;
+                }
+            }
+
+            if (searchIdRef.current === currentSearchId) {
+                setStatus('not-found');
+                setSearchingCluster(undefined);
+            }
+        };
+
+        searchClusters();
+
+        return () => {
+            if (searchIdRef.current === currentSearchId) {
+                searchIdRef.current += 1;
+            }
+        };
+    }, [signature, currentCluster, customUrl]);
+
+    return { foundCluster, searchingCluster, status };
+}
+
+function AdjacentTransactionLink({ signature, foundCluster }: { signature: string; foundCluster: Cluster }) {
+    const moniker = clusterSlug(foundCluster);
+    const foundClusterPath = useClusterPath({
+        additionalParams: new URLSearchParams(`cluster=${moniker}`),
+        pathname: `/tx/${signature}`,
+    });
+
+    return (
+        <a href={foundClusterPath} className="e-align-middle e-text-dk-info" style={{ marginRight: '5px' }}>
+            Found on {clusterName(foundCluster)}
+        </a>
+    );
+}
+
+function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
+    const spinnerCls = 'spinner-grow spinner-grow-sm';
+
+    return (
+        <>
+            <span
+                style={{ height: '10px', marginRight: '5px', width: '10px' }}
+                className={`${spinnerCls} e-inline-block e-align-middle`}
+            />
+            <span
+                className="e-align-middle e-text-dk-gray-700"
+                style={{ marginRight: '10px', verticalAlign: 'middle' }}
+            >
+                checking {clusterName(searchingCluster).toLowerCase()}
+            </span>
+        </>
     );
 }

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { Button } from '@components/shared/ui/button';
 import { useCluster } from '@providers/cluster';
-import { Button } from '@shared/ui/button';
 import { createSolanaRpc, signature as createSignature } from '@solana/kit';
 import { Cluster, clusterName, clusterSlug, clusterUrl } from '@utils/cluster';
 import { useClusterPath } from '@utils/url';
@@ -26,7 +26,7 @@ export function TransactionNotFoundCard({
     if (status === 'searching' && searchingCluster !== undefined) {
         subtext = (
             <span>
-                <span className="e-align-middle">Transaction does not exist</span>
+                <span className="align-middle">Transaction does not exist</span>
                 <br />
                 <SearchingClusterIndicator searchingCluster={searchingCluster} />
             </span>
@@ -34,7 +34,7 @@ export function TransactionNotFoundCard({
     } else if (status === 'found' && foundCluster !== undefined) {
         subtext = (
             <span>
-                <span className="e-align-middle">Transaction does not exist</span>
+                <span className="align-middle">Transaction does not exist</span>
                 <br />
                 <AdjacentTransactionLink signature={signature} foundCluster={foundCluster} />
             </span>
@@ -47,28 +47,22 @@ export function TransactionNotFoundCard({
 
     return (
         <Card ui="dashkit">
-            <CardBody ui="dashkit" className="e-text-center">
+            <CardBody ui="dashkit" className="text-center">
                 Not Found
                 {retry && (
                     <>
-                        <Button
-                            ui="dashkit"
-                            variant="white"
-                            className="e-ml-3 e-hidden md:e-inline"
-                            onClick={retry}
-                            asChild
-                        >
+                        <Button ui="dashkit" variant="white" className="ml-3 hidden md:inline" onClick={retry} asChild>
                             <span>{buttonText}</span>
                         </Button>
-                        <div className="e-mt-6 e-block md:e-hidden">
-                            <Button ui="dashkit" variant="white" className="e-w-full" onClick={retry} asChild>
+                        <div className="mt-6 block md:hidden">
+                            <Button ui="dashkit" variant="white" className="w-full" onClick={retry} asChild>
                                 <span>{buttonText}</span>
                             </Button>
                         </div>
                     </>
                 )}
                 {subtext && (
-                    <div className="e-text-dk-gray-700">
+                    <div className="text-dk-gray-700">
                         <hr />
                         {subtext}
                     </div>
@@ -165,7 +159,7 @@ function AdjacentTransactionLink({ signature, foundCluster }: { signature: strin
     });
 
     return (
-        <a href={foundClusterPath} className="e-align-middle e-text-dk-info" style={{ marginRight: '5px' }}>
+        <a href={foundClusterPath} className="align-middle text-dk-info" style={{ marginRight: '5px' }}>
             Found on {clusterName(foundCluster)}
         </a>
     );
@@ -178,12 +172,9 @@ function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Clu
         <>
             <span
                 style={{ height: '10px', marginRight: '5px', width: '10px' }}
-                className={`${spinnerCls} e-inline-block e-align-middle`}
+                className={`${spinnerCls} inline-block align-middle`}
             />
-            <span
-                className="e-align-middle e-text-dk-gray-700"
-                style={{ marginRight: '10px', verticalAlign: 'middle' }}
-            >
+            <span className="align-middle text-dk-gray-700" style={{ marginRight: '10px', verticalAlign: 'middle' }}>
                 checking {clusterName(searchingCluster).toLowerCase()}
             </span>
         </>

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -39,7 +39,7 @@ export function TransactionNotFoundCard({
                 <AdjacentTransactionLink signature={signature} foundCluster={foundCluster} />
             </span>
         );
-    } else if (firstAvailableBlock !== undefined && firstAvailableBlock > 0n) {
+    } else if (status === 'not-found' && firstAvailableBlock !== undefined && firstAvailableBlock > 0n) {
         subtext = `Note: Transactions processed before block ${firstAvailableBlock} are not available at this time`;
     }
 

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import { useCluster } from '@providers/cluster';
-import { createSolanaRpc, signature as createSignature } from '@solana/kit';
-import { Cluster, clusterName, clusterSlug, clusterUrl } from '@utils/cluster';
+import { Cluster, clusterName, clusterSlug } from '@utils/cluster';
 import { useClusterPath } from '@utils/url';
-import { useSearchParams } from 'next/navigation';
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 
+import { useClusterTransactionSearch } from '../model/use-cluster-transaction-search';
 import { BaseTransactionNotFoundCard } from './BaseTransactionNotFoundCard';
 
 export function TransactionNotFoundCard({
@@ -43,86 +42,6 @@ export function TransactionNotFoundCard({
     }
 
     return <BaseTransactionNotFoundCard retry={retry} subtext={subtext} />;
-}
-
-type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
-
-function useClusterTransactionSearch(signature: string, currentCluster: Cluster) {
-    const searchParams = useSearchParams();
-    const [status, setStatus] = useState<SearchStatus>('idle');
-    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
-    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
-    const searchIdRef = useRef(0);
-
-    const sleep = () => new Promise(res => setTimeout(res, 700));
-
-    const customUrl = searchParams?.get('customUrl');
-
-    useEffect(() => {
-        const currentSearchId = ++searchIdRef.current;
-
-        const clusters = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet].filter(c => c !== currentCluster);
-        const hasCustomUrlEnabled = Boolean(customUrl);
-
-        if (hasCustomUrlEnabled) {
-            clusters.push(Cluster.Custom);
-        }
-
-        const searchClusters = async () => {
-            if (searchIdRef.current !== currentSearchId) return;
-
-            setStatus('searching');
-            setFoundCluster(undefined);
-
-            for (const [index, cluster] of clusters.entries()) {
-                if (searchIdRef.current !== currentSearchId) return;
-
-                setSearchingCluster(cluster);
-
-                try {
-                    let url = clusterUrl(cluster, '');
-
-                    if (customUrl && cluster === Cluster.Custom) {
-                        url = customUrl;
-                    }
-
-                    const rpc = createSolanaRpc(url);
-                    const statusRes = await rpc
-                        .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
-                        .send();
-
-                    if (searchIdRef.current !== currentSearchId) return;
-
-                    // RPC returns literal null for missing signatures per JSON-RPC spec
-                    if (statusRes.value[0] !== null) {
-                        setFoundCluster(cluster);
-                        setStatus('found');
-                        return;
-                    } else if (index < clusters.length - 1) {
-                        // Only pace between checks; skip the trailing delay so not-found shows immediately
-                        await sleep();
-                    }
-                } catch (_error) {
-                    if (searchIdRef.current !== currentSearchId) return;
-                }
-            }
-
-            if (searchIdRef.current === currentSearchId) {
-                setStatus('not-found');
-                setSearchingCluster(undefined);
-            }
-        };
-
-        searchClusters();
-
-        return () => {
-            if (searchIdRef.current === currentSearchId) {
-                searchIdRef.current += 1;
-            }
-        };
-    }, [signature, currentCluster, customUrl]);
-
-    return { foundCluster, searchingCluster, status };
 }
 
 function AdjacentTransactionLink({ signature, foundCluster }: { signature: string; foundCluster: Cluster }) {

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@components/shared/ui/button';
 import { useCluster } from '@providers/cluster';
 import { createSolanaRpc, signature as createSignature } from '@solana/kit';
 import { Cluster, clusterName, clusterSlug, clusterUrl } from '@utils/cluster';
@@ -8,7 +7,7 @@ import { useClusterPath } from '@utils/url';
 import { useSearchParams } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { Card, CardBody } from '@/app/shared/ui/Card';
+import { BaseTransactionNotFoundCard } from './BaseTransactionNotFoundCard';
 
 export function TransactionNotFoundCard({
     signature,
@@ -43,33 +42,7 @@ export function TransactionNotFoundCard({
         subtext = `Note: Transactions processed before block ${firstAvailableBlock} are not available at this time`;
     }
 
-    const buttonText = 'Try Again';
-
-    return (
-        <Card ui="dashkit">
-            <CardBody ui="dashkit" className="text-center">
-                Not Found
-                {retry && (
-                    <>
-                        <Button ui="dashkit" variant="white" className="ml-3 hidden md:inline" onClick={retry} asChild>
-                            <span>{buttonText}</span>
-                        </Button>
-                        <div className="mt-6 block md:hidden">
-                            <Button ui="dashkit" variant="white" className="w-full" onClick={retry} asChild>
-                                <span>{buttonText}</span>
-                            </Button>
-                        </div>
-                    </>
-                )}
-                {subtext && (
-                    <div className="text-dk-gray-700">
-                        <hr />
-                        {subtext}
-                    </div>
-                )}
-            </CardBody>
-        </Card>
-    );
+    return <BaseTransactionNotFoundCard retry={retry} subtext={subtext} />;
 }
 
 type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -101,7 +101,7 @@ function useClusterTransactionSearch(signature: string, currentCluster: Cluster)
             setStatus('searching');
             setFoundCluster(undefined);
 
-            for (const cluster of clusters) {
+            for (const [index, cluster] of clusters.entries()) {
                 if (searchIdRef.current !== currentSearchId) return;
 
                 setSearchingCluster(cluster);
@@ -125,7 +125,8 @@ function useClusterTransactionSearch(signature: string, currentCluster: Cluster)
                         setFoundCluster(cluster);
                         setStatus('found');
                         return;
-                    } else {
+                    } else if (index < clusters.length - 1) {
+                        // Only pace between checks; skip the trailing delay so not-found shows immediately
                         await sleep();
                     }
                 } catch (_error) {

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useCluster } from '@providers/cluster';
+import { Button } from '@shared/ui/button';
+import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+import { Cluster, clusterName, clusterSlug, clusterUrl } from '@utils/cluster';
+import { useClusterPath } from '@utils/url';
+import { useSearchParams } from 'next/navigation';
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Card, CardBody } from '@/app/shared/ui/Card';
+
+type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
+
+function useClusterTransactionSearch(signature: string, currentCluster: Cluster) {
+    const searchParams = useSearchParams();
+    const [status, setStatus] = useState<SearchStatus>('idle');
+    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
+    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
+    const searchIdRef = useRef(0);
+
+    const sleep = () => new Promise(res => setTimeout(res, 700));
+
+    const customUrl = searchParams?.get('customUrl');
+
+    useEffect(() => {
+        const currentSearchId = ++searchIdRef.current;
+
+        const clusters = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet].filter(c => c !== currentCluster);
+        const hasCustomUrlEnabled = Boolean(customUrl);
+
+        if (hasCustomUrlEnabled) {
+            clusters.push(Cluster.Custom);
+        }
+
+        const searchClusters = async () => {
+            if (searchIdRef.current !== currentSearchId) return;
+
+            setStatus('searching');
+
+            for (const cluster of clusters) {
+                if (searchIdRef.current !== currentSearchId) return;
+
+                setSearchingCluster(cluster);
+
+                try {
+                    let url = clusterUrl(cluster, '');
+
+                    if (customUrl && cluster === Cluster.Custom) {
+                        url = customUrl;
+                    }
+
+                    const rpc = createSolanaRpc(url);
+                    const statusRes = await rpc
+                        .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
+                        .send();
+
+                    if (searchIdRef.current !== currentSearchId) return;
+
+                    if (statusRes.value[0] !== null) {
+                        setFoundCluster(cluster);
+                        setStatus('found');
+                        return;
+                    } else {
+                        await sleep();
+                    }
+                } catch (_error) {
+                    if (searchIdRef.current !== currentSearchId) return;
+                }
+            }
+
+            if (searchIdRef.current === currentSearchId) {
+                setStatus('not-found');
+                setSearchingCluster(undefined);
+            }
+        };
+
+        searchClusters();
+
+        return () => {
+            if (searchIdRef.current === currentSearchId) {
+                searchIdRef.current += 1;
+            }
+        };
+    }, [signature, currentCluster, customUrl]);
+
+    return { foundCluster, searchingCluster, status };
+}
+
+function AdjacentTransactionLink({ signature, foundCluster }: { signature: string; foundCluster: Cluster }) {
+    const moniker = clusterSlug(foundCluster);
+    const foundClusterPath = useClusterPath({
+        additionalParams: new URLSearchParams(`cluster=${moniker}`),
+        pathname: `/tx/${signature}`,
+    });
+
+    return (
+        <a href={foundClusterPath} className="e-align-middle e-text-dk-info" style={{ marginRight: '5px' }}>
+            Found on {clusterName(foundCluster)}
+        </a>
+    );
+}
+
+function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
+    const spinnerCls = 'spinner-grow spinner-grow-sm';
+
+    return (
+        <>
+            <span
+                style={{ height: '10px', marginRight: '5px', width: '10px' }}
+                className={`${spinnerCls} e-inline-block e-align-middle`}
+            />
+            <span
+                className="e-align-middle e-text-dk-gray-700"
+                style={{ marginRight: '10px', verticalAlign: 'middle' }}
+            >
+                checking {clusterName(searchingCluster).toLowerCase()}
+            </span>
+        </>
+    );
+}
+
+export function TransactionNotFoundCard({
+    signature,
+    retry,
+    firstAvailableBlock,
+}: {
+    signature: string;
+    retry?: () => void;
+    firstAvailableBlock?: bigint;
+}) {
+    const { cluster } = useCluster();
+    const { status, searchingCluster, foundCluster } = useClusterTransactionSearch(signature, cluster);
+
+    let subtext: React.ReactNode = undefined;
+    if (status === 'searching' && searchingCluster !== undefined) {
+        subtext = (
+            <span>
+                <span className="e-align-middle">Transaction does not exist</span>
+                <br />
+                <SearchingClusterIndicator searchingCluster={searchingCluster} />
+            </span>
+        );
+    } else if (status === 'found' && foundCluster !== undefined) {
+        subtext = (
+            <span>
+                <span className="e-align-middle">Transaction does not exist</span>
+                <br />
+                <AdjacentTransactionLink signature={signature} foundCluster={foundCluster} />
+            </span>
+        );
+    } else if (firstAvailableBlock !== undefined && firstAvailableBlock > 0n) {
+        subtext = `Note: Transactions processed before block ${firstAvailableBlock} are not available at this time`;
+    }
+
+    const buttonText = 'Try Again';
+
+    return (
+        <Card ui="dashkit">
+            <CardBody ui="dashkit" className="e-text-center">
+                Not Found
+                {retry && (
+                    <>
+                        <Button
+                            ui="dashkit"
+                            variant="white"
+                            className="e-ml-3 e-hidden md:e-inline"
+                            onClick={retry}
+                            asChild
+                        >
+                            <span>{buttonText}</span>
+                        </Button>
+                        <div className="e-mt-6 e-block md:e-hidden">
+                            <Button ui="dashkit" variant="white" className="e-w-full" onClick={retry} asChild>
+                                <span>{buttonText}</span>
+                            </Button>
+                        </div>
+                    </>
+                )}
+                {subtext && (
+                    <div className="e-text-dk-gray-700">
+                        <hr />
+                        {subtext}
+                    </div>
+                )}
+            </CardBody>
+        </Card>
+    );
+}

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -105,6 +105,7 @@ function useClusterTransactionSearch(signature: string, currentCluster: Cluster)
             if (searchIdRef.current !== currentSearchId) return;
 
             setStatus('searching');
+            setFoundCluster(undefined);
 
             for (const cluster of clusters) {
                 if (searchIdRef.current !== currentSearchId) return;

--- a/app/features/transaction/ui/__stories__/BaseTransactionNotFoundCard.stories.tsx
+++ b/app/features/transaction/ui/__stories__/BaseTransactionNotFoundCard.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { fn } from 'storybook/test';
+
+import { BaseTransactionNotFoundCard } from '../BaseTransactionNotFoundCard';
+
+const meta = {
+    args: {
+        retry: fn(),
+    },
+    component: BaseTransactionNotFoundCard,
+    tags: ['autodocs', 'test'],
+    title: 'Features/Transaction/BaseTransactionNotFoundCard',
+} satisfies Meta<typeof BaseTransactionNotFoundCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithoutRetry: Story = {
+    args: {
+        retry: undefined,
+    },
+};
+
+export const WithFirstAvailableBlockNote: Story = {
+    args: {
+        subtext: 'Note: Transactions processed before block 100 are not available at this time',
+    },
+};
+
+export const Searching: Story = {
+    args: {
+        subtext: (
+            <span>
+                <span className="align-middle">Transaction does not exist</span>
+                <br />
+                <span
+                    style={{ height: '10px', marginRight: '5px', width: '10px' }}
+                    className="spinner-grow spinner-grow-sm inline-block align-middle"
+                />
+                <span className="align-middle text-dk-gray-700">checking devnet</span>
+            </span>
+        ),
+    },
+};
+
+export const Found: Story = {
+    args: {
+        subtext: (
+            <span>
+                <span className="align-middle">Transaction does not exist</span>
+                <br />
+                <a href="#" className="align-middle text-dk-info">
+                    Found on Devnet
+                </a>
+            </span>
+        ),
+    },
+};

--- a/app/features/transaction/ui/__tests__/TransactionNotFoundCard.spec.tsx
+++ b/app/features/transaction/ui/__tests__/TransactionNotFoundCard.spec.tsx
@@ -1,0 +1,129 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Cluster } from '@/app/utils/cluster';
+
+import { TransactionNotFoundCard } from '../TransactionNotFoundCard';
+
+// Mock useCluster to return a controlled cluster value
+vi.mock('@/app/providers/cluster', () => ({
+    useCluster: vi.fn(() => ({ cluster: Cluster.MainnetBeta })),
+}));
+
+// Mock useClusterPath to return a simple path string
+vi.mock('@/app/utils/url', () => ({
+    useClusterPath: vi.fn(({ pathname }: { pathname: string }) => pathname),
+}));
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// Mock createSolanaRpc: by default all clusters return null (not found)
+const mockSend = vi.fn().mockResolvedValue({ value: [null] });
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
+    return {
+        ...actual,
+        createSolanaRpc: vi.fn(() => ({
+            getSignatureStatuses: vi.fn(() => ({
+                send: mockSend,
+            })),
+        })),
+    };
+});
+
+const TEST_SIGNATURE = '5UfDuX7hXbPjSUQPBfRBLRYoy4SZJvfP18VpoYz75Y4P6yCWNxbEq1RCfxGvod7U1PArBAkQbE4yLrdaAiZBmGEs';
+
+describe('TransactionNotFoundCard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.clearAllMocks();
+        mockSend.mockResolvedValue({ value: [null] });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should render "Not Found" text', () => {
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} />);
+        expect(screen.getByText('Not Found')).toBeInTheDocument();
+    });
+
+    it('should render retry button when retry prop is provided', () => {
+        const retry = vi.fn();
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} retry={retry} />);
+        // Two buttons exist (desktop + mobile responsive), so use getAllByText
+        expect(screen.getAllByText('Try Again').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not render retry button when retry prop is omitted', () => {
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} />);
+        expect(screen.queryByText('Try Again')).not.toBeInTheDocument();
+    });
+
+    it('should call retry callback when Try Again is clicked', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const retry = vi.fn();
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} retry={retry} />);
+        const btn = screen.getAllByText('Try Again')[0];
+        await user.click(btn);
+        expect(retry).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show firstAvailableBlock note when provided and positive', async () => {
+        mockSend.mockResolvedValue({ value: [null] });
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} firstAvailableBlock={100n} />);
+
+        // Advance past the 700ms sleep per cluster (3 clusters × 700ms)
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Note: Transactions processed before block 100 are not available at this time'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('should not show firstAvailableBlock note when block is 0n', async () => {
+        mockSend.mockResolvedValue({ value: [null] });
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} firstAvailableBlock={0n} />);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        // Search is done, but 0n does not meet the > 0n condition
+        expect(screen.queryByText('Transactions processed before block', { exact: false })).not.toBeInTheDocument();
+    });
+
+    it('should show searching indicator while probing clusters', async () => {
+        // Keep send pending so the hook stays in "searching" state
+        mockSend.mockReturnValue(new Promise(() => {}));
+
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Transaction does not exist')).toBeInTheDocument();
+            expect(screen.getByText('checking', { exact: false })).toBeInTheDocument();
+        });
+    });
+
+    it('should show "Found on" link when transaction is found on another cluster', async () => {
+        // First call finds the signature (non-null result)
+        mockSend.mockResolvedValueOnce({
+            value: [{ confirmationStatus: 'finalized', confirmations: null, err: null, slot: 100 }],
+        });
+
+        render(<TransactionNotFoundCard signature={TEST_SIGNATURE} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Found on', { exact: false })).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
## Description

This PR introduces a cross-cluster transaction lookup feature. When a user navigates to a transaction signature that does not exist on their currently selected cluster, the application will actively probe the other Solana clusters (Mainnet, Devnet, Testnet, Custom) in the background.

If the transaction is found on another cluster, the "Not Found" card updates to display a helpful "Found on [Cluster]" link to smoothly redirect the user. This matches the existing UX pattern established by [`UnknownAccountCard`](https://github.com/solana-foundation/explorer/blob/master/app/components/account/UnknownAccountCard.tsx).

Changes include:
- Added `useClusterTransactionSearch` hook to probe alternative clusters sequentially using `getSignatureStatuses`.
- Rendered visual states (`searching`, `found`, and `not-found`) directly in `TransactionNotFoundCard` with a loading indicator.
- Added unit tests covering the new hook states using fake timers.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

Before
<img width="1727" height="1081" alt="Screenshot 2026-06-16 at 6 34 24 AM" src="https://github.com/user-attachments/assets/8655a81a-f0c3-4c1e-8b15-5b13cc96876a" />

After
<img width="1728" height="1117" alt="Screenshot 2026-06-16 at 6 32 03 AM" src="https://github.com/user-attachments/assets/f40ca942-63db-4df2-87be-a8079097cb08" />
<img width="1728" height="1117" alt="Screenshot 2026-06-16 at 6 33 14 AM" src="https://github.com/user-attachments/assets/2b41e788-133d-43bc-ac2c-bb4734715eae" />
<img width="1727" height="1085" alt="Screenshot 2026-06-16 at 6 33 33 AM" src="https://github.com/user-attachments/assets/edbd8b73-2921-4b23-a8bd-f4731daf1805" />


## Testing

1. Verified the fallback states manually in the browser by looking up known Devnet transaction signatures while connected to Mainnet.
2. Verified the existing `firstAvailableBlock` behavior remains intact.
3. Ran `pnpm test` locally to ensure all suites pass.
4. Added a full unit test suite `TransactionNotFoundCard.spec.tsx` verifying:
   - Button renders correctly based on props.
   - Searching indicator displays correctly during `getSignatureStatuses` promises.
   - "Found on" link resolves successfully when `[null]` is not returned.

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information