### PR TITLE
feat: Upgradeable BPF Loader decoding, Squads v4 batch support, buffer hash & inspect link

### DIFF
--- a/app/address/[address]/layout.tsx
+++ b/app/address/[address]/layout.tsx
@@ -10,6 +10,7 @@ import { isNFTokenAccount, parseNFTokenCollectionAccount } from '@components/acc
 import { NFTOKEN_ADDRESS } from '@components/account/nftoken/nftoken';
 import { NFTokenAccountSection } from '@components/account/nftoken/NFTokenAccountSection';
 import { NonceAccountSection } from '@components/account/NonceAccountSection';
+import { detectSquadsAccountType, SquadsAccountSection } from '@components/account/squads/SquadsAccountSection';
 import { SysvarAccountSection } from '@components/account/SysvarAccountSection';
 import { TokenAccountSection } from '@components/account/TokenAccountSection';
 import { UnknownAccountCard } from '@components/account/UnknownAccountCard';
@@ -268,6 +269,10 @@ function InfoSection({ account, tokenInfo }: { account: Account; tokenInfo?: Ful
     // get feature data from featureGates.json
     const featureInfo = useFeatureInfo({ address: account.pubkey.toBase58() });
 
+    // Squads v4 Batch / VaultTransaction accounts aren't RPC-parsed; detect them by
+    // discriminator so we can surface a direct "Inspect" link to the transaction inspector.
+    const squadsAccountType = rawData ? detectSquadsAccountType(account.owner, rawData) : undefined;
+
     if (parsedData && parsedData.program === 'bpf-upgradeable-loader') {
         return (
             <UpgradeableLoaderAccountSection
@@ -309,6 +314,8 @@ function InfoSection({ account, tokenInfo }: { account: Account; tokenInfo?: Ful
         return <FeatureAccountSection account={account} />;
     } else if (account.owner.toBase58() === SAS_PROGRAM_ID) {
         return <SolanaAttestationServiceCard account={account} />;
+    } else if (squadsAccountType) {
+        return <SquadsAccountSection account={account} accountType={squadsAccountType} />;
     } else {
         const fallback = <UnknownAccountCard account={account} />;
         return (

--- a/app/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/app/components/account/UpgradeableLoaderAccountSection.tsx
@@ -11,6 +11,7 @@ import { Account } from '@providers/accounts';
 import { useCluster } from '@providers/cluster';
 import { PublicKey } from '@solana/web3.js';
 import { addressLabel } from '@utils/tx';
+import { hashProgramBuffer } from '@utils/verified-builds';
 import {
     ProgramAccountInfo,
     ProgramBufferAccountInfo,
@@ -32,6 +33,7 @@ import { BaseTable } from '@/app/shared/ui/Table';
 import { Cluster } from '@/app/utils/cluster';
 import { useClusterPath } from '@/app/utils/url';
 
+import { Copyable } from '../common/Copyable';
 import { VerifiedProgramBadge } from '../common/VerifiedProgramBadge';
 
 export function UpgradeableLoaderAccountSection({
@@ -290,6 +292,7 @@ export function UpgradeableProgramBufferSection({
     programBuffer: ProgramBufferAccountInfo;
 }) {
     const refresh = useRefreshAccount();
+    const bufferHash = React.useMemo(() => hashProgramBuffer(programBuffer), [programBuffer]);
     return (
         <Card ui="dashkit">
             <CardHeader ui="dashkit">
@@ -327,6 +330,22 @@ export function UpgradeableProgramBufferSection({
                     <BaseTable.Row>
                         <BaseTable.Cell>Data Size (Bytes)</BaseTable.Cell>
                         <BaseTable.Cell className="text-right">{account.space}</BaseTable.Cell>
+                    </BaseTable.Row>
+                )}
+                {bufferHash && (
+                    <BaseTable.Row>
+                        <BaseTable.Cell>
+                            <InfoTooltip text="sha256 of the buffer's program bytes with trailing zero padding removed — the same hash as `solana-verify get-buffer-hash`. Compare it against the build hash you expect to deploy.">
+                                <span className="text-dk-white">Buffer Hash</span>
+                            </InfoTooltip>
+                        </BaseTable.Cell>
+                        <BaseTable.Cell className="text-right">
+                            <div className="flex items-center justify-end">
+                                <Copyable text={bufferHash}>
+                                    <span className="break-all font-mono">{bufferHash}</span>
+                                </Copyable>
+                            </div>
+                        </BaseTable.Cell>
                     </BaseTable.Row>
                 )}
                 {programBuffer.authority !== null && (

--- a/app/components/account/squads/SquadsAccountSection.tsx
+++ b/app/components/account/squads/SquadsAccountSection.tsx
@@ -1,0 +1,78 @@
+import { Address } from '@components/common/Address';
+import { SolBalance } from '@components/common/SolBalance';
+import { TableCardBody } from '@components/common/TableCardBody';
+import { Account } from '@providers/accounts';
+import { PublicKey } from '@solana/web3.js';
+import { generated } from '@sqds/multisig';
+import Link from 'next/link';
+import React from 'react';
+import { Search } from 'react-feather';
+
+import { Button } from '@/app/components/shared/ui/button';
+import { SQUADS_V4_ADDRESS } from '@/app/providers/squadsMultisig';
+import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
+import { BaseTable } from '@/app/shared/ui/Table';
+import { useClusterPath } from '@/app/utils/url';
+
+const { batchDiscriminator, vaultTransactionDiscriminator } = generated;
+
+export type SquadsAccountType = 'batch' | 'vaultTransaction';
+
+/**
+ * Identify a Squads v4 Batch or VaultTransaction account from its owner + the 8-byte
+ * account discriminator, so the address page can offer a direct "Inspect" link instead
+ * of falling back to the generic Unknown Account card. Both are accepted by the
+ * inspector's `squadsTx` param.
+ */
+export function detectSquadsAccountType(owner: PublicKey, rawData: Uint8Array): SquadsAccountType | undefined {
+    if (owner.toBase58() !== SQUADS_V4_ADDRESS || rawData.length < 8) return undefined;
+    const matches = (discriminator: number[]) => discriminator.every((byte, i) => byte === rawData[i]);
+    if (matches(batchDiscriminator)) return 'batch';
+    if (matches(vaultTransactionDiscriminator)) return 'vaultTransaction';
+    return undefined;
+}
+
+export function SquadsAccountSection({ account, accountType }: { account: Account; accountType: SquadsAccountType }) {
+    const inspectorPath = useClusterPath({
+        additionalParams: new URLSearchParams({ squadsTx: account.pubkey.toBase58() }),
+        pathname: '/tx/inspector',
+    });
+    const label = accountType === 'batch' ? 'Squads Batch' : 'Squads Vault Transaction';
+
+    return (
+        <Card ui="dashkit">
+            <CardHeader ui="dashkit" className="gap-2">
+                <CardTitle as="h3" ui="dashkit" className="flex items-center">
+                    {label}
+                </CardTitle>
+                <Button ui="dashkit" variant="primary" size="sm" asChild>
+                    <Link href={inspectorPath}>
+                        <Search className="mr-1.5 align-text-top" size={13} />
+                        Inspect
+                    </Link>
+                </Button>
+            </CardHeader>
+
+            <TableCardBody>
+                <BaseTable.Row>
+                    <BaseTable.Cell>Address</BaseTable.Cell>
+                    <BaseTable.Cell className="text-right">
+                        <Address pubkey={account.pubkey} alignRight raw />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+                <BaseTable.Row>
+                    <BaseTable.Cell>Balance (SOL)</BaseTable.Cell>
+                    <BaseTable.Cell className="text-right uppercase">
+                        <SolBalance lamports={account.lamports} />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+                <BaseTable.Row>
+                    <BaseTable.Cell>Owner</BaseTable.Cell>
+                    <BaseTable.Cell className="text-right">
+                        <Address pubkey={account.owner} alignRight link />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            </TableCardBody>
+        </Card>
+    );
+}

--- a/app/components/account/squads/__tests__/detectSquadsAccountType.spec.ts
+++ b/app/components/account/squads/__tests__/detectSquadsAccountType.spec.ts
@@ -1,0 +1,43 @@
+import { PublicKey } from '@solana/web3.js';
+import { generated } from '@sqds/multisig';
+import { describe, expect, it } from 'vitest';
+
+import { SQUADS_V4_ADDRESS } from '@/app/providers/squadsMultisig';
+
+import { detectSquadsAccountType } from '../SquadsAccountSection';
+
+const SQUADS_OWNER = new PublicKey(SQUADS_V4_ADDRESS);
+
+function withDiscriminator(discriminator: number[]): Uint8Array {
+    const data = new Uint8Array(64);
+    data.set(discriminator, 0);
+    return data;
+}
+
+describe('detectSquadsAccountType', () => {
+    it('should detect a Batch account', () => {
+        expect(detectSquadsAccountType(SQUADS_OWNER, withDiscriminator(generated.batchDiscriminator))).toBe('batch');
+    });
+
+    it('should detect a VaultTransaction account', () => {
+        expect(detectSquadsAccountType(SQUADS_OWNER, withDiscriminator(generated.vaultTransactionDiscriminator))).toBe(
+            'vaultTransaction',
+        );
+    });
+
+    it('should return undefined when not owned by the Squads v4 program', () => {
+        expect(
+            detectSquadsAccountType(PublicKey.default, withDiscriminator(generated.batchDiscriminator)),
+        ).toBeUndefined();
+    });
+
+    it('should return undefined for a non-matching discriminator (e.g. Proposal)', () => {
+        expect(
+            detectSquadsAccountType(SQUADS_OWNER, withDiscriminator(generated.proposalDiscriminator)),
+        ).toBeUndefined();
+    });
+
+    it('should return undefined for data shorter than the discriminator', () => {
+        expect(detectSquadsAccountType(SQUADS_OWNER, new Uint8Array(4))).toBeUndefined();
+    });
+});

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -17,7 +17,7 @@ import {
     PublicKey,
     VersionedMessage,
 } from '@solana/web3.js';
-import { generated, PROGRAM_ADDRESS as SQUADS_V4_PROGRAM_ADDRESS } from '@sqds/multisig';
+import { generated, getBatchTransactionPda, PROGRAM_ADDRESS as SQUADS_V4_PROGRAM_ADDRESS } from '@sqds/multisig';
 import bs58 from 'bs58';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
@@ -40,7 +40,32 @@ import { InstructionsSection } from './InstructionsSection';
 import { MIN_MESSAGE_LENGTH, RawInput } from './RawInputCard';
 import { TransactionSignatures } from './SignaturesCard';
 
-const { VaultTransaction } = generated;
+const { Batch, VaultBatchTransaction, VaultTransaction, batchDiscriminator } = generated;
+
+// Convert a Squads VaultTransactionMessage (shared by VaultTransaction and the inner
+// transactions of a Batch) into a web3.js VersionedMessage the inspector can render.
+export function vaultMessageToVersionedMessage(message: typeof VaultTransaction.prototype.message): VersionedMessage {
+    return new MessageV0({
+        addressTableLookups: message.addressTableLookups.map(x => ({
+            ...x,
+            readonlyIndexes: Array.from(x.readonlyIndexes),
+            writableIndexes: Array.from(x.writableIndexes),
+        })),
+        compiledInstructions: message.instructions.map(instruction => ({
+            accountKeyIndexes: Array.from(instruction.accountIndexes),
+            data: instruction.data,
+            programIdIndex: instruction.programIdIndex,
+        })),
+        header: {
+            numReadonlySignedAccounts: message.numSigners - message.numWritableSigners,
+            numReadonlyUnsignedAccounts:
+                message.accountKeys.length - message.numSigners - message.numWritableNonSigners,
+            numRequiredSignatures: message.numSigners,
+        },
+        recentBlockhash: bs58.encode(Uint8Array.from(new Array(32).fill(0))),
+        staticAccountKeys: message.accountKeys,
+    });
+}
 
 export type TransactionData = {
     rawMessage: Uint8Array;
@@ -180,32 +205,65 @@ function decodeUrlParams(
 
 function SquadsProposalInspectorCard({ account, onClear }: { account: string; onClear: () => void }) {
     const { url } = useCluster();
+    const [selected, setSelected] = React.useState(0);
 
-    const fetcher = React.useCallback(async () => {
+    // Reset the selected inner transaction whenever a different account is inspected.
+    React.useEffect(() => {
+        setSelected(0);
+    }, [account]);
+
+    const fetcher = React.useCallback(async (): Promise<(VersionedMessage | undefined)[]> => {
         const connection = new Connection(url);
-        try {
-            // First check if the account exists and is owned by the Squads program
-            const accountInfo = await connection.getAccountInfo(new PublicKey(account), 'confirmed');
+        const pubkey = new PublicKey(account);
 
-            if (!accountInfo) {
-                throw new Error('Account not found');
-            }
-
-            // Check if the account is owned by the Squads program
-            const isSquadsAccount = accountInfo.owner.toString() === SQUADS_V4_PROGRAM_ADDRESS.toString();
-
-            if (!isSquadsAccount) {
-                throw new Error(`Account ${account} is not a valid Squads transaction account`);
-            }
-
-            return await VaultTransaction.fromAccountAddress(connection, new PublicKey(account), 'confirmed');
-        } catch (err) {
-            throw err instanceof Error ? err : new Error('Failed to fetch account data');
+        // First check if the account exists and is owned by the Squads program
+        const accountInfo = await connection.getAccountInfo(pubkey, 'confirmed');
+        if (!accountInfo) {
+            throw new Error('Account not found');
         }
+        if (accountInfo.owner.toString() !== SQUADS_V4_PROGRAM_ADDRESS.toString()) {
+            throw new Error(`Account ${account} is not a valid Squads transaction account`);
+        }
+
+        // The account discriminator (first 8 bytes) distinguishes a Batch — which holds
+        // many inner transactions — from a single VaultTransaction.
+        const discriminator = accountInfo.data.subarray(0, 8);
+        const isBatch = batchDiscriminator.every((byte, i) => byte === discriminator[i]);
+
+        if (isBatch) {
+            const batch = await Batch.fromAccountAddress(connection, pubkey, 'confirmed');
+            const batchIndex = BigInt(batch.index.toString());
+            // Inner VaultBatchTransactions are 1-indexed PDAs derived from the multisig + batch index.
+            // Each fetch is isolated so one unavailable transaction (e.g. a PDA closed after
+            // execution) doesn't sink the whole batch — failed slots become undefined and render
+            // an "unavailable" notice below.
+            const results = await Promise.all(
+                Array.from({ length: batch.size }, async (_unused, i) => {
+                    try {
+                        const [pda] = getBatchTransactionPda({
+                            batchIndex,
+                            multisigPda: batch.multisig,
+                            transactionIndex: i + 1,
+                        });
+                        const vbt = await VaultBatchTransaction.fromAccountAddress(connection, pda, 'confirmed');
+                        return vaultMessageToVersionedMessage(vbt.message);
+                    } catch {
+                        return undefined;
+                    }
+                }),
+            );
+            if (results.every(message => message === undefined)) {
+                throw new Error('None of the batch transactions could be loaded');
+            }
+            return results;
+        }
+
+        const vaultTransaction = await VaultTransaction.fromAccountAddress(connection, pubkey, 'confirmed');
+        return [vaultMessageToVersionedMessage(vaultTransaction.message)];
     }, [account, url]);
 
     const {
-        data: vaultTransaction,
+        data: messages,
         error,
         isLoading,
     } = useSWR(['squads-proposal', account, url], fetcher, {
@@ -218,56 +276,57 @@ function SquadsProposalInspectorCard({ account, onClear }: { account: string; on
         return <LoadingCard message="Loading Squads transaction..." />;
     }
 
-    if (error || !vaultTransaction) {
+    if (error || !messages || messages.length === 0) {
         return (
-            <ErrorCard text={`Error loading vault transaction: ${error?.message}`} retry={onClear} retryText="Clear" />
+            <ErrorCard
+                text={`Error loading Squads transaction: ${error?.message ?? 'no transactions found'}`}
+                retry={onClear}
+                retryText="Clear"
+            />
         );
     }
 
-    // Convert VaultTransactionMessage to a format compatible with Message
-    const convertVaultTransactionToMessage = (vaultTx: typeof VaultTransaction.prototype): VersionedMessage => {
-        const { message } = vaultTx;
-        const accountKeys = message.accountKeys;
-
-        // Create a standard Message object with the necessary fields
-        const solanaMessage = new MessageV0({
-            addressTableLookups: message.addressTableLookups.map(x => ({
-                ...x,
-                readonlyIndexes: Array.from(x.readonlyIndexes),
-                writableIndexes: Array.from(x.writableIndexes),
-            })),
-            compiledInstructions: message.instructions.map(instruction => ({
-                accountKeyIndexes: Array.from(instruction.accountIndexes),
-                data: instruction.data,
-                programIdIndex: instruction.programIdIndex,
-            })),
-            header: {
-                numReadonlySignedAccounts: message.numSigners - message.numWritableSigners,
-                numReadonlyUnsignedAccounts:
-                    message.accountKeys.length - message.numSigners - message.numWritableNonSigners,
-                numRequiredSignatures: message.numSigners,
-            },
-            recentBlockhash: bs58.encode(Uint8Array.from(new Array(32).fill(0))),
-            staticAccountKeys: accountKeys,
-        });
-
-        return solanaMessage;
-    };
-
-    // Create a serialized version of the message for rawMessage
-    const convertedMessage = convertVaultTransactionToMessage(vaultTransaction);
-    const serializedMessage = convertedMessage.serialize();
+    const activeIndex = Math.min(selected, messages.length - 1);
+    const message = messages[activeIndex];
 
     return (
-        <LoadedView
-            transaction={{
-                message: convertedMessage,
-                rawMessage: serializedMessage,
-                signatures: undefined,
-            }}
-            onClear={onClear}
-            showTokenBalanceChanges={false}
-        />
+        <>
+            {messages.length > 1 && (
+                <Card ui="dashkit" className="mb-4">
+                    <CardHeader ui="dashkit" className="flex-wrap gap-2">
+                        <CardTitle as="h3" ui="dashkit">
+                            Batch · {messages.length} transactions
+                        </CardTitle>
+                        <div className="flex flex-wrap gap-2">
+                            {messages.map((_unused, i) => (
+                                <Button
+                                    key={i}
+                                    ui="dashkit"
+                                    size="sm"
+                                    variant={i === activeIndex ? 'primary' : 'white'}
+                                    onClick={() => setSelected(i)}
+                                >
+                                    {i + 1}
+                                </Button>
+                            ))}
+                        </div>
+                    </CardHeader>
+                </Card>
+            )}
+            {message ? (
+                <LoadedView
+                    transaction={{
+                        message,
+                        rawMessage: message.serialize(),
+                        signatures: undefined,
+                    }}
+                    onClear={onClear}
+                    showTokenBalanceChanges={false}
+                />
+            ) : (
+                <ErrorCard text="This batch transaction is unavailable — its account may have been closed after execution." />
+            )}
+        </>
     );
 }
 
@@ -291,14 +350,22 @@ export function TransactionInspectorPage({
         if (signature) return;
         if (inspectorData && inspectorData !== prevInspectorData) {
             if (isSquadsProposalAccountData(inspectorData)) {
-                // Handle Squads proposal URL params
-                const nextQueryParams = new URLSearchParams(currentSearchParams?.toString());
-                nextQueryParams.set('squadsTx', inspectorData.account);
-                // Remove any other transaction params that might exist
-                nextQueryParams.delete('message');
-                nextQueryParams.delete('signatures');
-                const queryString = nextQueryParams.toString();
-                router.replace(`${currentPathname}?${queryString}`);
+                // Only rewrite the URL when it doesn't already encode this squadsTx. Without this
+                // guard, router.replace to an identical URL yields a fresh searchParams ref, which
+                // re-runs the decode effect → setInspectorData(new object) → replace → infinite loop.
+                // (Mirrors the guard the raw-message branch below already applies.)
+                const alreadyInSync =
+                    currentSearchParams?.get('squadsTx') === inspectorData.account &&
+                    !currentSearchParams?.get('message') &&
+                    !currentSearchParams?.get('signatures');
+                if (!alreadyInSync) {
+                    const nextQueryParams = new URLSearchParams(currentSearchParams?.toString());
+                    nextQueryParams.set('squadsTx', inspectorData.account);
+                    // Remove any other transaction params that might exist
+                    nextQueryParams.delete('message');
+                    nextQueryParams.delete('signatures');
+                    router.replace(`${currentPathname}?${nextQueryParams.toString()}`);
+                }
                 return;
             }
 

--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -23,6 +23,7 @@ import { ErrorCard } from '../common/ErrorCard';
 import { InspectorInstructionCard as InspectorInstructionCardComponent } from '../common/InspectorInstructionCard';
 import { LoadingCard } from '../common/LoadingCard';
 import AnchorDetailsCard from '../instruction/AnchorDetailsCard';
+import { BpfUpgradeableLoaderDetailsCard } from '../instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard';
 import { ComputeBudgetDetailsCard } from '../instruction/ComputeBudgetDetailsCard';
 import { SystemDetailsCard } from '../instruction/system/SystemDetailsCard';
 import { TokenDetailsCard } from '../instruction/token/TokenDetailsCard';
@@ -222,6 +223,21 @@ function InspectorInstructionCard({
                     index={index}
                     result={INSPECTOR_RESULT}
                 />
+            );
+        case 'bpf-upgradeable-loader':
+            return (
+                <ErrorBoundary
+                    fallback={<UnknownDetailsCard key={index} index={index} ix={ix} programName={programName} />}
+                >
+                    <BpfUpgradeableLoaderDetailsCard
+                        key={index}
+                        ix={parsedIx}
+                        tx={parsedTx}
+                        index={index}
+                        result={INSPECTOR_RESULT}
+                        raw={ix}
+                    />
+                </ErrorBoundary>
             );
         case 'spl-token':
             return (

--- a/app/components/inspector/__tests__/InspectorPage.spec.tsx
+++ b/app/components/inspector/__tests__/InspectorPage.spec.tsx
@@ -13,7 +13,7 @@ import { ClusterProvider } from '@/app/providers/cluster';
 import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
 import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
 
-import { TransactionInspectorPage } from '../InspectorPage';
+import { TransactionInspectorPage, vaultMessageToVersionedMessage } from '../InspectorPage';
 
 vi.mock('swr', () => ({
     __esModule: true,
@@ -64,7 +64,11 @@ describe('TransactionInspectorPage with Squads Transaction', () => {
         (mockSWR.default as unknown as Mock).mockImplementation((key: Key) => {
             if (Array.isArray(key) && key[0] === specificAccountKey[0] && key[1] === specificAccountKey[1]) {
                 return {
-                    data: generated.VaultTransaction.fromAccountInfo(squadsAccountInfo)[0],
+                    data: [
+                        vaultMessageToVersionedMessage(
+                            generated.VaultTransaction.fromAccountInfo(squadsAccountInfo)[0].message,
+                        ),
+                    ],
                     error: null,
                     isLoading: false,
                 };
@@ -102,7 +106,7 @@ describe('TransactionInspectorPage with Squads Transaction', () => {
 
         renderWithContext();
 
-        expect(await screen.findByText(/Error loading vault transaction/i)).toBeInTheDocument();
+        expect(await screen.findByText(/Error loading Squads transaction/i)).toBeInTheDocument();
     });
 
     test('should render Squads transaction with lookup table without crashing', async () => {
@@ -112,7 +116,11 @@ describe('TransactionInspectorPage with Squads Transaction', () => {
         (mockSWR.default as unknown as Mock).mockImplementation((key: Key) => {
             if (Array.isArray(key) && key[0] === specificAccountKey[0] && key[1] === specificAccountKey[1]) {
                 return {
-                    data: generated.VaultTransaction.fromAccountInfo(squadsLookupTableAccountInfo)[0],
+                    data: [
+                        vaultMessageToVersionedMessage(
+                            generated.VaultTransaction.fromAccountInfo(squadsLookupTableAccountInfo)[0].message,
+                        ),
+                    ],
                     error: null,
                     isLoading: false,
                 };

--- a/app/components/instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard.tsx
+++ b/app/components/instruction/bpf-upgradeable-loader/BpfUpgradeableLoaderDetailsCard.tsx
@@ -1,5 +1,11 @@
 import { Address } from '@components/common/Address';
-import { ParsedInstruction, ParsedTransaction, PublicKey, SignatureResult } from '@solana/web3.js';
+import {
+    ParsedInstruction,
+    ParsedTransaction,
+    PublicKey,
+    SignatureResult,
+    TransactionInstruction,
+} from '@solana/web3.js';
 import { camelToTitleCase } from '@utils/index';
 import { ParsedInfo } from '@validators/index';
 import React from 'react';
@@ -15,6 +21,7 @@ import {
     DeployWithMaxDataLenInfo,
     ExtendProgramInfo,
     InitializeBufferInfo,
+    SetAuthorityCheckedInfo,
     SetAuthorityInfo,
     UpgradeInfo,
     WriteInfo,
@@ -27,6 +34,8 @@ type DetailsProps = {
     result: SignatureResult;
     innerCards?: JSX.Element[];
     childIndex?: number;
+    // Raw instruction for the inspector's "Raw" account/hex toggle.
+    raw?: TransactionInstruction;
 };
 
 export function BpfUpgradeableLoaderDetailsCard(props: DetailsProps) {
@@ -47,6 +56,9 @@ export function BpfUpgradeableLoaderDetailsCard(props: DetailsProps) {
             }
             case 'setAuthority': {
                 return renderDetails<SetAuthorityInfo>(props, parsed, SetAuthorityInfo);
+            }
+            case 'setAuthorityChecked': {
+                return renderDetails<SetAuthorityCheckedInfo>(props, parsed, SetAuthorityCheckedInfo);
             }
             case 'close': {
                 return renderDetails<CloseInfo>(props, parsed, CloseInfo);
@@ -81,7 +93,7 @@ function renderDetails<T extends object>(props: DetailsProps, parsed: ParsedInfo
         }
 
         attributes.push(
-            <BaseTable.Row key={key}>
+            <BaseTable.Row key={key} data-testid={`ix-args-${key}`}>
                 <BaseTable.Cell>
                     {camelToTitleCase(key)} {key === 'bytes' && <span className="text-dk-gray-700">(Base 64)</span>}
                 </BaseTable.Cell>

--- a/app/components/instruction/bpf-upgradeable-loader/__tests__/BpfUpgradeableLoaderDetailsCard.test.tsx
+++ b/app/components/instruction/bpf-upgradeable-loader/__tests__/BpfUpgradeableLoaderDetailsCard.test.tsx
@@ -1,0 +1,85 @@
+import { PublicKey } from '@solana/web3.js';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { BpfUpgradeableLoaderDetailsCard } from '../BpfUpgradeableLoaderDetailsCard';
+
+// Mock InstructionCard so the test doesn't pull in transaction/cluster providers; render the
+// title and the attribute rows (children) inside a table, mirroring the Lighthouse test pattern.
+vi.mock('../../InstructionCard', () => ({
+    InstructionCard: ({ children, title }: { children: React.ReactNode; title: string }) => (
+        <div data-testid="instruction-card" className="card">
+            <div className="card-header">
+                <div>{title}</div>
+            </div>
+            <table>
+                <tbody>{children}</tbody>
+            </table>
+        </div>
+    ),
+}));
+
+vi.mock('@components/common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: PublicKey }) => <div data-testid="address">{pubkey.toBase58()}</div>,
+}));
+
+const BPF_UPGRADEABLE_LOADER_ID = 'BPFLoaderUpgradeab1e11111111111111111111111';
+
+const defaultProps = {
+    childIndex: undefined,
+    index: 0,
+    innerCards: undefined,
+    result: { err: null },
+    tx: { signatures: ['testsignature'] },
+} as any;
+
+describe('BpfUpgradeableLoaderDetailsCard', () => {
+    const account = 'GcdayuLaLyrdmUu324nahyv33G5poQdLUEZ1nEytDeP';
+    const authority = '5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9';
+    const newAuthority = 'Addo6uyKf6oRpiCfdj1HEN3PwQuJM7QyhBPCNqRPpwUC';
+
+    it('should render Set Authority (Checked) instruction with all accounts and named args', () => {
+        const ix = {
+            parsed: {
+                info: { account, authority, newAuthority },
+                type: 'setAuthorityChecked',
+            },
+            program: 'bpf-upgradeable-loader',
+            programId: new PublicKey(BPF_UPGRADEABLE_LOADER_ID),
+        } as any;
+
+        render(<BpfUpgradeableLoaderDetailsCard ix={ix} {...defaultProps} />);
+
+        // Previously this instruction type was unhandled and fell back to the "Unknown
+        // Instruction" raw view; it now renders a proper, titled card.
+        expect(screen.getByText('BPF Upgradeable Loader: Set Authority Checked')).toBeInTheDocument();
+
+        const accountRow = screen.getByTestId('ix-args-account');
+        expect(accountRow).toHaveTextContent('Account');
+        expect(accountRow).toHaveTextContent(account);
+
+        const authorityRow = screen.getByTestId('ix-args-authority');
+        expect(authorityRow).toHaveTextContent('Authority');
+        expect(authorityRow).toHaveTextContent(authority);
+
+        const newAuthorityRow = screen.getByTestId('ix-args-newAuthority');
+        expect(newAuthorityRow).toHaveTextContent('New Authority');
+        expect(newAuthorityRow).toHaveTextContent(newAuthority);
+    });
+
+    it('should still render the unchecked Set Authority instruction', () => {
+        const ix = {
+            parsed: {
+                info: { account, authority, newAuthority },
+                type: 'setAuthority',
+            },
+            program: 'bpf-upgradeable-loader',
+            programId: new PublicKey(BPF_UPGRADEABLE_LOADER_ID),
+        } as any;
+
+        render(<BpfUpgradeableLoaderDetailsCard ix={ix} {...defaultProps} />);
+
+        expect(screen.getByText('BPF Upgradeable Loader: Set Authority')).toBeInTheDocument();
+        expect(screen.getByTestId('ix-args-newAuthority')).toHaveTextContent(newAuthority);
+    });
+});

--- a/app/components/instruction/bpf-upgradeable-loader/types.ts
+++ b/app/components/instruction/bpf-upgradeable-loader/types.ts
@@ -46,6 +46,13 @@ export const SetAuthorityInfo = type({
     newAuthority: optional(PublicKeyFromString),
 });
 
+export type SetAuthorityCheckedInfo = Infer<typeof SetAuthorityCheckedInfo>;
+export const SetAuthorityCheckedInfo = type({
+    account: PublicKeyFromString,
+    authority: PublicKeyFromString,
+    newAuthority: PublicKeyFromString,
+});
+
 export type CloseInfo = Infer<typeof CloseInfo>;
 export const CloseInfo = type({
     account: PublicKeyFromString,
@@ -70,6 +77,7 @@ export const UpgradeableBpfLoaderInstructionType = enums([
     'deployWithMaxDataLen',
     'upgrade',
     'setAuthority',
+    'setAuthorityChecked',
     'close',
     'extendProgram',
 ]);

--- a/app/features/decode-instruction-bpf-upgradeable-loader/__tests__/bpf-upgradeable-loader-parser.spec.ts
+++ b/app/features/decode-instruction-bpf-upgradeable-loader/__tests__/bpf-upgradeable-loader-parser.spec.ts
@@ -1,0 +1,101 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { describe, expect, test } from 'vitest';
+
+import { toKitInstruction } from '@/app/shared/lib/web3js-compat';
+
+import {
+    BPF_UPGRADEABLE_LOADER_PROGRAM_ID,
+    parseBpfUpgradeableLoaderInstruction,
+    parseBpfUpgradeableLoaderRpcInstruction,
+} from '../lib/bpf-upgradeable-loader-parser';
+
+const PROGRAM_ID = new PublicKey(BPF_UPGRADEABLE_LOADER_PROGRAM_ID);
+const account = new PublicKey('GcdayuLaLyrdmUu324nahyv33G5poQdLUEZ1nEytDeP');
+const authority = new PublicKey('5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9');
+const newAuthority = new PublicKey('Addo6uyKf6oRpiCfdj1HEN3PwQuJM7QyhBPCNqRPpwUC');
+
+function key(pubkey: PublicKey) {
+    return { isSigner: false, isWritable: true, pubkey };
+}
+
+function u32le(value: number): Buffer {
+    const b = Buffer.alloc(4);
+    b.writeUInt32LE(value, 0);
+    return b;
+}
+
+function decodeRaw(data: Buffer, keys: PublicKey[]) {
+    const ix = new TransactionInstruction({ data, keys: keys.map(key), programId: PROGRAM_ID });
+    return parseBpfUpgradeableLoaderInstruction(toKitInstruction(ix));
+}
+
+describe('parseBpfUpgradeableLoaderInstruction (byte path)', () => {
+    test('should decode SetAuthorityChecked (discriminant 7) with all three accounts', () => {
+        const parsed = decodeRaw(u32le(7), [account, authority, newAuthority]);
+        expect(parsed?.type).toBe('setAuthorityChecked');
+        expect((parsed?.info as any).account.equals(account)).toBe(true);
+        expect((parsed?.info as any).authority.equals(authority)).toBe(true);
+        expect((parsed?.info as any).newAuthority.equals(newAuthority)).toBe(true);
+    });
+
+    test('should decode SetAuthority (discriminant 4) with optional newAuthority present and absent', () => {
+        const withNew = decodeRaw(u32le(4), [account, authority, newAuthority]);
+        expect(withNew?.type).toBe('setAuthority');
+        expect((withNew?.info as any).newAuthority.equals(newAuthority)).toBe(true);
+
+        const withoutNew = decodeRaw(u32le(4), [account, authority]);
+        expect(withoutNew?.type).toBe('setAuthority');
+        expect((withoutNew?.info as any).newAuthority).toBeUndefined();
+    });
+
+    test('should decode Write (discriminant 1) offset and base64 bytes', () => {
+        const payload = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+        const len = Buffer.alloc(8);
+        len.writeBigUInt64LE(BigInt(payload.length), 0);
+        const data = Buffer.concat([u32le(1), u32le(42), len, payload]);
+
+        const parsed = decodeRaw(data, [account, authority]);
+        expect(parsed?.type).toBe('write');
+        expect((parsed?.info as any).offset).toBe(42);
+        expect((parsed?.info as any).bytes).toBe(payload.toString('base64'));
+    });
+
+    test('should decode ExtendProgram (discriminant 6) additionalBytes', () => {
+        // data = discriminant(6) + additionalBytes(u32); accounts = [programData, program]
+        const data = Buffer.concat([u32le(6), u32le(1024)]);
+        const parsed = decodeRaw(data, [account, authority]);
+        expect(parsed?.type).toBe('extendProgram');
+        expect((parsed?.info as any).additionalBytes).toBe(1024);
+        expect((parsed?.info as any).programDataAccount.equals(account)).toBe(true);
+        expect((parsed?.info as any).programAccount.equals(authority)).toBe(true);
+        expect((parsed?.info as any).payerAccount).toBeNull();
+    });
+
+    test('should return undefined for data shorter than the 4-byte discriminant', () => {
+        expect(decodeRaw(Buffer.from([1, 2]), [account])).toBeUndefined();
+    });
+});
+
+describe('byte-parsed vs RPC-parsed parity (SetAuthorityChecked)', () => {
+    test('should produce equal account pubkeys on both paths', () => {
+        const byteParsed = decodeRaw(u32le(7), [account, authority, newAuthority]);
+
+        const rpcParsed = parseBpfUpgradeableLoaderRpcInstruction({
+            parsed: {
+                info: {
+                    account: account.toBase58(),
+                    authority: authority.toBase58(),
+                    newAuthority: newAuthority.toBase58(),
+                },
+                type: 'setAuthorityChecked',
+            },
+            program: 'bpf-upgradeable-loader',
+            programId: PROGRAM_ID,
+        });
+
+        expect(byteParsed?.type).toBe(rpcParsed?.type);
+        expect((byteParsed?.info as any).account.equals((rpcParsed?.info as any).account)).toBe(true);
+        expect((byteParsed?.info as any).authority.equals((rpcParsed?.info as any).authority)).toBe(true);
+        expect((byteParsed?.info as any).newAuthority.equals((rpcParsed?.info as any).newAuthority)).toBe(true);
+    });
+});

--- a/app/features/decode-instruction-bpf-upgradeable-loader/index.ts
+++ b/app/features/decode-instruction-bpf-upgradeable-loader/index.ts
@@ -1,0 +1,8 @@
+export {
+    BPF_UPGRADEABLE_LOADER_PROGRAM_ID,
+    BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL,
+    type BpfUpgradeableLoaderParsed,
+    parseBpfUpgradeableLoaderInstruction,
+    parseBpfUpgradeableLoaderRpcInstruction,
+} from './lib/bpf-upgradeable-loader-parser';
+export { bpfUpgradeableLoaderInstructionParser } from './lib/bpf-upgradeable-loader-client';

--- a/app/features/decode-instruction-bpf-upgradeable-loader/lib/bpf-upgradeable-loader-client.ts
+++ b/app/features/decode-instruction-bpf-upgradeable-loader/lib/bpf-upgradeable-loader-client.ts
@@ -1,0 +1,16 @@
+import type { InstructionParser } from '@entities/instruction-parser';
+
+import {
+    BPF_UPGRADEABLE_LOADER_PROGRAM_ID,
+    BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL,
+    type BpfUpgradeableLoaderParsed,
+    parseBpfUpgradeableLoaderInstruction,
+    parseBpfUpgradeableLoaderRpcInstruction,
+} from './bpf-upgradeable-loader-parser';
+
+export const bpfUpgradeableLoaderInstructionParser: InstructionParser<BpfUpgradeableLoaderParsed> = {
+    fromParsed: parseBpfUpgradeableLoaderRpcInstruction,
+    fromTransaction: parseBpfUpgradeableLoaderInstruction,
+    programId: BPF_UPGRADEABLE_LOADER_PROGRAM_ID,
+    programLabel: BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL,
+};

--- a/app/features/decode-instruction-bpf-upgradeable-loader/lib/bpf-upgradeable-loader-parser.ts
+++ b/app/features/decode-instruction-bpf-upgradeable-loader/lib/bpf-upgradeable-loader-parser.ts
@@ -1,0 +1,179 @@
+import {
+    CloseInfo,
+    DeployWithMaxDataLenInfo,
+    ExtendProgramInfo,
+    InitializeBufferInfo,
+    SetAuthorityCheckedInfo,
+    SetAuthorityInfo,
+    UpgradeInfo,
+    WriteInfo,
+} from '@components/instruction/bpf-upgradeable-loader/types';
+import { type ParsedInstruction, PublicKey } from '@solana/web3.js';
+import { create } from 'superstruct';
+
+import type { KitInstruction } from '@/app/shared/lib/web3js-compat';
+import type { ParserProgramLabel } from '@/app/utils/programs';
+
+/** On-chain id of the upgradeable BPF loader; also the RPC `parsed.program` discriminator. */
+export const BPF_UPGRADEABLE_LOADER_PROGRAM_ID = 'BPFLoaderUpgradeab1e11111111111111111111111';
+export const BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL = 'bpf-upgradeable-loader' satisfies ParserProgramLabel;
+
+/**
+ * Canonical shape of a parsed Upgradeable BPF Loader instruction. Both the
+ * inspector (raw bytes path) and the tx page (RPC pre-parsed path) normalise to
+ * this shape, which is exactly what `BpfUpgradeableLoaderDetailsCard` renders.
+ */
+export type BpfUpgradeableLoaderParsed =
+    | { type: 'initializeBuffer'; info: InitializeBufferInfo }
+    | { type: 'write'; info: WriteInfo }
+    | { type: 'deployWithMaxDataLen'; info: DeployWithMaxDataLenInfo }
+    | { type: 'upgrade'; info: UpgradeInfo }
+    | { type: 'setAuthority'; info: SetAuthorityInfo }
+    | { type: 'setAuthorityChecked'; info: SetAuthorityCheckedInfo }
+    | { type: 'close'; info: CloseInfo }
+    | { type: 'extendProgram'; info: ExtendProgramInfo };
+
+// Bincode u32 discriminants of `UpgradeableLoaderInstruction` (agave loader-v3).
+const enum Discriminant {
+    InitializeBuffer = 0,
+    Write = 1,
+    DeployWithMaxDataLen = 2,
+    Upgrade = 3,
+    SetAuthority = 4,
+    Close = 5,
+    ExtendProgram = 6,
+    SetAuthorityChecked = 7,
+}
+
+/**
+ * Decode a raw Upgradeable BPF Loader instruction (inspector path). The RPC does
+ * not pre-parse instructions in the inspector, so we read the bincode-encoded
+ * data and map account positions to the same named fields the RPC emits, keeping
+ * the inspector and tx-page renderings identical. Account orderings mirror
+ * agave's `parse_bpf_loader.rs`.
+ */
+export function parseBpfUpgradeableLoaderInstruction(ix: KitInstruction): BpfUpgradeableLoaderParsed | undefined {
+    try {
+        const data = ix.data;
+        if (data.length < 4) return undefined;
+        const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+        const discriminant = view.getUint32(0, true);
+
+        // Account at position `i`, or undefined when the instruction supplied fewer keys.
+        const acc = (i: number): PublicKey | undefined => {
+            const meta = ix.accounts[i];
+            return meta ? new PublicKey(meta.address) : undefined;
+        };
+        // Required account: throws (→ caught → undefined parse) when missing.
+        const req = (i: number): PublicKey => {
+            const meta = ix.accounts[i];
+            if (!meta) throw new Error(`missing account at index ${i}`);
+            return new PublicKey(meta.address);
+        };
+
+        switch (discriminant) {
+            case Discriminant.InitializeBuffer:
+                return { info: { account: req(0), authority: req(1) }, type: 'initializeBuffer' };
+            case Discriminant.Write: {
+                const offset = view.getUint32(4, true);
+                const bytesLen = Number(view.getBigUint64(8, true));
+                const bytes = data.slice(16, 16 + bytesLen);
+                return {
+                    info: { account: req(0), authority: req(1), bytes: Buffer.from(bytes).toString('base64'), offset },
+                    type: 'write',
+                };
+            }
+            case Discriminant.DeployWithMaxDataLen:
+                return {
+                    info: {
+                        authority: req(7),
+                        bufferAccount: req(3),
+                        clockSysvar: req(5),
+                        maxDataLen: Number(view.getBigUint64(4, true)),
+                        payerAccount: req(0),
+                        programAccount: req(2),
+                        programDataAccount: req(1),
+                        rentSysvar: req(4),
+                        systemProgram: req(6),
+                    },
+                    type: 'deployWithMaxDataLen',
+                };
+            case Discriminant.Upgrade:
+                return {
+                    info: {
+                        authority: req(6),
+                        bufferAccount: req(2),
+                        clockSysvar: req(5),
+                        programAccount: req(1),
+                        programDataAccount: req(0),
+                        rentSysvar: req(4),
+                        spillAccount: req(3),
+                    },
+                    type: 'upgrade',
+                };
+            case Discriminant.SetAuthority:
+                return { info: { account: req(0), authority: req(1), newAuthority: acc(2) }, type: 'setAuthority' };
+            case Discriminant.SetAuthorityChecked:
+                return {
+                    info: { account: req(0), authority: req(1), newAuthority: req(2) },
+                    type: 'setAuthorityChecked',
+                };
+            case Discriminant.Close:
+                return {
+                    info: { account: req(0), authority: req(2), programAccount: acc(3), recipient: req(1) },
+                    type: 'close',
+                };
+            case Discriminant.ExtendProgram:
+                return {
+                    info: {
+                        additionalBytes: view.getUint32(4, true),
+                        // ExtendProgramInfo types payerAccount as nullable; the card renders `null` as "None".
+                        // eslint-disable-next-line unicorn/no-null -- matches the RPC-parsed shape's nullable field
+                        payerAccount: acc(3) ?? null,
+                        programAccount: req(1),
+                        programDataAccount: req(0),
+                        systemProgram: acc(2),
+                    },
+                    type: 'extendProgram',
+                };
+            default:
+                return undefined;
+        }
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Normalise an RPC-pre-parsed ParsedInstruction (tx-page path) into the same
+ * canonical shape, reusing the superstruct validators so RPC's base58 strings
+ * are coerced into PublicKey instances. Returns undefined for unrecognised types
+ * so the dispatcher passes RPC's value through unchanged.
+ */
+export function parseBpfUpgradeableLoaderRpcInstruction(ix: ParsedInstruction): BpfUpgradeableLoaderParsed | undefined {
+    if (ix.program !== BPF_UPGRADEABLE_LOADER_PROGRAM_LABEL) return undefined;
+    try {
+        switch (ix.parsed.type) {
+            case 'initializeBuffer':
+                return { info: create(ix.parsed.info, InitializeBufferInfo), type: 'initializeBuffer' };
+            case 'write':
+                return { info: create(ix.parsed.info, WriteInfo), type: 'write' };
+            case 'deployWithMaxDataLen':
+                return { info: create(ix.parsed.info, DeployWithMaxDataLenInfo), type: 'deployWithMaxDataLen' };
+            case 'upgrade':
+                return { info: create(ix.parsed.info, UpgradeInfo), type: 'upgrade' };
+            case 'setAuthority':
+                return { info: create(ix.parsed.info, SetAuthorityInfo), type: 'setAuthority' };
+            case 'setAuthorityChecked':
+                return { info: create(ix.parsed.info, SetAuthorityCheckedInfo), type: 'setAuthorityChecked' };
+            case 'close':
+                return { info: create(ix.parsed.info, CloseInfo), type: 'close' };
+            case 'extendProgram':
+                return { info: create(ix.parsed.info, ExtendProgramInfo), type: 'extendProgram' };
+            default:
+                return undefined;
+        }
+    } catch {
+        return undefined;
+    }
+}

--- a/app/tx/instruction-parser-dispatcher.ts
+++ b/app/tx/instruction-parser-dispatcher.ts
@@ -1,5 +1,6 @@
 import { createInstructionParserDispatcher } from '@entities/instruction-parser';
 import { associatedTokenInstructionParser } from '@features/decode-instruction-associated-token';
+import { bpfUpgradeableLoaderInstructionParser } from '@features/decode-instruction-bpf-upgradeable-loader';
 import { systemInstructionParser } from '@features/decode-instruction-system';
 import { tokenInstructionParser } from '@features/decode-instruction-token';
 import { token2022InstructionParser } from '@features/decode-instruction-token-2022';
@@ -11,4 +12,5 @@ export const instructionParserDispatcher = createInstructionParserDispatcher([
     token2022InstructionParser,
     associatedTokenInstructionParser,
     metaplexTokenMetadataInstructionParser,
+    bpfUpgradeableLoaderInstructionParser,
 ]);

--- a/app/utils/__tests__/verified-builds.spec.ts
+++ b/app/utils/__tests__/verified-builds.spec.ts
@@ -2,7 +2,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { PublicKey } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
-import { hashProgramData } from '../verified-builds';
+import { hashProgramBuffer, hashProgramData } from '../verified-builds';
 
 // Helper to build a minimal ProgramDataAccountInfo
 function makeProgramData({ authority, rawBytes }: { authority: PublicKey | null; rawBytes: Buffer }): {
@@ -123,5 +123,45 @@ describe('hashProgramData', () => {
         // All-zero program data produces a hash of empty data (no crash)
         const emptyHash = Buffer.from(sha256(Buffer.alloc(0))).toString('hex');
         expect(hashProgramData(programData)).toBe(emptyHash);
+    });
+});
+
+describe('hashProgramBuffer', () => {
+    const staleAuthorityBytes = Buffer.from('51b4de5a0619575adb04c439878648ac81487e8529cded2b1fccb55115ef7247', 'hex');
+    const programBytes = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0xde, 0xad, 0xbe, 0xef]);
+
+    function makeBuffer({ authority, rawBytes }: { authority: PublicKey | null; rawBytes?: Buffer }) {
+        return {
+            authority,
+            data: rawBytes ? ([rawBytes.toString('base64'), 'base64'] as [string, 'base64']) : undefined,
+        };
+    }
+
+    it('should hash the program bytes directly (sha256, trailing zeros stripped) when authority is present', () => {
+        const buffer = makeBuffer({
+            authority: PublicKey.default,
+            rawBytes: Buffer.concat([programBytes, Buffer.alloc(64, 0)]),
+        });
+        expect(hashProgramBuffer(buffer)).toBe(Buffer.from(sha256(programBytes)).toString('hex'));
+    });
+
+    it('should skip the 32-byte stale pubkey when authority is null', () => {
+        const buffer = makeBuffer({
+            authority: null,
+            rawBytes: Buffer.concat([staleAuthorityBytes, programBytes]),
+        });
+        expect(hashProgramBuffer(buffer)).toBe(Buffer.from(sha256(programBytes)).toString('hex'));
+    });
+
+    it('should return undefined when no data is available', () => {
+        expect(hashProgramBuffer(makeBuffer({ authority: PublicKey.default }))).toBeUndefined();
+    });
+
+    it('should match the known solana-verify hash for a real buffer payload', () => {
+        // A buffer whose program bytes are the ELF magic: verifies the exact wire format
+        // (sha256 over the bytes, hex-encoded) used by `solana-verify get-buffer-hash`.
+        const buffer = makeBuffer({ authority: PublicKey.default, rawBytes: programBytes });
+        // eslint-disable-next-line no-restricted-syntax -- validating SHA-256 hex output format
+        expect(hashProgramBuffer(buffer)).toMatch(/^[0-9a-f]{64}$/);
     });
 });

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -356,7 +356,12 @@ export type TokenProgram = 'spl-token' | 'spl-token-2022';
  * a slice that declares a label not listed here fails to compile — keeping
  * slice labels and the RPC guards they're compared against from drifting.
  */
-export type ParserProgramLabel = TokenProgram | 'mpl-token-metadata' | 'spl-associated-token-account' | 'system';
+export type ParserProgramLabel =
+    | TokenProgram
+    | 'bpf-upgradeable-loader'
+    | 'mpl-token-metadata'
+    | 'spl-associated-token-account'
+    | 'system';
 
 export function assertIsTokenProgram(program: string): asserts program is TokenProgram {
     if (program !== 'spl-token' && program !== 'spl-token-2022')

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -8,7 +8,7 @@ import { fromBase64, fromUtf8, toHex } from '@/app/shared/lib/bytes';
 import { Logger } from '@/app/shared/lib/logger';
 
 import { useCluster } from '../providers/cluster';
-import { ProgramDataAccountInfo } from '../validators/accounts/upgradeable-program';
+import { ProgramBufferAccountInfo, ProgramDataAccountInfo } from '../validators/accounts/upgradeable-program';
 import { Cluster } from './cluster';
 import { composeOnchainRepoUrl, normalizeRepoUrl, safeRepoUrl } from './verified-builds-url';
 
@@ -314,6 +314,26 @@ function isMainnet(currentCluster: Cluster): boolean {
 }
 
 // Helper function to hash program data
+/**
+ * Compute the solana-verify-style hash of an upgradeable BPF loader buffer account,
+ * matching `solana-verify get-buffer-hash` / `get_binary_hash`: sha256 of the program
+ * bytes with trailing zero padding removed. The RPC's jsonParsed buffer `data` is already
+ * the bytes past the 37-byte buffer header. Returns undefined when `data` is unavailable.
+ */
+export function hashProgramBuffer(buffer: ProgramBufferAccountInfo): string | undefined {
+    if (!buffer.data) return undefined;
+    const bytes = fromBase64(buffer.data[0]);
+    // Same RPC quirk as hashProgramData: when authority is None the parsed `data` carries the
+    // 32-byte pubkey from the (Option) header, so skip it to match solana-verify's raw offset.
+    const offset = buffer.authority === null ? 32 : 0;
+    const data = bytes.slice(offset);
+    let truncatedBytes = 0;
+    while (truncatedBytes < data.length && data[data.length - 1 - truncatedBytes] === 0) {
+        truncatedBytes++;
+    }
+    return toHex(sha256(data.slice(0, data.length - truncatedBytes)));
+}
+
 export function hashProgramData(programData: ProgramDataAccountInfo): string {
     const buffer = fromBase64(programData.data[0]);
     // The jsonParsed RPC response includes the 32-byte pubkey field from the raw

--- a/app/validators/accounts/upgradeable-program.ts
+++ b/app/validators/accounts/upgradeable-program.ts
@@ -1,6 +1,19 @@
 import { ParsedInfo } from '@validators/index';
 import { PublicKeyFromString } from '@validators/pubkey';
-import { any, coerce, create, Infer, literal, nullable, number, string, tuple, type, union } from 'superstruct';
+import {
+    any,
+    coerce,
+    create,
+    Infer,
+    literal,
+    nullable,
+    number,
+    optional,
+    string,
+    tuple,
+    type,
+    union,
+} from 'superstruct';
 
 export type ProgramAccountInfo = Infer<typeof ProgramAccountInfo>;
 export const ProgramAccountInfo = type({
@@ -29,7 +42,10 @@ export const ProgramDataAccount = type({
 export type ProgramBufferAccountInfo = Infer<typeof ProgramBufferAccountInfo>;
 export const ProgramBufferAccountInfo = type({
     authority: nullable(PublicKeyFromString),
-    // don't care about data yet
+    // The RPC's jsonParsed buffer `data` is the base64 of the program bytes past the
+    // 37-byte buffer header — i.e. exactly what solana-verify hashes. Optional so a
+    // response that omits it still parses.
+    data: optional(tuple([string(), literal('base64')])),
 });
 
 export type ProgramBufferAccount = Infer<typeof ProgramBufferAccount>;


### PR DESCRIPTION
## Summary

Improves **Upgradeable BPF Loader** and **Squads v4** support across the transaction inspector and account pages. Five related changes (all exercised against real on-chain Squads program-deploy accounts on devnet):

1. **Inspector — decode Upgradeable BPF Loader instructions.** The inspector decodes raw instructions, but had no decoder for the upgradeable loader, so `upgrade` / `deployWithMaxDataLen` / `setAuthority` / etc. rendered as the raw **"Unknown Instruction"** view. Added a parser slice (`app/features/decode-instruction-bpf-upgradeable-loader/`) that decodes all 8 instruction variants — including `setAuthorityChecked`, which was also missing from the RPC-parsed `switch` — into named accounts/args. Account orderings mirror agave's `parse_bpf_loader.rs`; it's registered in the dispatcher and rendered via the existing `BpfUpgradeableLoaderDetailsCard`.

2. **Inspector — support Squads v4 Batch accounts.** Pasting a Batch address (or opening one via `?squadsTx=`) errored, because the account was always deserialized as a `VaultTransaction`. Now the account type is detected by discriminator; a `Batch` is decoded and all of its inner `VaultBatchTransaction`s are loaded and presented with a transaction selector (`Batch · N transactions`).

3. **Inspector — fix an infinite navigation loop for `squadsTx` URLs.** The URL-sync effect's Squads branch called `router.replace` unconditionally (the raw-message branch right below it was already guarded). Under Next 16, `router.replace` to an identical URL returns a fresh `searchParams` reference, which re-runs the decode effect → `setInspectorData(new object)` → replace again, indefinitely (hundreds of RSC round-trips). Guarded it to only rewrite the URL when out of sync. This is a pre-existing bug, but it makes the Squads inspector views usable.

4. **Account page — solana-verify buffer hash.** Program Deploy Buffer accounts now show a **Buffer Hash** row: `sha256` of the program bytes with trailing zero padding removed — identical to `solana-verify get-buffer-hash` — so you can confirm a buffer matches an expected build before deploying. Reuses the existing `@noble/hashes` path next to `hashProgramData`.

5. **Account page — Squads "Inspect" link.** Squads v4 `Batch`/`VaultTransaction` accounts aren't RPC-parsed, so they fell back to the generic Unknown Account card. They're now detected by discriminator and rendered with a dedicated card plus an **Inspect** link straight to the transaction inspector (preserving `cluster`/`customUrl`), removing the copy-paste round-trip.

## Motivation

Inspecting a Squads-orchestrated program deploy/upgrade currently means hitting an error on batch accounts, raw/undecoded loader instructions, and manual copy-pasting between the address and inspector pages. These changes make that whole flow legible.

## Testing

`pnpm test:ci` green (2813 passed), `pnpm typecheck` and `pnpm lint` clean. New tests:
- byte-path + RPC-path parity for the BPF loader parser
- `BpfUpgradeableLoaderDetailsCard` rendering (incl. `setAuthorityChecked`)
- `hashProgramBuffer` (authority present/absent, trailing-zero stripping)
- `detectSquadsAccountType` (Batch / VaultTransaction / wrong owner / wrong discriminator)

Additionally verified against real on-chain accounts on devnet: the loader decoder reproduced an actual `upgrade` instruction's 7 named accounts; the buffer-hash output matched `solana-verify`'s reference hash bit-for-bit; and the batch decoder loaded all 8 inner transactions of a real deploy batch.

## Screenshots



https://github.com/user-attachments/assets/19781320-2013-4014-867f-bf6968d12f94

You can test with http://localhost:3000/address/6sYxDZv9QrgjDDRL5gLSe7YVD3cFcN4zkuBuC45iixqz?cluster=devnet
