### PR TITLE
fix(token-2022): decode core token instructions in inspector

### DIFF
--- a/app/features/decode-instruction-token-2022/lib/token-2022-parser.ts
+++ b/app/features/decode-instruction-token-2022/lib/token-2022-parser.ts
@@ -4,7 +4,9 @@ import { unwrapOption } from '@solana/kit';
 import { type ParsedInstruction, PublicKey } from '@solana/web3.js';
 import {
     identifyToken2022Instruction,
+    parseCloseAccountInstruction,
     parseEmitTokenMetadataInstruction,
+    parseInitializeAccountInstruction,
     parseInitializeGroupMemberPointerInstruction,
     parseInitializeGroupPointerInstruction,
     parseInitializeMetadataPointerInstruction,
@@ -12,6 +14,9 @@ import {
     parseInitializeTokenGroupMemberInstruction,
     parseInitializeTokenMetadataInstruction,
     parseRemoveTokenMetadataKeyInstruction,
+    parseSyncNativeInstruction,
+    parseTransferCheckedInstruction,
+    parseTransferInstruction,
     parseUpdateGroupMemberPointerInstruction,
     parseUpdateGroupPointerInstruction,
     parseUpdateMetadataPointerInstruction,
@@ -21,6 +26,7 @@ import {
     parseUpdateTokenMetadataUpdateAuthorityInstruction,
     Token2022Instruction,
 } from '@solana-program/token-2022';
+import { normalizeTokenAmount } from '@utils/index';
 import { create } from 'superstruct';
 
 import type { KitInstruction } from '@/app/shared/lib/web3js-compat';
@@ -41,6 +47,70 @@ export function parseToken2022Instruction(ix: KitInstruction): Token2022Parsed |
         const instructionType = identifyToken2022Instruction(ix.data);
 
         switch (instructionType) {
+            // Core SPL Token instructions that Token-2022 shares byte-for-byte.
+            // These mirror the SPL Token slice's `parseTokenInstruction`; without
+            // them the inspector renders Token-2022 transfers/etc. as raw hex.
+            case Token2022Instruction.CloseAccount: {
+                const parsed = parseCloseAccountInstruction(ix);
+                return {
+                    info: {
+                        account: new PublicKey(parsed.accounts.account.address),
+                        destination: new PublicKey(parsed.accounts.destination.address),
+                        owner: new PublicKey(parsed.accounts.owner.address),
+                    },
+                    type: 'closeAccount',
+                };
+            }
+            case Token2022Instruction.InitializeAccount: {
+                const parsed = parseInitializeAccountInstruction(ix);
+                return {
+                    info: {
+                        account: new PublicKey(parsed.accounts.account.address),
+                        mint: new PublicKey(parsed.accounts.mint.address),
+                        owner: new PublicKey(parsed.accounts.owner.address),
+                        rentSysvar: new PublicKey(parsed.accounts.rent.address),
+                    },
+                    type: 'initializeAccount',
+                };
+            }
+            case Token2022Instruction.SyncNative: {
+                const parsed = parseSyncNativeInstruction(ix);
+                return {
+                    info: { account: new PublicKey(parsed.accounts.account.address) },
+                    type: 'syncNative',
+                };
+            }
+            case Token2022Instruction.Transfer: {
+                const parsed = parseTransferInstruction(ix);
+                return {
+                    info: {
+                        amount: parsed.data.amount.toString(),
+                        authority: new PublicKey(parsed.accounts.authority.address),
+                        destination: new PublicKey(parsed.accounts.destination.address),
+                        source: new PublicKey(parsed.accounts.source.address),
+                    },
+                    type: 'transfer',
+                };
+            }
+            case Token2022Instruction.TransferChecked: {
+                const parsed = parseTransferCheckedInstruction(ix);
+                const amount = parsed.data.amount.toString();
+                const decimals = parsed.data.decimals;
+                return {
+                    info: {
+                        authority: new PublicKey(parsed.accounts.authority.address),
+                        destination: new PublicKey(parsed.accounts.destination.address),
+                        mint: new PublicKey(parsed.accounts.mint.address),
+                        source: new PublicKey(parsed.accounts.source.address),
+                        tokenAmount: {
+                            amount,
+                            decimals,
+                            uiAmountString: normalizeTokenAmount(amount, decimals).toString(),
+                        },
+                    },
+                    type: 'transferChecked',
+                };
+            }
             case Token2022Instruction.InitializeTokenMetadata: {
                 const parsed = parseInitializeTokenMetadataInstruction(ix);
                 return {

--- a/app/tx/__tests__/instruction-parser-contract.spec.ts
+++ b/app/tx/__tests__/instruction-parser-contract.spec.ts
@@ -168,6 +168,80 @@ describe('instruction-parser contract', () => {
         expect(byteInfo.authority.equals(authority)).toBe(true);
     });
 
+    test('should produce equivalent info for byte-parsed and RPC-parsed Token-2022 TransferChecked paths', () => {
+        const dispatcher = createInstructionParserDispatcher([token2022InstructionParser]);
+
+        const source = Keypair.generate().publicKey;
+        const mint = Keypair.generate().publicKey;
+        const destination = Keypair.generate().publicKey;
+        const authority = Keypair.generate().publicKey;
+        const amount = 1_000n;
+        const decimals = 6;
+        const programId = new PublicKey(TOKEN_2022_PROGRAM_ADDRESS);
+
+        // TransferChecked wire layout is identical to SPL Token:
+        // [discriminator=12, amount u64 LE, decimals u8].
+        const data = Buffer.alloc(10);
+        data.writeUInt8(12, 0);
+        data.writeBigUInt64LE(amount, 1);
+        data.writeUInt8(decimals, 9);
+        const rawIx = new TransactionInstruction({
+            data,
+            keys: [
+                { isSigner: false, isWritable: true, pubkey: source },
+                { isSigner: false, isWritable: false, pubkey: mint },
+                { isSigner: false, isWritable: true, pubkey: destination },
+                { isSigner: true, isWritable: false, pubkey: authority },
+            ],
+            programId,
+        });
+
+        // Byte-parsed path (Inspector): raw TransactionInstruction -> ParsedInstruction.
+        const byteParsed = dispatcher.fromTransactionInstruction(rawIx);
+
+        // RPC-pre-parsed path (tx page): RPC's transferChecked shape -> dispatcher.
+        const rpcInput: ParsedInstruction = {
+            parsed: {
+                info: {
+                    authority: authority.toBase58(),
+                    destination: destination.toBase58(),
+                    mint: mint.toBase58(),
+                    source: source.toBase58(),
+                    tokenAmount: { amount: amount.toString(), decimals, uiAmountString: '0.001' },
+                },
+                type: 'transferChecked',
+            },
+            program: 'spl-token-2022',
+            programId,
+        };
+        const rpcParsed = dispatcher.fromParsedInstruction(rpcInput);
+
+        if (!isParsedInstruction(byteParsed)) {
+            throw new Error('byte-parsed Token-2022 TransferChecked should be recognised');
+        }
+
+        expect(byteParsed.program).toBe('spl-token-2022');
+        expect(rpcParsed.program).toBe('spl-token-2022');
+        expect(byteParsed.parsed.type).toBe('transferChecked');
+        expect(rpcParsed.parsed.type).toBe('transferChecked');
+
+        const byteInfo = create(byteParsed.parsed.info, TransferChecked);
+        const rpcInfo = create(rpcParsed.parsed.info, TransferChecked);
+
+        if (!byteInfo.authority || !rpcInfo.authority) throw new Error('TransferChecked authority must be present');
+        expect(byteInfo.source.equals(rpcInfo.source)).toBe(true);
+        expect(byteInfo.destination.equals(rpcInfo.destination)).toBe(true);
+        expect(byteInfo.mint.equals(rpcInfo.mint)).toBe(true);
+        expect(byteInfo.authority.equals(rpcInfo.authority)).toBe(true);
+        expect(byteInfo.tokenAmount.amount).toBe(rpcInfo.tokenAmount.amount);
+        expect(byteInfo.tokenAmount.decimals).toBe(rpcInfo.tokenAmount.decimals);
+
+        expect(byteInfo.tokenAmount.amount).toBe(amount.toString());
+        expect(byteInfo.tokenAmount.decimals).toBe(decimals);
+        expect(byteInfo.source.equals(source)).toBe(true);
+        expect(byteInfo.authority.equals(authority)).toBe(true);
+    });
+
     test('should produce equivalent info for byte-parsed and RPC-parsed Token-2022 InitializeMetadataPointer paths', () => {
         const dispatcher = createInstructionParserDispatcher([token2022InstructionParser]);
 


### PR DESCRIPTION
## Problem

In the transaction inspector, Token-2022 transfers (and other core token instructions) render as raw hex with no decoded fields — no amount, no source/destination, etc.

Example: https://explorer.solana.com/tx/inspector?squadsTx=949B6HVx1T87TAwtia8guXguQhUCoSAKnzA7gopfqydL

The instruction data `0c ae 5e 27 23 00 00 00 00 06` is a valid `TransferChecked` (discriminator `0x0c`=12, amount `589782702`, decimals `6`), yet the inspector shows only the raw bytes.

## Root cause

The Token-2022 byte-path parser (`parseToken2022Instruction`) only handled the Token-2022–specific extension instructions (metadata / group / pointers). The core instructions that Token-2022 inherits from SPL Token — `Transfer`, `TransferChecked`, `CloseAccount`, `InitializeAccount`, `SyncNative` — hit the `default` case and returned `undefined`, so the dispatcher wrapped them as unparsed and the inspector fell back to `UnknownDetailsCard` (raw hex).

This only affected the **byte path** (inspector). The tx page's RPC pre-parsed path already decoded these via the shared validator map, which is why it only showed up in the inspector.

## Fix

Token-2022 shares these instruction layouts byte-for-byte with SPL Token, so decode them the same way the SPL Token slice does — mirroring `parseTokenInstruction` in the `decode-instruction-token` slice, using `@solana-program/token-2022`'s parse functions. The output `{ type, info }` shapes match the existing `IX_STRUCTS`/`IX_TITLES` validators in `app/components/instruction/token/types.ts`, which `TokenDetailsCard` already renders (the `spl-token-2022` case was already wired up in the inspector's `InstructionsSection`).

The duplication with the SPL Token slice is intentional and follows the existing pattern in this file (see the `parseToken2022RpcInstruction` comment) — slices stay independent with no feature-to-feature imports.

## Test

Adds a byte-vs-RPC parity contract test for Token-2022 `TransferChecked` alongside the existing SPL Token one. `pnpm test` passes.

New:
<img width="968" height="405" alt="Screenshot 2026-07-01 at 9 38 38 AM" src="https://github.com/user-attachments/assets/354e1463-671e-45a7-84c8-bc3c70505e06" />


Old:
<img width="960" height="431" alt="Screenshot 2026-07-01 at 9 38 58 AM" src="https://github.com/user-attachments/assets/d77bab8a-9470-4473-b652-5b2135dce462" />