### PR TITLE
refactor(botid): extract botid middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,6 @@ NEXT_PUBLIC_INTERACTIVE_IDL_ENABLED=true
 NEXT_PUBLIC_BAD_TOKENS=
 ## Configuration for "BotId" bot protection feature
 NEXT_PUBLIC_BOTID_ENABLED=true
-## Simulate bot behavior locally for testing (dev only)
-NEXT_PUBLIC_BOTID_SIMULATE_BOT=false
 ## Enable challenge mode to return status code for detected bots (default: log only)
 NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED=false
 ## Set to any value to disable token search in the search bar

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,8 +20,7 @@ import { CookieConsent } from '@/app/features/cookie';
 import { VisibilityProvider } from '@/app/shared/lib/visibility';
 import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
 import { rubikFont } from '@/app/styles';
-
-import { botIdProtectedRoutes } from '../proxy';
+import { botIdProtectedRoutes } from '@/config/botid-middleware.mjs';
 
 export const metadata: Metadata = {
     description: 'Inspect transactions, accounts, blocks, and more on the Solana blockchain',

--- a/config/__tests__/botid-middleware.spec.ts
+++ b/config/__tests__/botid-middleware.spec.ts
@@ -1,5 +1,10 @@
+import { checkBotId } from 'botid/server';
 import { NextRequest } from 'next/server';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import { botIdMiddleware } from '../botid-middleware.mjs';
 
 // Set default log level for this test to avoid flaky tests if .env changes
 const TEST_LOG_LEVEL = '0';
@@ -8,18 +13,12 @@ vi.mock('botid/server', () => ({
     checkBotId: vi.fn(),
 }));
 
-import { checkBotId } from 'botid/server';
-
-import { Logger } from '@/app/shared/lib/logger';
-
-import { proxy } from '../proxy';
-
 function createRequest(pathname: string, headers: Record<string, string> = {}): NextRequest {
     const url = new URL(pathname, 'http://localhost');
     return new NextRequest(url, { headers });
 }
 
-describe('Next.js proxy', () => {
+describe('botIdMiddleware', () => {
     const originalEnv = { ...process.env };
 
     let loggerInfoSpy: ReturnType<typeof vi.spyOn>;
@@ -57,11 +56,11 @@ describe('Next.js proxy', () => {
         it.each<{ headers: Record<string, string>; description: string }>([
             { description: 'with x-is-human header', headers: { 'x-is-human': 'true' } },
             { description: 'without x-is-human header', headers: {} },
-        ])('should allow request to pass through $description', async ({ headers }) => {
+        ])('should pass through $description', async ({ headers }) => {
             const request = createRequest('/api/test', headers);
-            const response = await proxy(request);
+            const response = await botIdMiddleware(request);
 
-            expect(response.status).toBe(200);
+            expect(response).toBeUndefined();
             expect(checkBotId).not.toHaveBeenCalled();
         });
     });
@@ -72,36 +71,36 @@ describe('Next.js proxy', () => {
         });
 
         describe('without x-is-human header', () => {
-            it('should allow request without verification and log info', async () => {
+            it('should pass through without verification and log info', async () => {
                 const request = createRequest('/api/test');
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
-                expect(response.status).toBe(200);
+                expect(response).toBeUndefined();
                 expect(checkBotId).not.toHaveBeenCalled();
                 expect(loggerInfoSpy).toHaveBeenCalledWith(
-                    '[proxy] No x-is-human header, allowing',
+                    '[botid] No x-is-human header, allowing',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
         });
 
         describe('when checkBotId throws', () => {
-            it('should allow request and log warning when verification fails', async () => {
+            it('should pass through and log warning when verification fails', async () => {
                 vi.mocked(checkBotId).mockRejectedValue(new SyntaxError('Unexpected token < in JSON'));
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
-                expect(response.status).toBe(200);
+                expect(response).toBeUndefined();
                 expect(loggerWarnSpy).toHaveBeenCalledWith(
-                    '[proxy] BotId verification failed, allowing request',
+                    '[botid] BotId verification failed, allowing request',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
         });
 
         describe('with x-is-human header', () => {
-            it('should allow human requests and log verification info', async () => {
+            it('should pass through human requests and log verification info', async () => {
                 vi.mocked(checkBotId).mockResolvedValue({
                     bypassed: false,
                     isBot: false,
@@ -110,21 +109,21 @@ describe('Next.js proxy', () => {
                 });
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
-                expect(response.status).toBe(200);
+                expect(response).toBeUndefined();
                 expect(checkBotId).toHaveBeenCalled();
                 expect(loggerInfoSpy).toHaveBeenCalledWith(
-                    '[proxy] BotId verification',
+                    '[botid] BotId verification',
                     expect.objectContaining({ isHuman: true }),
                 );
                 expect(loggerInfoSpy).toHaveBeenCalledWith(
-                    '[proxy] Human verified',
+                    '[botid] Human verified',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
 
-            it('should allow bot requests when challenge mode is disabled and log warning', async () => {
+            it('should pass through bot requests when challenge mode is disabled and log warning', async () => {
                 vi.mocked(checkBotId).mockResolvedValue({
                     bypassed: false,
                     isBot: true,
@@ -133,11 +132,11 @@ describe('Next.js proxy', () => {
                 });
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
-                expect(response.status).toBe(200);
+                expect(response).toBeUndefined();
                 expect(loggerWarnSpy).toHaveBeenCalledWith(
-                    '[proxy] Bot detected',
+                    '[botid] Bot detected',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
@@ -157,17 +156,18 @@ describe('Next.js proxy', () => {
                 });
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
+                if (!response) throw new Error('expected NextResponse from middleware');
                 expect(response.status).toBe(401);
                 const body = await response.json();
                 expect(body).toEqual({ error: 'Access denied: request identified as automated bot' });
                 expect(loggerWarnSpy).toHaveBeenCalledWith(
-                    '[proxy] Bot detected',
+                    '[botid] Bot detected',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
                 expect(loggerErrorSpy).toHaveBeenCalledWith(
-                    new Error('[proxy] Challenge mode enabled, blocking'),
+                    new Error('[botid] Challenge mode enabled, blocking'),
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
@@ -181,16 +181,17 @@ describe('Next.js proxy', () => {
                 });
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
+                if (!response) throw new Error('expected NextResponse from middleware');
                 expect(response.status).toBe(401);
                 expect(loggerErrorSpy).toHaveBeenCalledWith(
-                    new Error('[proxy] Challenge mode enabled, blocking'),
+                    new Error('[botid] Challenge mode enabled, blocking'),
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
 
-            it('should allow human requests and log info', async () => {
+            it('should pass through human requests and log info', async () => {
                 vi.mocked(checkBotId).mockResolvedValue({
                     bypassed: false,
                     isBot: false,
@@ -199,11 +200,11 @@ describe('Next.js proxy', () => {
                 });
 
                 const request = createRequest('/api/test', { 'x-is-human': 'true' });
-                const response = await proxy(request);
+                const response = await botIdMiddleware(request);
 
-                expect(response.status).toBe(200);
+                expect(response).toBeUndefined();
                 expect(loggerInfoSpy).toHaveBeenCalledWith(
-                    '[proxy] Human verified',
+                    '[botid] Human verified',
                     expect.objectContaining({ pathname: '/api/test' }),
                 );
             });
@@ -211,7 +212,7 @@ describe('Next.js proxy', () => {
     });
 
     describe('simulate bot mode', () => {
-        it('should allow request when simulate bot mode is enabled but challenge mode is disabled', async () => {
+        it('should pass through when simulate bot mode is enabled but challenge mode is disabled', async () => {
             process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
             process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
 
@@ -223,11 +224,11 @@ describe('Next.js proxy', () => {
             });
 
             const request = createRequest('/api/test', { 'x-is-human': 'true' });
-            const response = await proxy(request);
+            const response = await botIdMiddleware(request);
 
-            expect(response.status).toBe(200);
+            expect(response).toBeUndefined();
             expect(loggerWarnSpy).toHaveBeenCalledWith(
-                '[proxy] Bot detected',
+                '[botid] Bot detected',
                 expect.objectContaining({ pathname: '/api/test' }),
             );
         });
@@ -245,11 +246,12 @@ describe('Next.js proxy', () => {
             });
 
             const request = createRequest('/api/test', { 'x-is-human': 'true' });
-            const response = await proxy(request);
+            const response = await botIdMiddleware(request);
 
+            if (!response) throw new Error('expected NextResponse from middleware');
             expect(response.status).toBe(401);
             expect(loggerErrorSpy).toHaveBeenCalledWith(
-                new Error('[proxy] Challenge mode enabled, blocking'),
+                new Error('[botid] Challenge mode enabled, blocking'),
                 expect.objectContaining({ pathname: '/api/test' }),
             );
         });

--- a/config/__tests__/botid-middleware.spec.ts
+++ b/config/__tests__/botid-middleware.spec.ts
@@ -214,7 +214,7 @@ describe('botIdMiddleware', () => {
     describe('simulate bot mode', () => {
         it('should pass through when simulate bot mode is enabled but challenge mode is disabled', async () => {
             process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
-            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+            process.env.NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT = 'true';
 
             vi.mocked(checkBotId).mockResolvedValue({
                 bypassed: true,
@@ -235,7 +235,7 @@ describe('botIdMiddleware', () => {
 
         it('should block request when both simulate bot mode and challenge mode are enabled', async () => {
             process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
-            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+            process.env.NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT = 'true';
             process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED = 'true';
 
             vi.mocked(checkBotId).mockResolvedValue({

--- a/config/__tests__/proxy.integration.spec.ts
+++ b/config/__tests__/proxy.integration.spec.ts
@@ -202,7 +202,7 @@ describe('proxy — real BotID middleware', () => {
     describe('simulate-bot mode', () => {
         it('should pass through (200) when simulate-bot is on and challenge mode is off', async () => {
             process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
-            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+            process.env.NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT = 'true';
 
             vi.mocked(checkBotId).mockResolvedValue({
                 bypassed: true,
@@ -222,7 +222,7 @@ describe('proxy — real BotID middleware', () => {
 
         it('should block (401) when simulate-bot and challenge mode are both on', async () => {
             process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
-            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+            process.env.NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT = 'true';
             process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED = 'true';
 
             vi.mocked(checkBotId).mockResolvedValue({

--- a/config/__tests__/proxy.integration.spec.ts
+++ b/config/__tests__/proxy.integration.spec.ts
@@ -1,0 +1,243 @@
+import { checkBotId } from 'botid/server';
+import { NextRequest } from 'next/server';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+// Exercises the real proxy → botIdMiddleware stack (unmocked). Asserts observable
+// behaviour — return status/body, whether checkBotId ran, which log LEVEL fired with
+// pathname context — NOT log message prefixes, so it stays valid across the intentional
+// `[proxy]` → `[botid]` rename.
+import { proxy } from '../../proxy';
+
+const TEST_LOG_LEVEL = '0';
+
+vi.mock('botid/server', () => ({
+    checkBotId: vi.fn(),
+}));
+
+function createRequest(pathname: string, headers: Record<string, string> = {}): NextRequest {
+    return new NextRequest(new URL(pathname, 'http://localhost'), { headers });
+}
+
+describe('proxy — real BotID middleware', () => {
+    const originalEnv = { ...process.env };
+
+    let loggerInfoSpy: ReturnType<typeof vi.spyOn>;
+    let loggerWarnSpy: ReturnType<typeof vi.spyOn>;
+    let loggerErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeAll(() => {
+        process.env.NEXT_LOG_LEVEL = TEST_LOG_LEVEL;
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = { ...originalEnv, NEXT_LOG_LEVEL: TEST_LOG_LEVEL };
+
+        loggerInfoSpy = vi.spyOn(Logger, 'info').mockImplementation(() => {});
+        loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
+        loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        loggerInfoSpy.mockRestore();
+        loggerWarnSpy.mockRestore();
+        loggerErrorSpy.mockRestore();
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    describe('when feature flag is disabled', () => {
+        beforeEach(() => {
+            delete process.env.NEXT_PUBLIC_BOTID_ENABLED;
+        });
+
+        it.each<{ description: string; headers: Record<string, string> }>([
+            { description: 'with x-is-human header', headers: { 'x-is-human': 'true' } },
+            { description: 'without x-is-human header', headers: {} },
+        ])('should pass through (200) without calling checkBotId $description', async ({ headers }) => {
+            const response = await proxy(createRequest('/api/test', headers));
+
+            expect(response.status).toBe(200);
+            expect(checkBotId).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when feature flag is enabled', () => {
+        beforeEach(() => {
+            process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
+        });
+
+        it('should pass through (200) and log info when x-is-human header is absent', async () => {
+            const response = await proxy(createRequest('/api/test'));
+
+            expect(response.status).toBe(200);
+            expect(checkBotId).not.toHaveBeenCalled();
+            expect(loggerInfoSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ pathname: '/api/test' }),
+            );
+        });
+
+        it('should pass through (200) and warn when checkBotId throws', async () => {
+            vi.mocked(checkBotId).mockRejectedValue(new SyntaxError('Unexpected token < in JSON'));
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(200);
+            expect(loggerWarnSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ pathname: '/api/test' }),
+            );
+            expect(loggerErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should pass through (200) and log verification info for a human', async () => {
+            vi.mocked(checkBotId).mockResolvedValue({
+                bypassed: false,
+                isBot: false,
+                isHuman: true,
+                isVerifiedBot: false,
+            });
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(200);
+            expect(checkBotId).toHaveBeenCalled();
+            expect(loggerInfoSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ isHuman: true }));
+            expect(loggerErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should pass through (200) and warn when a bot is detected and challenge mode is off', async () => {
+            vi.mocked(checkBotId).mockResolvedValue({
+                bypassed: false,
+                isBot: true,
+                isHuman: false,
+                isVerifiedBot: false,
+            });
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(200);
+            expect(loggerWarnSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ pathname: '/api/test' }),
+            );
+            expect(loggerErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should pass through (200) for a verified bot when challenge mode is off', async () => {
+            vi.mocked(checkBotId).mockResolvedValue({
+                bypassed: false,
+                isBot: true,
+                isHuman: false,
+                isVerifiedBot: true,
+            });
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(200);
+            expect(checkBotId).toHaveBeenCalled();
+            expect(loggerErrorSpy).not.toHaveBeenCalled();
+        });
+
+        describe('with challenge mode enabled', () => {
+            beforeEach(() => {
+                process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED = 'true';
+            });
+
+            it('should block (401) with the access-denied body when a bot is detected', async () => {
+                vi.mocked(checkBotId).mockResolvedValue({
+                    bypassed: false,
+                    isBot: true,
+                    isHuman: false,
+                    isVerifiedBot: false,
+                });
+
+                const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+                expect(response.status).toBe(401);
+                expect(await response.json()).toEqual({
+                    error: 'Access denied: request identified as automated bot',
+                });
+                expect(loggerErrorSpy).toHaveBeenCalledWith(
+                    expect.any(Error),
+                    expect.objectContaining({ pathname: '/api/test' }),
+                );
+            });
+
+            it('should block (401) for a verified bot', async () => {
+                vi.mocked(checkBotId).mockResolvedValue({
+                    bypassed: false,
+                    isBot: true,
+                    isHuman: false,
+                    isVerifiedBot: true,
+                });
+
+                const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+                expect(response.status).toBe(401);
+            });
+
+            it('should pass through (200) for a human', async () => {
+                vi.mocked(checkBotId).mockResolvedValue({
+                    bypassed: false,
+                    isBot: false,
+                    isHuman: true,
+                    isVerifiedBot: false,
+                });
+
+                const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+                expect(response.status).toBe(200);
+                expect(checkBotId).toHaveBeenCalled();
+                expect(loggerErrorSpy).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('simulate-bot mode', () => {
+        it('should pass through (200) when simulate-bot is on and challenge mode is off', async () => {
+            process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
+            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+
+            vi.mocked(checkBotId).mockResolvedValue({
+                bypassed: true,
+                isBot: true,
+                isHuman: false,
+                isVerifiedBot: false,
+            });
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(200);
+            expect(checkBotId).toHaveBeenCalledWith(
+                expect.objectContaining({ developmentOptions: { bypass: 'BAD-BOT' } }),
+            );
+            expect(loggerErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should block (401) when simulate-bot and challenge mode are both on', async () => {
+            process.env.NEXT_PUBLIC_BOTID_ENABLED = 'true';
+            process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT = 'true';
+            process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED = 'true';
+
+            vi.mocked(checkBotId).mockResolvedValue({
+                bypassed: true,
+                isBot: true,
+                isHuman: false,
+                isVerifiedBot: false,
+            });
+
+            const response = await proxy(createRequest('/api/test', { 'x-is-human': 'true' }));
+
+            expect(response.status).toBe(401);
+            expect(checkBotId).toHaveBeenCalledWith(
+                expect.objectContaining({ developmentOptions: { bypass: 'BAD-BOT' } }),
+            );
+        });
+    });
+});

--- a/config/__tests__/proxy.spec.ts
+++ b/config/__tests__/proxy.spec.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { botIdMiddleware } from '@/config/botid-middleware.mjs';
+
+import { proxy } from '../../proxy';
+
+vi.mock('@/config/botid-middleware.mjs', () => ({
+    botIdMiddleware: vi.fn(),
+}));
+
+function createRequest(pathname: string): NextRequest {
+    return new NextRequest(new URL(pathname, 'http://localhost'));
+}
+
+describe('Next.js proxy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should pass through with 200 when middleware returns undefined', async () => {
+        vi.mocked(botIdMiddleware).mockResolvedValue(undefined);
+
+        const response = await proxy(createRequest('/api/test'));
+
+        expect(response.status).toBe(200);
+        expect(botIdMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return the middleware response verbatim when it short-circuits', async () => {
+        const blocked = NextResponse.json({ error: 'blocked' }, { status: 401 });
+        vi.mocked(botIdMiddleware).mockResolvedValue(blocked);
+
+        const response = await proxy(createRequest('/api/test'));
+
+        expect(response).toBe(blocked);
+        expect(response.status).toBe(401);
+    });
+});

--- a/config/botid-middleware.mjs
+++ b/config/botid-middleware.mjs
@@ -8,7 +8,7 @@ const BOT_RESPONSE = { body: { error: 'Access denied: request identified as auto
 
 /**
  * BotIdClient protected routes — only API routes need protection.
- * Must mirror `proxy.ts` matcher in BotID's glob format.
+ * Must mirror `proxy.ts`'s `config.matcher`, expressed in BotID's glob format.
  *
  * @type {Array<{ path: string; method: string }>}
  */

--- a/config/botid-middleware.mjs
+++ b/config/botid-middleware.mjs
@@ -1,0 +1,70 @@
+import { isEnvEnabled } from '@utils/env';
+import { checkBotId } from 'botid/server';
+import { NextResponse } from 'next/server';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+const BOT_RESPONSE = { body: { error: 'Access denied: request identified as automated bot' }, status: 401 };
+
+/**
+ * BotIdClient protected routes — only API routes need protection.
+ * Must mirror `proxy.ts` matcher in BotID's glob format.
+ *
+ * @type {Array<{ path: string; method: string }>}
+ */
+export const botIdProtectedRoutes = [{ method: '*', path: '/api/*' }];
+
+/**
+ * BotId verification middleware. Returns a `NextResponse` to block, or `undefined` to pass through.
+ * Fail-open by design: thrown errors and the disabled flag both pass through.
+ *
+ * @param {import('next/server').NextRequest} request
+ * @returns {Promise<import('next/server').NextResponse | undefined>}
+ */
+export async function botIdMiddleware(request) {
+    const { pathname } = request.nextUrl;
+
+    if (!isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_ENABLED)) {
+        return;
+    }
+
+    // Allow requests without x-is-human header (direct API calls)
+    if (!request.headers.has('x-is-human')) {
+        Logger.info('[botid] No x-is-human header, allowing', { pathname });
+        return;
+    }
+
+    // Verify requests with x-is-human header (browser requests via BotIdClient)
+    let verification;
+    try {
+        verification = await checkBotId({
+            developmentOptions: {
+                bypass: isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT) ? 'BAD-BOT' : undefined,
+            },
+        });
+    } catch (error) {
+        // checkBotId throws SyntaxError when Vercel returns non-JSON (e.g. 504 HTML).
+        Logger.warn('[botid] BotId verification failed, allowing request', { error, pathname });
+        return;
+    }
+
+    Logger.info('[botid] BotId verification', {
+        bypassed: verification.bypassed,
+        isBot: verification.isBot,
+        isHuman: verification.isHuman,
+        isVerifiedBot: verification.isVerifiedBot,
+        pathname,
+    });
+
+    // Bot detected: warn always; only block under challenge mode.
+    if (verification.isBot) {
+        Logger.warn('[botid] Bot detected', { pathname });
+
+        if (isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED)) {
+            Logger.error(new Error('[botid] Challenge mode enabled, blocking'), { pathname });
+            return NextResponse.json(BOT_RESPONSE.body, { status: BOT_RESPONSE.status });
+        }
+    } else {
+        Logger.info('[botid] Human verified', { pathname });
+    }
+}

--- a/config/botid-middleware.mjs
+++ b/config/botid-middleware.mjs
@@ -39,7 +39,7 @@ export async function botIdMiddleware(request) {
     try {
         verification = await checkBotId({
             developmentOptions: {
-                bypass: isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT) ? 'BAD-BOT' : undefined,
+                bypass: isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT) ? 'BAD-BOT' : undefined,
             },
         });
     } catch (error) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,10 +1,7 @@
-import { isEnvEnabled } from '@utils/env';
-import { checkBotId } from 'botid/server';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { Logger } from '@/app/shared/lib/logger';
-
-const BOT_RESPONSE = { body: { error: 'Access denied: request identified as automated bot' }, status: 401 } as const;
+import { botIdMiddleware } from '@/config/botid-middleware.mjs';
 
 // Log runtime once per cold start so any future edge↔node drift is visible without per-request overhead.
 let runtimeLogged = false;
@@ -18,59 +15,10 @@ export async function proxy(request: NextRequest) {
         });
     }
 
-    const { pathname } = request.nextUrl;
-
-    if (!isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_ENABLED)) {
-        return NextResponse.next();
-    }
-
-    // Allow requests without x-is-human header (direct API calls)
-    if (!request.headers.has('x-is-human')) {
-        Logger.info('[proxy] No x-is-human header, allowing', { pathname });
-        return NextResponse.next();
-    }
-
-    // Verify requests with x-is-human header (browser requests via BotIdClient)
-    let verification;
-    try {
-        verification = await checkBotId({
-            developmentOptions: {
-                bypass: isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_SIMULATE_BOT) ? 'BAD-BOT' : undefined,
-            },
-        });
-    } catch (error) {
-        // checkBotId can throw SyntaxError when Vercel's bot-protection API
-        // returns a non-JSON response (e.g. 504 with HTML body).
-        Logger.warn('[proxy] BotId verification failed, allowing request', { error, pathname });
-        return NextResponse.next();
-    }
-
-    Logger.info('[proxy] BotId verification', {
-        bypassed: verification.bypassed,
-        isBot: verification.isBot,
-        isHuman: verification.isHuman,
-        isVerifiedBot: verification.isVerifiedBot,
-        pathname,
-    });
-
-    // Block bots only when challenge mode is enabled
-    if (verification.isBot) {
-        Logger.warn('[proxy] Bot detected', { pathname });
-
-        if (isEnvEnabled(process.env.NEXT_PUBLIC_BOTID_CHALLENGE_MODE_ENABLED)) {
-            Logger.error(new Error('[proxy] Challenge mode enabled, blocking'), { pathname });
-            return NextResponse.json(BOT_RESPONSE.body, { status: BOT_RESPONSE.status });
-        }
-    } else {
-        Logger.info('[proxy] Human verified', { pathname });
-    }
-
-    return NextResponse.next();
+    const blocked = await botIdMiddleware(request);
+    return blocked ?? NextResponse.next();
 }
 
 export const config = {
     matcher: ['/api/:path*'],
 };
-
-// BotIdClient protected routes - only API routes need protection
-export const botIdProtectedRoutes: { path: string; method: string }[] = [{ method: '*', path: '/api/*' }];


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Extracts the inline BotID verification logic out of `proxy.ts` (the Next.js middleware proxy — not the `/api/metadata/proxy` image endpoint) into a reusable util at `config/botid-middleware.mjs`.

- `proxy.ts` becomes a thin delegator: `const blocked = await botIdMiddleware(request); return blocked ?? NextResponse.next()`
- `botIdMiddleware` + `botIdProtectedRoutes` now live in one module with their own tests
- `app/layout.tsx` re-points its `botIdProtectedRoutes` import to `@/config/botid-middleware.mjs`
- the dev-only simulation flag is renamed `NEXT_PUBLIC_BOTID_SIMULATE_BOT` → `NEXT_PUBLIC_BOTID_DEV_SIMULATE_BOT` and dropped from `.env.example` (it maps to BotID `developmentOptions`, a no-op in production)

Pure refactor — behaviour is preserved. The middleware stays fail-open by design (disabled flag, missing `x-is-human` header, and thrown verification errors all pass through). Log prefixes were rebased `[proxy]` → `[botid]` to match the new module home.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe):

Refactor — extract middleware into a reusable util, no behavioural change.

## Screenshots

<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->

N/A — no UI change (the only `app/layout.tsx` edit is an import re-point).

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

- `config/__tests__/botid-middleware.spec.ts` — unit coverage of the extracted middleware (feature flag on/off, `x-is-human` header presence, `checkBotId` throwing, bot/human detection, challenge mode, simulate-bot mode).
- `config/__tests__/proxy.spec.ts` — delegation: `proxy` passes through when the middleware returns `undefined`, forwards its response verbatim when it short-circuits.
- `config/__tests__/proxy.integration.spec.ts` — real `proxy` → `botIdMiddleware` stack (unmocked), asserting behaviour across every branch. Authored against master's inline implementation first and proven identical after the extraction (golden-master), so it guards against behavioural degradation.
- All config specs green (30 tests, 0 type errors); `eslint` clean on the changed files; production build compiles the Proxy middleware.
- Verified live on the dev server: with challenge mode + simulated bot, `/api/*` + `x-is-human` → `401` (`{"error":"Access denied: request identified as automated bot"}`); without the header → `200` pass-through.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

[HOO-598](https://linear.app/solana-fndn/issue/HOO-598)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR

## Additional Notes

<!-- Add any other context about the PR here -->
<!-- For Solana Verify (Verified Builds) related changes, note that bugs should be reported to disclosures@solana.org -->

- The old root `__tests__/proxy.spec.ts` was removed — its coverage moved into `config/__tests__/botid-middleware.spec.ts`. The `/api/metadata/proxy` image endpoint keeps its own separate, untouched tests.
- Silent-failure hardening opportunities exist in the middleware (verification-failure warning not routed to Sentry; unscoped catch), but they pre-exist on master and were carried over verbatim — deliberately kept out of this refactor's scope.
