### PR TITLE
feat: Render permissioned burn token extension

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -30,6 +30,7 @@ import {
     MintCloseAuthority,
     PausableConfig,
     PermanentDelegate,
+    PermissionedBurnConfig,
     ScaledUiAmountConfig,
     TokenExtension,
     TokenExtensionType,
@@ -534,6 +535,7 @@ function cmpExtension(a: TokenExtension, b: TokenExtension) {
         'cpiGuard',
         'pausableAccount',
         'permanentDelegate',
+        'permissionedBurnConfig',
         'transferHook',
         'transferHookAccount',
         'metadataPointer',
@@ -871,6 +873,21 @@ export function TokenExtensionRow(
                     </>
                 </>
             );
+        }
+        case 'permissionedBurnConfig': {
+            const extension = create(tokenExtension.state, PermissionedBurnConfig);
+            if (extension.authority) {
+                return (
+                    <BaseTable.Row>
+                        <BaseTable.Cell>Permissioned Burn Authority</BaseTable.Cell>
+                        <BaseTable.Cell className="md:text-right">
+                            <Address pubkey={extension.authority} alignRight link />
+                        </BaseTable.Cell>
+                    </BaseTable.Row>
+                );
+            } else {
+                return <></>;
+            }
         }
         case 'permanentDelegate': {
             const extension = create(tokenExtension.state, PermanentDelegate);

--- a/app/components/account/__tests__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__tests__/TokenExtensionRow.spec.tsx
@@ -301,6 +301,49 @@ describe('TokenExtensionRow', () => {
         expect(screen.getByText('paused')).toBeInTheDocument();
     });
 
+    test('should render permissionedBurnConfig extension', async () => {
+        const data = {
+            extension: 'permissionedBurnConfig',
+            state: {
+                authority: new PublicKey('2apBGMsS6ti9RyF5TwQTDswXBWskiJP2LD4cUEDqYJjk'),
+            },
+        } as TokenExtension;
+
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <AccountsProvider>
+                        <TableCardBody>{TokenExtensionRow(data, undefined, 6, undefined)}</TableCardBody>
+                    </AccountsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(await screen.findByText('Permissioned Burn Authority')).toBeInTheDocument();
+        expect(screen.queryAllByText(new RegExp(`${data.state.authority.toString()}`))).toHaveLength(1);
+    });
+
+    test('should render nothing for permissionedBurnConfig extension without an authority', async () => {
+        const data = {
+            extension: 'permissionedBurnConfig',
+            state: {
+                authority: null,
+            },
+        } as TokenExtension;
+
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <AccountsProvider>
+                        <TableCardBody>{TokenExtensionRow(data, undefined, 6, undefined)}</TableCardBody>
+                    </AccountsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(screen.queryByText('Permissioned Burn Authority')).not.toBeInTheDocument();
+    });
+
     test('should render permanentDelegate extension', async () => {
         const data = {
             extension: 'permanentDelegate',

--- a/app/utils/token-extension.ts
+++ b/app/utils/token-extension.ts
@@ -255,6 +255,22 @@ export function populatePartialParsedTokenExtension(
                 tooltip: description,
             };
         }
+        case 'permissionedBurnConfig': {
+            const description =
+                'Restricts burning tokens to a designated burn authority instead of allowing any token holder to burn';
+            return {
+                description,
+                externalLinks: [
+                    {
+                        label: 'Docs',
+                        url: 'https://www.solana-program.com/docs/token-2022/extensions#permissioned-burn',
+                    },
+                ],
+                name: 'Permissioned Burn',
+                status: 'active',
+                tooltip: description,
+            };
+        }
         case 'unparseableExtension':
         default:
             return {

--- a/app/validators/accounts/token-extension.ts
+++ b/app/validators/accounts/token-extension.ts
@@ -30,6 +30,7 @@ const ExtensionType = enums([
     'scaledUiAmountConfig',
     'pausableAccount',
     'pausableConfig',
+    'permissionedBurnConfig',
     'unparseableExtension',
 ]);
 
@@ -174,4 +175,8 @@ export const ScaledUiAmountConfig = type({
 export const PausableConfig = type({
     authority: nullable(PublicKeyFromString),
     paused: boolean(),
+});
+
+export const PermissionedBurnConfig = type({
+    authority: nullable(PublicKeyFromString),
 });


### PR DESCRIPTION
Adds parsing and display for the token-2022 permissioned burn mint extension. The RPC now returns it as `permissionedBurnConfig` (via the agave account-decoder change in anza-xyz/agave#13504), so the extensions page can surface the burn authority.

Adds the `permissionedBurnConfig` extension type + validator, a "Permissioned Burn" label with description and docs link, and a row rendering the burn authority.

Example mint that carries it: `6rS8E5CQHLHmLenNNevUdJ9APzKNairr1kfWAM3EhDX3`