### PR TITLE
feat: improved ga analytics for idl

### DIFF
--- a/app/features/idl/interactive-idl/lib/analytics.spec.ts
+++ b/app/features/idl/interactive-idl/lib/analytics.spec.ts
@@ -2,13 +2,33 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { trackEvent } from '@/app/shared/lib/analytics';
 
-import { createIdlAnalytics } from './analytics';
+import { createIdlAnalytics, trackIdlViewed } from './analytics';
 
 vi.mock('@/app/shared/lib/analytics', () => ({
     trackEvent: vi.fn(),
 }));
 
 const mockedTrackEvent = vi.mocked(trackEvent);
+
+describe('trackIdlViewed', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should emit iidl_anchor_idl_viewed for Anchor standard', () => {
+        trackIdlViewed('Anchor', 'prog1');
+        expect(mockedTrackEvent).toHaveBeenCalledWith('iidl_anchor_idl_viewed', {
+            program_id: 'prog1',
+        });
+    });
+
+    it('should emit iidl_codama_idl_viewed for Codama standard', () => {
+        trackIdlViewed('Codama', 'prog2');
+        expect(mockedTrackEvent).toHaveBeenCalledWith('iidl_codama_idl_viewed', {
+            program_id: 'prog2',
+        });
+    });
+});
 
 describe('createIdlAnalytics', () => {
     afterEach(() => {

--- a/app/features/idl/interactive-idl/lib/analytics.spec.ts
+++ b/app/features/idl/interactive-idl/lib/analytics.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { trackEvent } from '@/app/shared/lib/analytics';
 
-import { createIdlAnalytics, trackIdlViewed } from './analytics';
+import { createIdlAnalytics } from './analytics';
 
 vi.mock('@/app/shared/lib/analytics', () => ({
     trackEvent: vi.fn(),
@@ -16,14 +16,14 @@ describe('trackIdlViewed', () => {
     });
 
     it('should emit iidl_anchor_idl_viewed for Anchor standard', () => {
-        trackIdlViewed('Anchor', 'prog1');
+        createIdlAnalytics('Anchor').trackIdlViewed('prog1');
         expect(mockedTrackEvent).toHaveBeenCalledWith('iidl_anchor_idl_viewed', {
             program_id: 'prog1',
         });
     });
 
     it('should emit iidl_codama_idl_viewed for Codama standard', () => {
-        trackIdlViewed('Codama', 'prog2');
+        createIdlAnalytics('Codama').trackIdlViewed('prog2');
         expect(mockedTrackEvent).toHaveBeenCalledWith('iidl_codama_idl_viewed', {
             program_id: 'prog2',
         });

--- a/app/features/idl/interactive-idl/lib/analytics.ts
+++ b/app/features/idl/interactive-idl/lib/analytics.ts
@@ -12,6 +12,7 @@ const IDL_TYPE_LABELS: Record<IdlStandard, IdlTypeLabel> = {
 // Interactive IDL actions are the same for IdlStandards.
 // This generates both the `iidl_anchor_*` and `iidl_codama_*` variants.
 const IIDL_ACTIONS = {
+    IdlViewed: 'idl_viewed',
     SectionsExpanded: 'sections_expanded',
     TabOpened: 'tab_opened',
     TransactionConfirmed: 'transaction_confirmed',
@@ -39,6 +40,18 @@ export type IdlAnalytics = {
     trackTransactionSubmitted(programId?: string, instructionName?: string): void;
     trackWalletConnected(programId?: string, walletType?: string): void;
 };
+
+/**
+ * Fires a `idl_viewed` event when an IDL is displayed to the user.
+ * Includes `idl_type` to differentiate between anchor and codama IDLs.
+ * This is the top-of-funnel event for IDL engagement analytics.
+ */
+export function trackIdlViewed(standard: IdlStandard, programId?: string): void {
+    const idlType = IDL_TYPE_LABELS[standard];
+    trackEvent(eventName(idlType, IIDL_ACTIONS.IdlViewed), {
+        program_id: programId,
+    });
+}
 
 /**
  * Builds an Interactive IDL analytics tracker.

--- a/app/features/idl/interactive-idl/lib/analytics.ts
+++ b/app/features/idl/interactive-idl/lib/analytics.ts
@@ -42,8 +42,8 @@ export type IdlAnalytics = {
 };
 
 /**
- * Fires a `idl_viewed` event when an IDL is displayed to the user.
- * Includes `idl_type` to differentiate between anchor and codama IDLs.
+ * Fires an `idl_viewed` event when an IDL is displayed to the user.
+ * The IDL standard is encoded in the event name (`iidl_anchor_idl_viewed` vs `iidl_codama_idl_viewed`).
  * This is the top-of-funnel event for IDL engagement analytics.
  */
 export function trackIdlViewed(standard: IdlStandard, programId?: string): void {

--- a/app/features/idl/interactive-idl/lib/analytics.ts
+++ b/app/features/idl/interactive-idl/lib/analytics.ts
@@ -25,13 +25,14 @@ const IIDL_ACTIONS = {
 type IidlAction = (typeof IIDL_ACTIONS)[keyof typeof IIDL_ACTIONS];
 type IidlEventName = `iidl_${IdlTypeLabel}_${IidlAction}`;
 
-// Single compile-time guard for ALL generated names (2 standards × 6 actions).
+// Single compile-time guard for ALL generated names (2 standards × 8 actions).
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- forces a compile error if any generated name exceeds GA4's 40-char limit
 const _assertGA4Length: IidlEventName extends GA4EventName<IidlEventName> ? true : never = true;
 
 const eventName = (idlType: IdlTypeLabel, action: IidlAction): IidlEventName => `iidl_${idlType}_${action}`;
 
 export type IdlAnalytics = {
+    trackIdlViewed(programId?: string): void;
     trackSectionsExpanded(programId?: string, expandedSections?: string[]): void;
     trackTabOpened(programId?: string): void;
     trackTransactionConfirmed(programId?: string, instructionName?: string, signature?: string): void;
@@ -42,18 +43,6 @@ export type IdlAnalytics = {
 };
 
 /**
- * Fires an `idl_viewed` event when an IDL is displayed to the user.
- * The IDL standard is encoded in the event name (`iidl_anchor_idl_viewed` vs `iidl_codama_idl_viewed`).
- * This is the top-of-funnel event for IDL engagement analytics.
- */
-export function trackIdlViewed(standard: IdlStandard, programId?: string): void {
-    const idlType = IDL_TYPE_LABELS[standard];
-    trackEvent(eventName(idlType, IIDL_ACTIONS.IdlViewed), {
-        program_id: programId,
-    });
-}
-
-/**
  * Builds an Interactive IDL analytics tracker.
  * GA event names are scoped to the IDL standard:
  * - 'Anchor' -> iidl_anchor_*
@@ -62,6 +51,11 @@ export function trackIdlViewed(standard: IdlStandard, programId?: string): void 
 export function createIdlAnalytics(standard: IdlStandard): IdlAnalytics {
     const idlType = IDL_TYPE_LABELS[standard];
     return {
+        trackIdlViewed(programId) {
+            trackEvent(eventName(idlType, IIDL_ACTIONS.IdlViewed), {
+                program_id: programId,
+            });
+        },
         trackSectionsExpanded(programId, expandedSections) {
             trackEvent(eventName(idlType, IIDL_ACTIONS.SectionsExpanded), {
                 expanded_sections: expandedSections?.join(','),

--- a/app/features/idl/ui/IdlRenderer.tsx
+++ b/app/features/idl/ui/IdlRenderer.tsx
@@ -2,7 +2,7 @@ import { type AnchorIdl, CodamaIdl, getDisplayIdlSpecType, getIdlStandard, type 
 import ReactJson from '@microlink/react-json-view';
 import { PublicKey } from '@solana/web3.js';
 import { useSetAtom } from 'jotai';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { AnchorFormattedIdl } from '../formatted-idl/ui/AnchorFormattedIdl';
@@ -32,13 +32,14 @@ export function IdlRenderer({
         setProgramId(new PublicKey(programId));
     }, [idl, programId, setOriginalIdl, setProgramId]);
 
-    const [hasTrackedView, setHasTrackedView] = useState(false);
+    const trackedKey = useRef<string | null>(null);
     useEffect(() => {
-        if (!hasTrackedView) {
+        const key = `${programId}:${getIdlStandard(idl)}`;
+        if (trackedKey.current !== key) {
+            trackedKey.current = key;
             trackIdlViewed(getIdlStandard(idl), programId);
-            setHasTrackedView(true);
         }
-    }, [hasTrackedView, idl, programId]);
+    }, [idl, programId]);
 
     if (raw) {
         return <IdlJson idl={idl} collapsed={collapsed} />;

--- a/app/features/idl/ui/IdlRenderer.tsx
+++ b/app/features/idl/ui/IdlRenderer.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 
 import { AnchorFormattedIdl } from '../formatted-idl/ui/AnchorFormattedIdl';
 import { CodamaFormattedIdl } from '../formatted-idl/ui/CodamaFormattedIdl';
-import { trackIdlViewed } from '../interactive-idl/lib/analytics';
+import { createIdlAnalytics } from '../interactive-idl/lib/analytics';
 import { originalIdlAtom, programIdAtom } from '../interactive-idl/model/state-atoms';
 import type { BaseIdl } from '../interactive-idl/model/unified-program';
 
@@ -37,7 +37,7 @@ export function IdlRenderer({
         const key = `${programId}:${getIdlStandard(idl)}`;
         if (trackedKey.current !== key) {
             trackedKey.current = key;
-            trackIdlViewed(getIdlStandard(idl), programId);
+            createIdlAnalytics(getIdlStandard(idl)).trackIdlViewed(programId);
         }
     }, [idl, programId]);
 

--- a/app/features/idl/ui/IdlRenderer.tsx
+++ b/app/features/idl/ui/IdlRenderer.tsx
@@ -1,12 +1,13 @@
-import { type AnchorIdl, CodamaIdl, getDisplayIdlSpecType, type SupportedIdl } from '@entities/idl';
+import { type AnchorIdl, CodamaIdl, getDisplayIdlSpecType, getIdlStandard, type SupportedIdl } from '@entities/idl';
 import ReactJson from '@microlink/react-json-view';
 import { PublicKey } from '@solana/web3.js';
 import { useSetAtom } from 'jotai';
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { AnchorFormattedIdl } from '../formatted-idl/ui/AnchorFormattedIdl';
 import { CodamaFormattedIdl } from '../formatted-idl/ui/CodamaFormattedIdl';
+import { trackIdlViewed } from '../interactive-idl/lib/analytics';
 import { originalIdlAtom, programIdAtom } from '../interactive-idl/model/state-atoms';
 import type { BaseIdl } from '../interactive-idl/model/unified-program';
 
@@ -30,6 +31,14 @@ export function IdlRenderer({
         setOriginalIdl(idl as BaseIdl);
         setProgramId(new PublicKey(programId));
     }, [idl, programId, setOriginalIdl, setProgramId]);
+
+    const [hasTrackedView, setHasTrackedView] = useState(false);
+    useEffect(() => {
+        if (!hasTrackedView) {
+            trackIdlViewed(getIdlStandard(idl), programId);
+            setHasTrackedView(true);
+        }
+    }, [hasTrackedView, idl, programId]);
 
     if (raw) {
         return <IdlJson idl={idl} collapsed={collapsed} />;


### PR DESCRIPTION
## Description
- adding separated funnel for idl

## Type of change
-   [x] New feature

## Testing
1. now you will get which type of idl user saw

## Related Issues
[HOO-493](https://linear.app/solana-fndn/issue/HOO-493/improve-ga-reports-to-have-a-separate-funnel-or-another-report-to-see)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR