### PR TITLE
Fix: observer for transaction history table

### DIFF
--- a/app/features/transaction-history/lib/use-instruction-names.ts
+++ b/app/features/transaction-history/lib/use-instruction-names.ts
@@ -9,10 +9,10 @@ import { fetchParsedTransactionSequential } from './transaction-queue';
  * Uses a global sequential queue to avoid rate-limit (429) errors.
  * Returns null while loading, empty array if no instructions found.
  */
-export function useInstructionNames(signature: string): TransactionInstructionInfo[] | null {
+export function useInstructionNames(signature: string, enabled = true): TransactionInstructionInfo[] | null {
     const { url } = useCluster();
     const { data } = useSWR(
-        `instruction-names:${url}:${signature}`,
+        enabled ? `instruction-names:${url}:${signature}` : null,
         async () => {
             const tx = await fetchParsedTransactionSequential(signature, url);
             return tx ? getTransactionInstructionNames(tx) : [];

--- a/app/features/transaction-history/ui/TransactionHistoryCard.tsx
+++ b/app/features/transaction-history/ui/TransactionHistoryCard.tsx
@@ -16,6 +16,7 @@ import { Badge } from '@/app/components/shared/ui/badge';
 import { useFetchRawTransaction, useRawTransactionDetails } from '@/app/providers/transactions/raw';
 import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
 import { toBase64 } from '@/app/shared/lib/bytes';
+import { useVisibility } from '@/app/shared/lib/visibility';
 import { RelativeTime } from '@/app/shared/RelativeTime';
 import { Card } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -113,10 +114,11 @@ type TransactionRowProps = {
 };
 
 function TransactionRow({ signature, slot, blockTime, statusClass, statusText, hasTimestamps }: TransactionRowProps) {
-    const instructionNames = useInstructionNames(signature);
+    const { isVisible, ref } = useVisibility<HTMLTableRowElement>(true);
+    const instructionNames = useInstructionNames(signature, isVisible);
 
     return (
-        <BaseTable.Row>
+        <BaseTable.Row ref={ref}>
             <BaseTable.Cell>
                 <Signature signature={signature} link />
                 {instructionNames !== null && instructionNames.length > 0 ? (

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -53,7 +53,7 @@
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 890 B | 1.03 MB |
+| Static | `/tos` | 880 B | 1.03 MB |
 | Dynamic | `/tx/[signature]` | 600 kB | 1.61 MB |
 | Dynamic | `/tx/[signature]/inspect` | 390 kB | 1.41 MB |
 | Static | `/tx/inspector` | 390 kB | 1.41 MB |


### PR DESCRIPTION
## Description
- adding viewport observer for transaction history table for loading instructions only for transactions in viewscreen

## Type of change
-   [x] Bug fix

## Testing
1. open [address page](https://explorer-git-fork-hoodieshq-fix-hoo-63-34018a-solana-foundation.vercel.app/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
2. open network tab
3. loading for instructions will start working only for transactions on screen

## Related Issues
[HOO-639](https://linear.app/solana-fndn/issue/HOO-639/fix-transaction-history-loading)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
