### PR TITLE
Temporary fix for codama idls with only one instruction

### DIFF
--- a/app/components/instruction/codama/CodamaInstructionDetailsCard.tsx
+++ b/app/components/instruction/codama/CodamaInstructionDetailsCard.tsx
@@ -79,12 +79,14 @@ export function CodamaInstructionCard({
                     <Address pubkey={new PublicKey(ix.programId)} alignRight link raw overrideText={programName} />
                 </BaseTable.Cell>
             </BaseTable.Row>
-            <BaseTable.Row className="e-bg-dark-background e-text-dk-xs e-font-semibold e-uppercase e-tracking-[0.08em] e-text-dark-muted-foreground">
-                <BaseTable.Cell>Account Name</BaseTable.Cell>
-                <BaseTable.Cell className="e-text-right" colSpan={2}>
-                    Address
-                </BaseTable.Cell>
-            </BaseTable.Row>
+            {accountDetails.length > 0 && (
+                <BaseTable.Row className="e-bg-dark-background e-text-dk-xs e-font-semibold e-uppercase e-tracking-[0.08em] e-text-dark-muted-foreground">
+                    <BaseTable.Cell>Account Name</BaseTable.Cell>
+                    <BaseTable.Cell className="e-text-right" colSpan={2}>
+                        Address
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
             {accountDetails}
             {parsedIx.data ? (
                 <>

--- a/app/components/instruction/program-metadata-idl/ProgramMetadataIdlInstructionDetailsCard.tsx
+++ b/app/components/instruction/program-metadata-idl/ProgramMetadataIdlInstructionDetailsCard.tsx
@@ -1,12 +1,51 @@
 import { parseInstruction } from '@codama/dynamic-parsers';
 import { rootNodeFromAnchor } from '@codama/nodes-from-anchor';
 import { SignatureResult, TransactionInstruction } from '@solana/web3.js';
-import { RootNode } from 'codama';
+import {
+    bytesTypeNode,
+    bytesValueNode,
+    constantDiscriminatorNode,
+    constantValueNode,
+    fixedSizeTypeNode,
+    type RootNode,
+} from 'codama';
 
 import { toKitInstruction } from '@/app/shared/lib/web3js-compat';
 
 import { CodamaInstructionCard } from '../codama/CodamaInstructionDetailsCard';
 import { UnknownDetailsCard } from '../UnknownDetailsCard';
+
+/**
+ * Programs with a single instruction and no discriminators (e.g. Memo) can't be
+ * identified by the standard parser. This injects a zero-length constant
+ * discriminator that matches any byte payload, letting parseInstruction proceed
+ * with codec-based decoding.
+ */
+function withCatchAllDiscriminator(idl: RootNode): RootNode | null {
+    if (idl.kind !== 'rootNode') return null;
+    const { instructions } = idl.program;
+    if (instructions.length !== 1) return null;
+
+    const ix = instructions[0];
+    if (ix.discriminators && ix.discriminators.length > 0) return null;
+
+    return {
+        ...idl,
+        program: {
+            ...idl.program,
+            instructions: [
+                {
+                    ...ix,
+                    discriminators: [
+                        constantDiscriminatorNode(
+                            constantValueNode(fixedSizeTypeNode(bytesTypeNode(), 0), bytesValueNode('base16', '')),
+                        ),
+                    ],
+                },
+            ],
+        },
+    } as RootNode;
+}
 
 export function ProgramMetadataIdlInstructionDetailsCard({
     ix,
@@ -29,7 +68,6 @@ export function ProgramMetadataIdlInstructionDetailsCard({
     };
     const kitIx = toKitInstruction(ix);
 
-    // Try parsing with the provided idl, then fallback to rootNodeFromAnchor(idl)
     const tryParse = (idlRoot: RootNode) => {
         try {
             const parsedIx = parseInstruction(idlRoot, kitIx);
@@ -50,5 +88,14 @@ export function ProgramMetadataIdlInstructionDetailsCard({
             // ignore and fallback
         }
     }
+
+    // Fallback for single-instruction programs without discriminators (e.g. Memo)
+    if (!parsedCard) {
+        const modified = withCatchAllDiscriminator(idl as RootNode);
+        if (modified) {
+            parsedCard = tryParse(modified);
+        }
+    }
+
     return parsedCard ?? <UnknownDetailsCard {...props} />;
 }


### PR DESCRIPTION
- This should be fixed upstream in dynamic parsers

Currently transactions with the new memo program can not support IDLs without discriminators. 
4zZzKaBbH8UWV8Bmr7S7jNwVqqKYMYDz3r6qii5Qe7Wpqrdo78Q1fZqKUeZ7q2eWrRMv44wioj9Jndvd6jAUKRoX 

This is a temporary fix until the upstream fix in dynamic parsers lands: 
<img width="952" height="274" alt="image" src="https://github.com/user-attachments/assets/7ae54f50-9323-47a3-8246-78712b4803e2" />
