### PR TITLE
Fix: removed css file for tx page

### DIFF
--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -7,7 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/shared/ui/
 import React, { useEffect, useMemo, useState } from 'react';
 import { Check, ChevronDown, Copy, Download } from 'react-feather';
 
-import { DownloadDropdown, type DownloadState } from '@/app/shared/components/DownloadDropdown';
+import { DownloadDropdown, DownloadState } from '@/app/shared/components/DownloadDropdown';
 import { type ByteArray, toBase64, toHex } from '@/app/shared/lib/bytes';
 import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 
@@ -33,11 +33,11 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
     const [tab, setTab] = useState<'hex' | 'base64'>('hex');
     const [expanded, setExpanded] = useState(false);
     const [copyState, copy] = useCopyToClipboard();
-    const [downloadState, setDownloadState] = useState<DownloadState>('idle');
+    const [downloadState, setDownloadState] = useState<DownloadState>(DownloadState.Idle);
 
     useEffect(() => {
-        if (downloadState === 'downloaded') {
-            const t = setTimeout(() => setDownloadState('idle'), 1000);
+        if (downloadState === DownloadState.Downloaded) {
+            const t = setTimeout(() => setDownloadState(DownloadState.Idle), 1000);
             return () => clearTimeout(t);
         }
     }, [downloadState]);
@@ -103,12 +103,12 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                         loading={loading}
                         disabled={!hasData}
                         encodings={[tab]}
-                        onDownload={() => setDownloadState('downloaded')}
+                        onDownload={() => setDownloadState(DownloadState.Downloaded)}
                     >
                         <Button variant="outline" size="sm" aria-label="Download" disabled={!hasData || loading}>
-                            {downloadState === 'downloaded' ? <Check size={12} /> : <Download size={12} />}
+                            {downloadState === DownloadState.Downloaded ? <Check size={12} /> : <Download size={12} />}
                             <span className="hidden md:inline">
-                                {downloadState === 'downloaded' ? 'Downloaded!' : 'Download'}
+                                {downloadState === DownloadState.Downloaded ? 'Downloaded!' : 'Download'}
                             </span>
                         </Button>
                     </DownloadDropdown>

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -7,7 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/shared/ui/
 import React, { useEffect, useMemo, useState } from 'react';
 import { Check, ChevronDown, Copy, Download } from 'react-feather';
 
-import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
+import { DownloadDropdown, type DownloadState } from '@/app/shared/components/DownloadDropdown';
 import { type ByteArray, toBase64, toHex } from '@/app/shared/lib/bytes';
 import { useCopyToClipboard } from '@/app/shared/lib/useCopyToClipboard';
 
@@ -33,7 +33,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
     const [tab, setTab] = useState<'hex' | 'base64'>('hex');
     const [expanded, setExpanded] = useState(false);
     const [copyState, copy] = useCopyToClipboard();
-    const [downloadState, setDownloadState] = useState<'idle' | 'downloaded'>('idle');
+    const [downloadState, setDownloadState] = useState<DownloadState>('idle');
 
     useEffect(() => {
         if (downloadState === 'downloaded') {

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -5,7 +5,7 @@ import { HexData } from '@components/shared/HexData';
 import { Button } from '@components/shared/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/shared/ui/tabs';
 import React, { useEffect, useMemo, useState } from 'react';
-import { Check, ChevronDown, Copy } from 'react-feather';
+import { Check, ChevronDown, Copy, Download } from 'react-feather';
 
 import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
 import { type ByteArray, toBase64, toHex } from '@/app/shared/lib/bytes';
@@ -33,6 +33,14 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
     const [tab, setTab] = useState<'hex' | 'base64'>('hex');
     const [expanded, setExpanded] = useState(false);
     const [copyState, copy] = useCopyToClipboard();
+    const [downloadState, setDownloadState] = useState<'idle' | 'downloaded'>('idle');
+
+    useEffect(() => {
+        if (downloadState === 'downloaded') {
+            const t = setTimeout(() => setDownloadState('idle'), 1000);
+            return () => clearTimeout(t);
+        }
+    }, [downloadState]);
 
     useEffect(() => {
         setExpanded(false);
@@ -95,7 +103,15 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                         loading={loading}
                         disabled={!hasData}
                         encodings={[tab]}
-                    />
+                        onDownload={() => setDownloadState('downloaded')}
+                    >
+                        <Button variant="outline" size="sm" aria-label="Download" disabled={!hasData || loading}>
+                            {downloadState === 'downloaded' ? <Check size={12} /> : <Download size={12} />}
+                            <span className="hidden md:inline">
+                                {downloadState === 'downloaded' ? 'Downloaded!' : 'Download'}
+                            </span>
+                        </Button>
+                    </DownloadDropdown>
                 </div>
             </div>
 

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -82,7 +82,7 @@ function TransactionAccountRow({
                     <div className="mr-2 text-outer-space-300 [grid-area:number] lg:mr-0">{index + 1}</div>
                     <div className="[grid-area:address]">
                         <div className="flex items-center justify-between gap-1 lg:justify-normal landscape:justify-normal">
-                            <div onClick={e => isDesktop && e.stopPropagation()}>
+                            <div className="min-w-0 flex-1" onClick={e => isDesktop && e.stopPropagation()}>
                                 <Address
                                     className={!isDesktop ? 'text-[#33a382]' : ''}
                                     pubkey={pubkey}

--- a/app/features/transaction/ui/transaction-page.css
+++ b/app/features/transaction/ui/transaction-page.css
@@ -1,4 +1,0 @@
-.transaction-page ::selection {
-    background-color: #13d89b40;
-    color: inherit;
-}

--- a/app/shared/components/DownloadDropdown.tsx
+++ b/app/shared/components/DownloadDropdown.tsx
@@ -54,8 +54,8 @@ export function DownloadDropdown({
             return React.cloneElement(trigger as React.ReactElement<React.ButtonHTMLAttributes<HTMLButtonElement>>, {
                 onClick: () => {
                     if (data) {
-                        handleDownload(data, encodings[0], filename);
-                        onDownload?.();
+                        const ok = handleDownload(data, encodings[0], filename);
+                        if (ok) onDownload?.();
                     }
                 },
             });
@@ -76,8 +76,8 @@ export function DownloadDropdown({
                             disabled={loading || !data}
                             onClick={() => {
                                 if (data) {
-                                    handleDownload(data, encoding, filename);
-                                    onDownload?.();
+                                    const ok = handleDownload(data, encoding, filename);
+                                    if (ok) onDownload?.();
                                 }
                             }}
                         >
@@ -90,11 +90,13 @@ export function DownloadDropdown({
     );
 }
 
-function handleDownload(data: ByteArray, encoding: EncodingFormat, filename: string) {
+function handleDownload(data: ByteArray, encoding: EncodingFormat, filename: string): boolean {
     try {
         const encoded = encodeBytes(data, encoding);
         triggerDownloadText(encoded, `${filename}_${encoding}.txt`);
+        return true;
     } catch (err) {
         Logger.error(new Error(`Failed to download ${encoding} file`, { cause: err }));
+        return false;
     }
 }

--- a/app/shared/components/DownloadDropdown.tsx
+++ b/app/shared/components/DownloadDropdown.tsx
@@ -12,7 +12,10 @@ import { type ByteArray, encodeTransactionData as encodeBytes, type EncodingForm
 import React from 'react';
 import { Download } from 'react-feather';
 
-export type DownloadState = 'idle' | 'downloaded';
+export enum DownloadState {
+    Downloaded = 'downloaded',
+    Idle = 'idle',
+}
 
 import { Logger } from '@/app/shared/lib/logger';
 import { triggerDownloadText } from '@/app/shared/lib/triggerDownload';

--- a/app/shared/components/DownloadDropdown.tsx
+++ b/app/shared/components/DownloadDropdown.tsx
@@ -12,6 +12,8 @@ import { type ByteArray, encodeTransactionData as encodeBytes, type EncodingForm
 import React from 'react';
 import { Download } from 'react-feather';
 
+export type DownloadState = 'idle' | 'downloaded';
+
 import { Logger } from '@/app/shared/lib/logger';
 import { triggerDownloadText } from '@/app/shared/lib/triggerDownload';
 
@@ -33,6 +35,7 @@ export function DownloadDropdown({
     filename,
     encodings = DEFAULT_ENCODINGS,
     onOpenChange,
+    onDownload,
     children,
 }: {
     data: ByteArray | undefined;
@@ -42,13 +45,19 @@ export function DownloadDropdown({
     filename: string;
     encodings?: EncodingFormat[];
     onOpenChange?: (open: boolean) => void;
+    onDownload?: () => void;
     children?: React.ReactNode;
 }) {
     if (encodings.length <= 1) {
         const trigger = children ?? <DefaultTrigger disabled={loading || disabled} />;
         if (React.isValidElement(trigger)) {
             return React.cloneElement(trigger as React.ReactElement<React.ButtonHTMLAttributes<HTMLButtonElement>>, {
-                onClick: () => data && handleDownload(data, encodings[0], filename),
+                onClick: () => {
+                    if (data) {
+                        handleDownload(data, encodings[0], filename);
+                        onDownload?.();
+                    }
+                },
             });
         }
         return trigger;
@@ -65,7 +74,12 @@ export function DownloadDropdown({
                         <DropdownMenuItem
                             key={encoding}
                             disabled={loading || !data}
-                            onClick={() => data && handleDownload(data, encoding, filename)}
+                            onClick={() => {
+                                if (data) {
+                                    handleDownload(data, encoding, filename);
+                                    onDownload?.();
+                                }
+                            }}
                         >
                             {loading ? `Loading ${encoding}…` : `Download ${encoding}`}
                         </DropdownMenuItem>

--- a/app/tx/[signature]/page-client.tsx
+++ b/app/tx/[signature]/page-client.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import '@features/transaction/ui/transaction-page.css';
-
 import { ErrorCard } from '@components/common/ErrorCard';
 import { LoadingCard } from '@components/common/LoadingCard';
 import { SignatureContext } from '@components/instruction/SignatureContext';
@@ -85,7 +83,7 @@ export function TransactionDetailsPageClient({ params: { signature: raw } }: Pro
     }
 
     return (
-        <div className="transaction-page mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 lg:space-y-12 lg:px-6 lg:pt-5">
+        <div className="mx-auto flex max-w-5xl flex-col space-y-9 px-4 pt-3 selection:bg-[#13d89b40] selection:text-inherit lg:space-y-12 lg:px-6 lg:pt-5">
             <header className="-mb-6 flex flex-col gap-1.5 pb-3 pt-2 lg:mb-0">
                 <span className="text-xs font-normal uppercase text-muted">Details</span>
                 <h1 className="m-0 text-2xl font-normal leading-none text-white md:text-3xl">Transaction</h1>


### PR DESCRIPTION
## Description
- removing css file and moving styles to tailwind
- adding complete state for download btn
- fixing styles for address wrapping in accounts card

## Type of change
-   [x] Bug fix

## Screenshots
<img width="1120" height="598" alt="Screenshot 2026-06-24 at 17 22 50" src="https://github.com/user-attachments/assets/2029e477-e4bd-4cbb-bf72-b6d641aa2d75" />

## Testing
1. open tx page
2. Scroll to the accounts block

## Related Issues
[HOO-713](https://linear.app/solana-fndn/issue/HOO-713/consider-adding-a-template-for-issues)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes
