### PR TITLE
feat(idl): display program name in header and Program IDL tab

### DIFF
--- a/app/__fixtures__/gen.ts
+++ b/app/__fixtures__/gen.ts
@@ -2,6 +2,7 @@
 // If generators proliferate, consider replacing with `fast-check` arbitraries
 // (e.g. fc.bigInt(), fc.sample()) for composability and shrinking support.
 
+import type { SecurityTxtFields, SecurityTxtSource } from '@solana/security-txt';
 import { PublicKey } from '@solana/web3.js';
 import bs58 from 'bs58';
 
@@ -27,6 +28,8 @@ export const gen = {
     epoch: () => gen.bigint(1_000n),
     /** Same as `address` but returns a `PublicKey` so callers needn't wrap it. */
     publicKey: (seed?: number) => new PublicKey(gen.address(seed)),
+    /** Bare resolved security.txt for hook mocks; pass `fields` (e.g. name, version) for the case at hand. */
+    securityTxt: (fields: SecurityTxtFields = {}, type: SecurityTxtSource = 'pmp') => ({ fields, type }),
     /** Deterministic when seed provided (same seed → same value) so story fixtures stay pixel-stable. */
     signature: (seed?: number) => {
         const bytes = new Uint8Array(64);

--- a/app/components/shared/account/ProgramHeader.tsx
+++ b/app/components/shared/account/ProgramHeader.tsx
@@ -6,6 +6,7 @@
 // `ProxiedImage` and the security-txt helpers down into `shared`/`entities`, re-point
 // consumers, then drop these two imports.
 import { Tooltip, TooltipContent, TooltipTrigger } from '@components/shared/ui/tooltip';
+import { buildProgramName, useProgramIdls } from '@entities/idl';
 import { ProxiedImage } from '@features/metadata';
 import { useSecurityTxt } from '@features/security-txt';
 import { type UpgradeableLoaderAccountData } from '@providers/accounts';
@@ -26,7 +27,10 @@ export function ProgramHeader({
     parsedData?: UpgradeableLoaderAccountData | undefined;
 }) {
     const { securityTxt } = useSecurityTxt(address);
-    const { cluster } = useCluster();
+    const { url, cluster } = useCluster();
+    const { anchorIdl, programMetadataIdl } = useProgramIdls(address, url, cluster);
+    // Codama / modern Anchor names only; legacy Anchor top-level name is intentionally not shown.
+    const idlProgramName = buildProgramName([programMetadataIdl, anchorIdl]);
     const { programName, logo, version, selfReported } = ((): {
         programName: string;
         logo?: string;
@@ -38,32 +42,24 @@ export function ProgramHeader({
         const trustedProgramName = isTrustedProgram ? programInfo.name : undefined;
         const namePlaceholder = 'Program Account';
 
-        let programName = trustedProgramName ?? namePlaceholder;
+        // Self-reported name fallbacks, in order: security.txt, then the program's own IDL.
+        // `||` (not `??`) so an empty security.txt name falls through to the IDL name.
+        const selfReportedName = securityTxt?.fields.name || idlProgramName;
+        const programName = trustedProgramName ?? selfReportedName ?? namePlaceholder;
+        // Warn only when the displayed name is self-reported (no trusted-registry entry).
+        const selfReported = !trustedProgramName && Boolean(selfReportedName);
 
-        if (!securityTxt) {
-            return {
-                programName,
-                selfReported: false,
-            };
-        }
-
-        // Only show warning if we're actually using self-reported data
-        const usingSelfReportedName = !trustedProgramName;
-
-        // Handle empty name in security.txt
-        programName = (trustedProgramName ?? securityTxt.fields.name) || namePlaceholder;
-
-        if (securityTxt.type === 'pmp') {
+        if (securityTxt?.type === 'pmp') {
             return {
                 logo: securityTxt.fields.logo,
                 programName,
-                selfReported: usingSelfReportedName,
+                selfReported,
                 version: securityTxt.fields.version,
             };
         }
         return {
             programName,
-            selfReported: usingSelfReportedName,
+            selfReported,
         };
     })();
 

--- a/app/components/shared/account/__tests__/ProgramHeader.spec.tsx
+++ b/app/components/shared/account/__tests__/ProgramHeader.spec.tsx
@@ -1,0 +1,124 @@
+import { gen } from '@__fixtures__/gen';
+import type { SupportedIdl } from '@entities/idl';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { Cluster } from '@/app/utils/cluster';
+
+import { ProgramHeader } from '../ProgramHeader';
+
+const mocks = vi.hoisted(() => ({
+    programInfoById: {} as Record<string, { name: string; deployments: Cluster[] }>,
+    useProgramIdls: vi.fn(),
+    useSecurityTxt: vi.fn(),
+}));
+
+// ProgramHeader resolves its name from three sources; mock each so the priority is observable.
+vi.mock('@/app/entities/idl/model/use-program-idls', () => ({ useProgramIdls: mocks.useProgramIdls }));
+vi.mock('@features/security-txt', () => ({ useSecurityTxt: mocks.useSecurityTxt }));
+vi.mock('@providers/cluster', () => ({
+    useCluster: () => ({ cluster: Cluster.MainnetBeta, url: 'https://example.com' }),
+}));
+// Partial mock: the @entities/idl barrel transitively pulls real exports from this module, so only
+// override PROGRAM_INFO_BY_ID (via a getter so each test can swap the trusted-registry contents).
+vi.mock('@utils/programs', async importOriginal => {
+    const actual = await importOriginal<typeof import('@utils/programs')>();
+    return {
+        ...actual,
+        get PROGRAM_INFO_BY_ID() {
+            return mocks.programInfoById;
+        },
+    };
+});
+// Avoid the metadata-proxy image stack in a unit test.
+vi.mock('@features/metadata', () => ({ ProxiedImage: () => null }));
+
+const ADDRESS = 'EgJAPMy5V2j442dTGFRqT5ZtPCWtg6BEbEo2QzkExYyw';
+
+function anchorIdlNamed(name: string): SupportedIdl {
+    return {
+        address: ADDRESS,
+        instructions: [],
+        metadata: { name, spec: '0.1.0', version: '0.1.0' },
+    } as unknown as SupportedIdl;
+}
+
+function mockIdls(idl?: SupportedIdl): void {
+    mocks.useProgramIdls.mockReturnValue({
+        anchorIdl: idl,
+        anchorIdlAddress: undefined,
+        isLoading: false,
+        programMetadataIdl: undefined,
+        programMetadataIdlAddress: undefined,
+    });
+}
+
+describe('ProgramHeader', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.programInfoById = {};
+        mocks.useSecurityTxt.mockReturnValue({ securityTxt: undefined });
+        mockIdls();
+    });
+
+    test('should prefer the trusted-registry name over security.txt and IDL names', () => {
+        mocks.programInfoById = { [ADDRESS]: { deployments: [Cluster.MainnetBeta], name: 'Trusted Program' } };
+        mocks.useSecurityTxt.mockReturnValue({ securityTxt: gen.securityTxt({ name: 'SecTxt Name' }) });
+        mockIdls(anchorIdlNamed('idl_program'));
+
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('Trusted Program')).toBeInTheDocument();
+        // Trusted name is not self-reported, so no warning.
+        expect(screen.queryByLabelText('Self-reported program')).not.toBeInTheDocument();
+    });
+
+    test('should use the security.txt name (self-reported) when no trusted entry exists', () => {
+        mocks.useSecurityTxt.mockReturnValue({ securityTxt: gen.securityTxt({ name: 'SecTxt Name' }) });
+        mockIdls(anchorIdlNamed('idl_program'));
+
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('SecTxt Name')).toBeInTheDocument();
+        expect(screen.getByLabelText('Self-reported program')).toBeInTheDocument();
+    });
+
+    test('should fall back to the IDL program name (title-cased, self-reported) when no trusted or security.txt name', () => {
+        mockIdls(anchorIdlNamed('idl_program'));
+
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('Idl Program')).toBeInTheDocument();
+        expect(screen.getByLabelText('Self-reported program')).toBeInTheDocument();
+    });
+
+    test('should show the placeholder when no name source resolves', () => {
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('Program Account')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Self-reported program')).not.toBeInTheDocument();
+    });
+
+    test('should fall through an empty security.txt name to the IDL program name', () => {
+        // `||` (not `??`): an empty security.txt name must not win over the IDL name.
+        mocks.useSecurityTxt.mockReturnValue({ securityTxt: gen.securityTxt({ name: '' }) });
+        mockIdls(anchorIdlNamed('idl_program'));
+
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('Idl Program')).toBeInTheDocument();
+        expect(screen.getByLabelText('Self-reported program')).toBeInTheDocument();
+    });
+
+    test('should show the placeholder without a warning when a pmp security.txt has an empty name and no IDL name', () => {
+        mocks.useSecurityTxt.mockReturnValue({ securityTxt: gen.securityTxt({ name: '', version: '1.2.3' }) });
+
+        render(<ProgramHeader address={ADDRESS} />);
+
+        expect(screen.getByText('Program Account')).toBeInTheDocument();
+        // No self-reported name resolved, so no warning even though a pmp security.txt is present.
+        expect(screen.queryByLabelText('Self-reported program')).not.toBeInTheDocument();
+        // Version still surfaces from the pmp security.txt regardless of the name.
+        expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    });
+});

--- a/app/entities/idl/index.ts
+++ b/app/entities/idl/index.ts
@@ -19,6 +19,7 @@ export { IdlVariant } from './model/idl-variant';
 // "Unknown Program" / "Unknown Instruction".
 export { useInstructionNameResolvers } from './model/use-instruction-name-resolvers';
 export type { InstructionNameResolver, ProgramIdlNames } from './model/use-instruction-name-resolvers';
+export { buildProgramName } from './model/instruction-name-table';
 
 export { getIdlSpecType as getDisplayIdlSpecType } from './model/converters/convert-display-idl';
 export { formatDisplayIdl, formatSerdeIdl, getFormattedIdl } from './model/formatters/format';

--- a/app/features/idl/ui/IdlCard.tsx
+++ b/app/features/idl/ui/IdlCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@components/shared/ui/badge';
 import { Button, buttonVariants } from '@components/shared/ui/button';
 import { ExternalLink } from '@components/shared/ui/external-link';
 import {
+    buildProgramName,
     getIdlBadgeLabel,
     getIdlProgramVersion,
     IdlVariant,
@@ -145,6 +146,8 @@ export function IdlCard({ programId }: { programId: string }) {
     const idlAddress = isFallback ? anchorIdlAddress : programMetadataIdlAddress;
     const idlSourceLabel = isFallback ? 'Anchor' : 'PMP';
     const programVersion = getIdlProgramVersion(idl);
+    // Codama / modern Anchor names only; legacy Anchor top-level name is intentionally not shown.
+    const programName = buildProgramName([idl]);
     const info = (
         <dl className="flex flex-col gap-1 text-xs">
             {idlAddress && (
@@ -154,6 +157,12 @@ export function IdlCard({ programId }: { programId: string }) {
                         <AddressLink address={idlAddress as Address} truncate={{ head: 4, tail: 4 }} />
                         <span className="text-neutral-500">(PDA)</span>
                     </dd>
+                </div>
+            )}
+            {programName && (
+                <div className="flex items-baseline gap-2">
+                    <dt className="w-32 shrink-0 text-neutral-400">Name</dt>
+                    <dd className="text-white">{programName}</dd>
                 </div>
             )}
             <div className="flex items-baseline gap-2">

--- a/app/features/idl/ui/__tests__/IdlCard.spec.tsx
+++ b/app/features/idl/ui/__tests__/IdlCard.spec.tsx
@@ -205,6 +205,25 @@ describe('IdlCard', () => {
         expect(screen.getByText('0.4.2')).toBeInTheDocument();
     });
 
+    test('should show the program name (title-cased) under the badge when the IDL names the program', async () => {
+        const idl = createMockProgramMetadataIdl();
+        (idl as unknown as { program: { name: string } }).program.name = 'crypto_primitives';
+        mockProgramIdls({ programMetadataIdl: idl, programMetadataIdlAddress: PMP_PDA });
+
+        render(
+            <ClusterProvider>
+                <IdlCard programId={programId} />
+            </ClusterProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+        });
+        // Scope to the info-block <dt>; the rendered instruction table also has a "Name" column header.
+        expect(screen.getByText('Name', { selector: 'dt' })).toBeInTheDocument();
+        expect(screen.getByText('Crypto Primitives')).toBeInTheDocument();
+    });
+
     test('should label the source as Anchor when falling back to the Anchor IDL', async () => {
         mockProgramIdls({ anchorIdl: createMockAnchorIdl(), anchorIdlAddress: DEFAULT_ADDRESS });
 

--- a/app/features/security-txt/ui/__tests__/helpers.ts
+++ b/app/features/security-txt/ui/__tests__/helpers.ts
@@ -11,6 +11,7 @@ export const programDataFixture = {
     slot: 123,
 };
 
+// TODO: rebuild these on `gen.securityTxt` (@__fixtures__/gen) so there's one security.txt fixture source.
 export function createPmpSecurityTxt(fields: Partial<SecurityTxtFields> = {}): ResolvedSecurityTxt {
     return {
         fields: {

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -2,9 +2,9 @@
 
 | Type | Route | Size | First Load JS |
 |------|-------|------|---------------|
-| Static | `/` | 130 kB | 1.16 MB |
+| Static | `/` | 130 kB | 1.15 MB |
 | Static | `/_not-found` | 0 B | 1.03 MB |
-| Dynamic | `/address/[address]` | 380 kB | 1.39 MB |
+| Dynamic | `/address/[address]` | 380 kB | 1.40 MB |
 | Dynamic | `/address/[address]/anchor-account` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/anchor-program` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/attestation` | 370 kB | 1.39 MB |
@@ -47,13 +47,13 @@
 | Dynamic | `/block/[slot]` | 230 kB | 1.25 MB |
 | Dynamic | `/block/[slot]/accounts` | 230 kB | 1.25 MB |
 | Dynamic | `/block/[slot]/programs` | 230 kB | 1.25 MB |
-| Dynamic | `/block/[slot]/rewards` | 230 kB | 1.25 MB |
+| Dynamic | `/block/[slot]/rewards` | 230 kB | 1.24 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |
 | Static | `/feature-gates` | 50 kB | 1.07 MB |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 580 kB | 1.59 MB |
-| Dynamic | `/tx/[signature]/inspect` | 350 kB | 1.36 MB |
-| Static | `/tx/inspector` | 350 kB | 1.36 MB |
+| Static | `/tos` | 890 B | 1.03 MB |
+| Dynamic | `/tx/[signature]` | 590 kB | 1.60 MB |
+| Dynamic | `/tx/[signature]/inspect` | 370 kB | 1.39 MB |
+| Static | `/tx/inspector` | 370 kB | 1.39 MB |


### PR DESCRIPTION
## Description

The Codama / Anchor IDL carries a program name that the Explorer never surfaced. Display it in two places:

-   _Page-top program header_ — as a self-reported fallback name, after the trusted registry and security.txt, before the "Program Account" placeholder.
-   _Program IDL tab_ — as a new `Name` row in the IDL info block.

Name is title-cased via the existing `buildProgramName`; the `formatted-idl` model (shared with the interactive IDL) is untouched.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

Devnet `EgJAPMy5V2j442dTGFRqT5ZtPCWtg6BEbEo2QzkExYyw`: header shows "Crypto Primitives" with the self-reported warning icon; the Program IDL tab shows a `Name` row.

<img width="1288" height="762" alt="image" src="https://github.com/user-attachments/assets/405266e4-dc3b-45b2-aefc-05c48116ef8e" />
<img width="1118" height="319" alt="image" src="https://github.com/user-attachments/assets/f9a610d0-50b4-47ed-a25e-29a5ec3e9b97" />


## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

-   New `ProgramHeader.spec` covers the name priority (trusted → security.txt → IDL → placeholder), the empty-name `||` fallthrough, and warning visibility per source.
-   New `IdlCard.spec` case asserts the title-cased `Name` row.
-   Verified live on devnet/mainnet (trusted program still wins, no regression on the warning).
-   Full suite green; `pnpm typecheck` clean.

Preview links:

-   _IDL-name fallback_ (no registry / no security.txt) — https://explorer-git-fork-hoodieshq-hoo-760-fi-c89a03-solana-foundation.vercel.app/address/EgJAPMy5V2j442dTGFRqT5ZtPCWtg6BEbEo2QzkExYyw/idl?cluster=devnet — name in header + `Name` row, self-reported warning.
-   _security.txt name + verified build_ — https://explorer-git-fork-hoodieshq-hoo-760-fi-c89a03-solana-foundation.vercel.app/address/BUYuxRfhCMWavaUWxhGtPP3ksKEDZxCD5gzknk3JfAya?cluster=mainnet-beta — warning still shown (decoupled from verified build).
-   _trusted registry_ — https://explorer-git-fork-hoodieshq-hoo-760-fi-c89a03-solana-foundation.vercel.app/address/MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD?cluster=mainnet-beta — trusted name wins, no warning.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

[HOO-760](https://linear.app/solana-fndn/issue/HOO-760)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

-   Legacy Anchor top-level `name` is intentionally not shown (simplification); `buildProgramName` reads Codama `program.name` / modern Anchor `metadata.name`.
-   The self-reported warning is deliberately decoupled from verified-build status — a verified build attests code provenance, not the self-reported name.
-   `ProgramHeader` now calls `useProgramIdls` (SWR-immutable, shared cache with the IDL card / tx decoder) — no extra fetch.
