### PR TITLE
fix: add smart scrolling for logs section

### DIFF
--- a/app/components/ProgramLogsCardBody.tsx
+++ b/app/components/ProgramLogsCardBody.tsx
@@ -245,7 +245,7 @@ function ProgramLogRow({
     }
 
     return (
-        <BaseTable.Row>
+        <BaseTable.Row data-ix-index={index}>
             <BaseTable.Cell>
                 <Link className="flex items-center" href={anchorPath}>
                     {/* badgeColor='white' falls through to a plain `.badge` (no bg-white-soft is defined in dashkit) — same as legacy. */}
@@ -268,7 +268,7 @@ function ProgramLogRow({
                     <ChevronsUp className="m-1.5 cursor-pointer" size={13} />
                 </Link>
                 {programLogs && (
-                    <div className="flex flex-col items-start p-1.5 font-mono">
+                    <div className="flex flex-col items-start whitespace-pre-wrap break-all p-1.5 font-mono">
                         {programLogs.logs.map((log, key) => {
                             return (
                                 <span key={key}>

--- a/app/features/transaction/ui/CollapsibleSection.tsx
+++ b/app/features/transaction/ui/CollapsibleSection.tsx
@@ -12,6 +12,7 @@ type CollapsibleSectionProps = {
     children: ReactNode;
     defaultExpanded?: boolean;
     className?: string;
+    titleClassName?: string;
 };
 
 export function CollapsibleSection({
@@ -21,13 +22,14 @@ export function CollapsibleSection({
     children,
     defaultExpanded = true,
     className = baseCardVariants({ ui: 'dashkit' }),
+    titleClassName,
 }: CollapsibleSectionProps) {
     const [expanded, setExpanded] = useState(defaultExpanded);
     const headingId = useId();
 
     return (
         <section id={id} aria-labelledby={headingId} className="flex flex-col gap-3">
-            <div className="flex items-center justify-between">
+            <div className={cn('flex items-center justify-between', titleClassName)}>
                 <h2 id={headingId} className="m-0 text-lg font-normal text-white">
                     {title}
                 </h2>

--- a/app/features/transaction/ui/CollapsibleSection.tsx
+++ b/app/features/transaction/ui/CollapsibleSection.tsx
@@ -13,6 +13,7 @@ type CollapsibleSectionProps = {
     defaultExpanded?: boolean;
     className?: string;
     titleClassName?: string;
+    sectionClassName?: string;
 };
 
 export function CollapsibleSection({
@@ -23,12 +24,13 @@ export function CollapsibleSection({
     defaultExpanded = true,
     className = baseCardVariants({ ui: 'dashkit' }),
     titleClassName,
+    sectionClassName,
 }: CollapsibleSectionProps) {
     const [expanded, setExpanded] = useState(defaultExpanded);
     const headingId = useId();
 
     return (
-        <section id={id} aria-labelledby={headingId} className="flex flex-col gap-3">
+        <section id={id} aria-labelledby={headingId} className={cn('flex flex-col gap-3', sectionClassName)}>
             <div className={cn('flex items-center justify-between', titleClassName)}>
                 <h2 id={headingId} className="m-0 text-lg font-normal text-white">
                     {title}

--- a/app/features/transaction/ui/CollapsibleSection.tsx
+++ b/app/features/transaction/ui/CollapsibleSection.tsx
@@ -31,7 +31,7 @@ export function CollapsibleSection({
 
     return (
         <section id={id} aria-labelledby={headingId} className={cn('flex flex-col gap-3', sectionClassName)}>
-            <div className={cn('flex items-center justify-between', titleClassName)}>
+            <div data-section-title className={cn('flex items-center justify-between', titleClassName)}>
                 <h2 id={headingId} className="m-0 text-lg font-normal text-white">
                     {title}
                 </h2>

--- a/app/features/transaction/ui/ProgramLogSection.tsx
+++ b/app/features/transaction/ui/ProgramLogSection.tsx
@@ -60,7 +60,7 @@ export function ProgramLogSection({ signature }: SignatureProps) {
             title="Logs"
             actions={chips}
             sectionClassName="xxl:!gap-0"
-            titleClassName="xxl:sticky xxl:top-0 xxl:z-10 xxl:bg-[var(--bs-body-bg)] xxl:pb-3"
+            titleClassName="xxl:sticky xxl:top-0 xxl:z-10 xxl:bg-[var(--background)] xxl:pb-3"
         >
             {prettyLogs !== null && logMessages !== null ? (
                 showRaw ? (

--- a/app/features/transaction/ui/ProgramLogSection.tsx
+++ b/app/features/transaction/ui/ProgramLogSection.tsx
@@ -8,7 +8,7 @@ import { parseProgramLogs } from '@utils/program-logs';
 import React from 'react';
 
 import { Button } from '@/app/components/shared/ui/button';
-import { BaseCardBody, Card } from '@/app/shared/ui/Card';
+import { BaseCardBody } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 import { CollapsibleSection } from './CollapsibleSection';
@@ -59,20 +59,18 @@ export function ProgramLogSection({ signature }: SignatureProps) {
         <CollapsibleSection
             title="Logs"
             actions={chips}
-            className=""
+            sectionClassName="xxl:!gap-0"
             titleClassName="xxl:sticky xxl:top-0 xxl:z-10 xxl:bg-[var(--bs-body-bg)] xxl:pb-3"
         >
-            <Card ui="dashkit">
-                {prettyLogs !== null && logMessages !== null ? (
-                    showRaw ? (
-                        <RawProgramLogs raw={logMessages} />
-                    ) : (
-                        <ProgramLogsCardBody message={message} logs={prettyLogs} cluster={cluster} url={url} />
-                    )
+            {prettyLogs !== null && logMessages !== null ? (
+                showRaw ? (
+                    <RawProgramLogs raw={logMessages} />
                 ) : (
-                    <BaseCardBody className="text-sm text-muted">Logs not supported for this transaction</BaseCardBody>
-                )}
-            </Card>
+                    <ProgramLogsCardBody message={message} logs={prettyLogs} cluster={cluster} url={url} />
+                )
+            ) : (
+                <BaseCardBody className="text-sm text-muted">Logs not supported for this transaction</BaseCardBody>
+            )}
         </CollapsibleSection>
     );
 }

--- a/app/features/transaction/ui/ProgramLogSection.tsx
+++ b/app/features/transaction/ui/ProgramLogSection.tsx
@@ -56,7 +56,12 @@ export function ProgramLogSection({ signature }: SignatureProps) {
     );
 
     return (
-        <CollapsibleSection title="Logs" actions={chips} className="">
+        <CollapsibleSection
+            title="Logs"
+            actions={chips}
+            className=""
+            titleClassName="xxl:sticky xxl:top-0 xxl:z-10 xxl:bg-[var(--bs-body-bg)] xxl:pb-3"
+        >
             <Card ui="dashkit">
                 {prettyLogs !== null && logMessages !== null ? (
                     showRaw ? (

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -121,11 +121,8 @@ function DetailsSection({ signature }: SignatureProps) {
     const isManualScrollRef = useRef(false);
     const manualScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Sync the sticky logs panel with the active instruction on the left.
-    // Proportionally scrolls the log panel within the active instruction's log
-    // section as the user scrolls through that instruction's detail card.
-    // Wheel events on the log panel scroll it independently for 2 s before
-    // auto-sync resumes.
+    // Sync the sticky logs panel with the active instruction as the page scrolls.
+    // Manual wheel scroll on the panel takes over for 2s before auto-sync resumes.
     useEffect(() => {
         if (!isXxl) return;
         const logsPanel = logsPanelRef.current;
@@ -147,16 +144,14 @@ function DetailsSection({ signature }: SignatureProps) {
 
         const handlePageScroll = () => {
             if (isManualScrollRef.current) return;
-            // Top-level instruction cards have id="ix-N" (set by useScrollAnchor).
-            // Keep only top-level instruction cards (id="ix-N"), not inner ones (id="ix-N-M").
+            // Top-level ix-N cards only (excludes nested ix-N-M).
             const cards = Array.from(document.querySelectorAll<HTMLElement>('[id^="ix-"]')).filter(el => {
-                const suffix = el.id.slice(3); // strip "ix-"
+                const suffix = el.id.slice(3);
                 return suffix.length > 0 && !suffix.includes('-') && !Number.isNaN(Number(suffix));
             });
             if (cards.length === 0) return;
 
-            // The "active" instruction is the last one whose top has scrolled
-            // past the sticky nav bar (~70 px).
+            // Active = last card whose top has crossed the sticky nav threshold.
             const threshold = 80;
             let activeIndex = 0;
             for (let i = 0; i < cards.length; i++) {
@@ -165,16 +160,12 @@ function DetailsSection({ signature }: SignatureProps) {
             }
 
             const cardRect = cards[activeIndex].getBoundingClientRect();
-            // 0 = just entered view, 1 = fully scrolled past
             const progress = Math.max(0, Math.min(1, (threshold - cardRect.top) / cardRect.height));
 
             const logRow = logsPanel.querySelector<HTMLElement>(`[data-ix-index="${activeIndex}"]`);
             if (!logRow) return;
 
-            // `logRow` is a <tr> whose offsetParent is the <table>, not logsPanel.
-            // Use getBoundingClientRect to get the row's absolute position within
-            // the scroll container, independent of current scrollTop.
-            // Offset by the sticky title height so the row header appears below it, not under it.
+            // Use getBoundingClientRect for position independent of current scrollTop.
             const titleHeight = (logsPanel.querySelector('section > div') as HTMLElement | null)?.offsetHeight ?? 0;
             const panelRect = logsPanel.getBoundingClientRect();
             const rowRect = logRow.getBoundingClientRect();

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -27,6 +27,7 @@ import { generateTokenBalanceRows, TokenBalancesCard } from '@/app/features/tran
 import { AutoRefresh, useAutoRefreshState } from '@/app/shared/lib/use-auto-refresh';
 import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
 import { BaseNavigationTabs } from '@/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs';
+import { useLogsPanelScrollSync } from '@/app/tx/[signature]/use-logs-scroll-sync';
 import useTabVisibility from '@/app/utils/use-tab-visibility';
 
 const ALL_TRANSACTION_TABS = [
@@ -118,69 +119,10 @@ function DetailsSection({ signature }: SignatureProps) {
     const refreshDetails = () => fetchDetails(signature);
 
     const logsPanelRef = useRef<HTMLDivElement>(null);
-    const isManualScrollRef = useRef(false);
-    const manualScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Sync the sticky logs panel with the active instruction as the page scrolls.
-    // Manual wheel scroll on the panel takes over for 2s before auto-sync resumes.
-    useEffect(() => {
-        if (!isXxl) return;
-        const logsPanel = logsPanelRef.current;
-        if (!logsPanel) return;
-
-        const handleWheel = (e: WheelEvent) => {
-            const { scrollTop, scrollHeight, clientHeight } = logsPanel;
-            const atTop = scrollTop === 0 && e.deltaY < 0;
-            const atBottom = scrollTop + clientHeight >= scrollHeight && e.deltaY > 0;
-            if (atTop || atBottom) return;
-            e.preventDefault();
-            logsPanel.scrollTop += e.deltaY;
-            isManualScrollRef.current = true;
-            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
-            manualScrollTimeoutRef.current = setTimeout(() => {
-                isManualScrollRef.current = false;
-            }, 2000);
-        };
-
-        const handlePageScroll = () => {
-            if (isManualScrollRef.current) return;
-            // Top-level ix-N cards only (excludes nested ix-N-M).
-            const cards = Array.from(document.querySelectorAll<HTMLElement>('[id^="ix-"]')).filter(el => {
-                const suffix = el.id.slice(3);
-                return suffix.length > 0 && !suffix.includes('-') && !Number.isNaN(Number(suffix));
-            });
-            if (cards.length === 0) return;
-
-            // Active = last card whose top has crossed the sticky nav threshold.
-            const threshold = 80;
-            let activeIndex = 0;
-            for (let i = 0; i < cards.length; i++) {
-                if (cards[i].getBoundingClientRect().top <= threshold) activeIndex = i;
-                else break;
-            }
-
-            const cardRect = cards[activeIndex].getBoundingClientRect();
-            const progress = Math.max(0, Math.min(1, (threshold - cardRect.top) / cardRect.height));
-
-            const logRow = logsPanel.querySelector<HTMLElement>(`[data-ix-index="${activeIndex}"]`);
-            if (!logRow) return;
-
-            // Use getBoundingClientRect for position independent of current scrollTop.
-            const titleHeight = (logsPanel.querySelector('section > div') as HTMLElement | null)?.offsetHeight ?? 0;
-            const panelRect = logsPanel.getBoundingClientRect();
-            const rowRect = logRow.getBoundingClientRect();
-            const rowAbsoluteTop = rowRect.top - panelRect.top + logsPanel.scrollTop;
-            logsPanel.scrollTop = Math.max(0, rowAbsoluteTop - titleHeight + rowRect.height * progress);
-        };
-
-        logsPanel.addEventListener('wheel', handleWheel, { passive: false });
-        window.addEventListener('scroll', handlePageScroll, { passive: true });
-        return () => {
-            logsPanel.removeEventListener('wheel', handleWheel);
-            window.removeEventListener('scroll', handlePageScroll);
-            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
-        };
-    }, [isXxl, transactionWithMeta]);
+    // Manual interaction (wheel, scrollbar, keyboard) takes over for 2s before auto-sync resumes.
+    useLogsPanelScrollSync({ enabled: isXxl, panelRef: logsPanelRef, watchValue: transactionWithMeta });
 
     useEffect(() => {
         if (!details && clusterStatus === ClusterStatus.Connected && status?.status === FetchStatus.Fetched) {

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -241,7 +241,7 @@ function DetailsSection({ signature }: SignatureProps) {
                 </div>
                 <div
                     ref={logsPanelRef}
-                    className="xxl:sticky xxl:top-[70px] xxl:max-h-[calc(100vh-90px)] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-y-auto"
+                    className="scrollbar-hide xxl:sticky xxl:top-[70px] xxl:max-h-[calc(100vh-90px)] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-y-auto xxl:rounded-b-lg"
                     id="logs"
                 >
                     <ProgramLogSection signature={signature} />

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -17,7 +17,7 @@ import { ClusterStatus } from '@utils/cluster';
 import { SignatureProps } from '@utils/index';
 import bs58 from 'bs58';
 import { useSearchParams } from 'next/navigation';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
 
 import { AccountsCard } from '@/app/features/transaction/ui/AccountsCard';
 import { InstructionsSection } from '@/app/features/transaction/ui/InstructionsSection';
@@ -117,6 +117,80 @@ function DetailsSection({ signature }: SignatureProps) {
     const { isXxl } = useBreakpoint();
     const refreshDetails = () => fetchDetails(signature);
 
+    const logsPanelRef = useRef<HTMLDivElement>(null);
+    const isManualScrollRef = useRef(false);
+    const manualScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Sync the sticky logs panel with the active instruction on the left.
+    // Proportionally scrolls the log panel within the active instruction's log
+    // section as the user scrolls through that instruction's detail card.
+    // Wheel events on the log panel scroll it independently for 2 s before
+    // auto-sync resumes.
+    useEffect(() => {
+        if (!isXxl) return;
+        const logsPanel = logsPanelRef.current;
+        if (!logsPanel) return;
+
+        const handleWheel = (e: WheelEvent) => {
+            const { scrollTop, scrollHeight, clientHeight } = logsPanel;
+            const atTop = scrollTop === 0 && e.deltaY < 0;
+            const atBottom = scrollTop + clientHeight >= scrollHeight && e.deltaY > 0;
+            if (atTop || atBottom) return;
+            e.preventDefault();
+            logsPanel.scrollTop += e.deltaY;
+            isManualScrollRef.current = true;
+            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
+            manualScrollTimeoutRef.current = setTimeout(() => {
+                isManualScrollRef.current = false;
+            }, 2000);
+        };
+
+        const handlePageScroll = () => {
+            if (isManualScrollRef.current) return;
+            // Top-level instruction cards have id="ix-N" (set by useScrollAnchor).
+            // Keep only top-level instruction cards (id="ix-N"), not inner ones (id="ix-N-M").
+            const cards = Array.from(document.querySelectorAll<HTMLElement>('[id^="ix-"]')).filter(el => {
+                const suffix = el.id.slice(3); // strip "ix-"
+                return suffix.length > 0 && !suffix.includes('-') && !Number.isNaN(Number(suffix));
+            });
+            if (cards.length === 0) return;
+
+            // The "active" instruction is the last one whose top has scrolled
+            // past the sticky nav bar (~70 px).
+            const threshold = 80;
+            let activeIndex = 0;
+            for (let i = 0; i < cards.length; i++) {
+                if (cards[i].getBoundingClientRect().top <= threshold) activeIndex = i;
+                else break;
+            }
+
+            const cardRect = cards[activeIndex].getBoundingClientRect();
+            // 0 = just entered view, 1 = fully scrolled past
+            const progress = Math.max(0, Math.min(1, (threshold - cardRect.top) / cardRect.height));
+
+            const logRow = logsPanel.querySelector<HTMLElement>(`[data-ix-index="${activeIndex}"]`);
+            if (!logRow) return;
+
+            // `logRow` is a <tr> whose offsetParent is the <table>, not logsPanel.
+            // Use getBoundingClientRect to get the row's absolute position within
+            // the scroll container, independent of current scrollTop.
+            // Offset by the sticky title height so the row header appears below it, not under it.
+            const titleHeight = (logsPanel.querySelector('section > div') as HTMLElement | null)?.offsetHeight ?? 0;
+            const panelRect = logsPanel.getBoundingClientRect();
+            const rowRect = logRow.getBoundingClientRect();
+            const rowAbsoluteTop = rowRect.top - panelRect.top + logsPanel.scrollTop;
+            logsPanel.scrollTop = Math.max(0, rowAbsoluteTop - titleHeight + rowRect.height * progress);
+        };
+
+        logsPanel.addEventListener('wheel', handleWheel, { passive: false });
+        window.addEventListener('scroll', handlePageScroll, { passive: true });
+        return () => {
+            logsPanel.removeEventListener('wheel', handleWheel);
+            window.removeEventListener('scroll', handlePageScroll);
+            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
+        };
+    }, [isXxl, transactionWithMeta]);
+
     useEffect(() => {
         if (!details && clusterStatus === ClusterStatus.Connected && status?.status === FetchStatus.Fetched) {
             fetchDetails(signature);
@@ -165,7 +239,11 @@ function DetailsSection({ signature }: SignatureProps) {
                 <div className="xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-hidden">
                     <InstructionsSection signature={signature} />
                 </div>
-                <div className="xxl:sticky xxl:top-[70px] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-hidden" id="logs">
+                <div
+                    ref={logsPanelRef}
+                    className="xxl:sticky xxl:top-[70px] xxl:max-h-[calc(100vh-90px)] xxl:min-w-0 xxl:flex-[1_1_0%] xxl:overflow-y-auto"
+                    id="logs"
+                >
                     <ProgramLogSection signature={signature} />
                     <CUProfilingSection signature={signature} />
                 </div>

--- a/app/tx/[signature]/use-logs-scroll-sync.ts
+++ b/app/tx/[signature]/use-logs-scroll-sync.ts
@@ -1,0 +1,78 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+export function useLogsPanelScrollSync({
+    panelRef,
+    enabled,
+    watchValue,
+    navThreshold = 80,
+}: {
+    panelRef: RefObject<HTMLDivElement | null>;
+    enabled: boolean;
+    watchValue?: unknown;
+    navThreshold?: number;
+}) {
+    const isManualScrollRef = useRef(false);
+    const manualScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (!enabled) return;
+        const logsPanel = panelRef.current;
+        if (!logsPanel) return;
+
+        // Compute title height once — it doesn't change while scrolling.
+        const titleHeight = (logsPanel.querySelector('[data-section-title]') as HTMLElement | null)?.offsetHeight ?? 0;
+
+        const handleWheel = (e: WheelEvent) => {
+            const { scrollTop, scrollHeight, clientHeight } = logsPanel;
+            const atTop = scrollTop === 0 && e.deltaY < 0;
+            const atBottom = scrollTop + clientHeight >= scrollHeight && e.deltaY > 0;
+            if (atTop || atBottom) return;
+            e.preventDefault();
+            logsPanel.scrollTop += e.deltaY;
+            isManualScrollRef.current = true;
+            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
+            manualScrollTimeoutRef.current = setTimeout(() => {
+                isManualScrollRef.current = false;
+            }, 2000);
+        };
+
+        const handlePageScroll = () => {
+            if (isManualScrollRef.current) return;
+            // Top-level ix-N cards only (excludes nested ix-N-M).
+            const cards = Array.from(document.querySelectorAll<HTMLElement>('[id^="ix-"]')).filter(el => {
+                const suffix = el.id.slice(3);
+                return suffix.length > 0 && !suffix.includes('-') && !Number.isNaN(Number(suffix));
+            });
+            if (cards.length === 0) return;
+
+            // Active = last card whose top has crossed the sticky nav threshold.
+            let activeIndex = 0;
+            for (let i = 0; i < cards.length; i++) {
+                if (cards[i].getBoundingClientRect().top <= navThreshold) activeIndex = i;
+                else break;
+            }
+
+            const cardRect = cards[activeIndex].getBoundingClientRect();
+            const progress = Math.max(0, Math.min(1, (navThreshold - cardRect.top) / cardRect.height));
+
+            const logRow = logsPanel.querySelector<HTMLElement>(`[data-ix-index="${activeIndex}"]`);
+            if (!logRow) return;
+
+            // Use getBoundingClientRect for position independent of current scrollTop.
+            // Offset by the sticky title height so the row appears below it, not under it.
+            const panelRect = logsPanel.getBoundingClientRect();
+            const rowRect = logRow.getBoundingClientRect();
+            const rowAbsoluteTop = rowRect.top - panelRect.top + logsPanel.scrollTop;
+            logsPanel.scrollTop = Math.max(0, rowAbsoluteTop - titleHeight + rowRect.height * progress);
+        };
+
+        logsPanel.addEventListener('wheel', handleWheel, { passive: false });
+        window.addEventListener('scroll', handlePageScroll, { passive: true });
+        return () => {
+            logsPanel.removeEventListener('wheel', handleWheel);
+            window.removeEventListener('scroll', handlePageScroll);
+            if (manualScrollTimeoutRef.current) clearTimeout(manualScrollTimeoutRef.current);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, watchValue, navThreshold]);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
 
 export const breakpoints = new Map([
     ['xxs', 320],
@@ -57,7 +58,17 @@ export const dkColors = {
 
 const config: Config = {
     content: ['./app/**/*.{ts,tsx}'],
-    plugins: [],
+    plugins: [
+        plugin(({ addUtilities }) => {
+            addUtilities({
+                '.scrollbar-hide': {
+                    'scrollbar-width': 'none',
+                    '-ms-overflow-style': 'none',
+                    '&::-webkit-scrollbar': { display: 'none' },
+                },
+            });
+        }),
+    ],
     theme: {
         extend: {
             boxShadow: {


### PR DESCRIPTION
## Description
- adding a sticky logs section
- adding scrolling for both sections at the same time

## Type of change
-   [x] Bug fix

## Screenshots

## Testing
1. open [transaction page](https://explorer-git-fork-hoodieshq-fix-hoo-63-652623-solana-foundation.vercel.app/tx/23wzfRubK7kg6CYTwc4mZXeESRWmPEH5nbgEopVDv9B8hzGYRmg3RhaT26FwchZz764pSR2AWjT52VTZ53FqP4Xe)
2. scroll to programs/logs section

## Related Issues
[HOO-637](https://linear.app/solana-fndn/issue/HOO-637/fix-scrolling-of-log-section)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
