### PR TITLE
Fix: fixing auto close and open of another accordion on extensions tab

### DIFF
--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -697,7 +697,7 @@ export function TokenExtensionRow(
             const extension = create(tokenExtension.state, ConfidentialTransferMint);
             return (
                 <>
-                    {headerStyle === 'header' ? <HHeader name="Confidential Transfer" /> : null}
+                    {headerStyle === 'header' ? <HHeader name="Confidential Transfer Mint" /> : null}
                     {extension.authority && (
                         <BaseTable.Row>
                             <BaseTable.Cell>Authority</BaseTable.Cell>
@@ -814,7 +814,7 @@ export function TokenExtensionRow(
             const extension = create(tokenExtension.state, ScaledUiAmountConfig);
             return (
                 <>
-                    {headerStyle === 'header' ? <HHeader name="Scaled UI Amount" /> : null}
+                    {headerStyle === 'header' ? <HHeader name="Scaled UI Amount Config" /> : null}
                     {extension.authority && (
                         <BaseTable.Row>
                             <BaseTable.Cell>Authority</BaseTable.Cell>
@@ -852,7 +852,7 @@ export function TokenExtensionRow(
             const extension = create(tokenExtension.state, PausableConfig);
             return (
                 <>
-                    {headerStyle === 'header' ? <HHeader name="Pausable" /> : null}
+                    {headerStyle === 'header' ? <HHeader name="Pausable Config" /> : null}
                     <>
                         {extension.authority && (
                             <BaseTable.Row>
@@ -1053,7 +1053,7 @@ export function TokenExtensionRow(
             const extension = create(tokenExtension.state, ConfidentialTransferAccount);
             return (
                 <>
-                    {headerStyle === 'header' ? <HHeader name="Confidential Transfer" /> : null}
+                    {headerStyle === 'header' ? <HHeader name="Confidential Transfer Account" /> : null}
                     <BaseTable.Row>
                         <BaseTable.Cell>Status</BaseTable.Cell>
                         <BaseTable.Cell className="md:text-right">

--- a/app/components/account/TokenExtensionsSection.tsx
+++ b/app/components/account/TokenExtensionsSection.tsx
@@ -1,5 +1,5 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@components/shared/ui/accordion';
-import { SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Code, ExternalLink } from 'react-feather';
 
 import { SolarizedJsonViewer as ReactJson } from '@/app/components/common/JsonViewer';
@@ -30,41 +30,32 @@ export function TokenExtensionsSection({
     parsedExtensions: ParsedTokenExtension[];
     symbol?: string;
 }) {
-    const { activeExtension: selectedExtension, setActiveExtension: setSelectedExtension } =
-        useTokenExtensionNavigation({ uriComponent: `/address/${address}` });
+    const { activeExtension: selectedExtension, navigateToExtension } = useTokenExtensionNavigation({
+        uriComponent: `/address/${address}`,
+    });
 
     const onSelect = useCallback(
         (id: string) => {
-            setSelectedExtension(id === selectedExtension ? undefined : id);
+            navigateToExtension(id);
         },
-        [selectedExtension, setSelectedExtension],
-    );
-
-    // handle accordion item click to change the selected extension
-    const handleSelect = useCallback(
-        (e: SyntheticEvent<HTMLDivElement>) => {
-            const selectedValue = e.currentTarget.dataset.value;
-            if (selectedValue === selectedExtension) {
-                setSelectedExtension(undefined);
-            }
-        },
-        [selectedExtension, setSelectedExtension],
+        [navigateToExtension],
     );
 
     return (
-        <Accordion type="single" value={selectedExtension} collapsible className="px-0">
+        <Accordion
+            type="single"
+            value={selectedExtension ?? ''}
+            collapsible
+            className="px-0"
+            onValueChange={value => navigateToExtension(value || undefined)}
+        >
             {parsedExtensions.map(ext => {
                 const extension = extensions.find(({ extension }) => {
                     return extension === ext.extension;
                 });
 
                 return (
-                    <AccordionItem
-                        id={getAnchorId(ext)}
-                        key={ext.extension}
-                        value={ext.extension}
-                        onClick={handleSelect}
-                    >
+                    <AccordionItem id={getAnchorId(ext)} key={ext.extension} value={ext.extension}>
                         {extension && (
                             <TokenExtensionAccordionItem
                                 decimals={decimals}

--- a/app/components/account/TokenExtensionsSection.tsx
+++ b/app/components/account/TokenExtensionsSection.tsx
@@ -55,7 +55,12 @@ export function TokenExtensionsSection({
                 });
 
                 return (
-                    <AccordionItem id={getAnchorId(ext)} key={ext.extension} value={ext.extension}>
+                    <AccordionItem
+                        id={getAnchorId(ext)}
+                        key={ext.extension}
+                        value={ext.extension}
+                        style={{ scrollMarginTop: 'var(--sticky-header-height, 0px)' }}
+                    >
                         {extension && (
                             <TokenExtensionAccordionItem
                                 decimals={decimals}

--- a/app/components/account/__tests__/TokenExtensionRow.spec.tsx
+++ b/app/components/account/__tests__/TokenExtensionRow.spec.tsx
@@ -126,7 +126,7 @@ describe('TokenExtensionRow', () => {
             </ScrollAnchorProvider>,
         );
 
-        expect(await screen.findByText('Confidential Transfer')).toBeInTheDocument();
+        expect(await screen.findByText('Confidential Transfer Mint')).toBeInTheDocument();
         expect(screen.getByText(/Authority/)).toBeInTheDocument();
         expect(screen.getByText(/Auditor Elgamal Pubkey/)).toBeInTheDocument();
         expect(screen.getByText('test-pubkey')).toBeInTheDocument();
@@ -253,7 +253,7 @@ describe('TokenExtensionRow', () => {
             </ScrollAnchorProvider>,
         );
 
-        expect(await screen.findByText('Scaled UI Amount')).toBeInTheDocument();
+        expect(await screen.findByText('Scaled UI Amount Config')).toBeInTheDocument();
         expect(screen.getByText('2')).toBeInTheDocument();
         expect(screen.getByText('4.22')).toBeInTheDocument();
     });
@@ -297,7 +297,7 @@ describe('TokenExtensionRow', () => {
             </ScrollAnchorProvider>,
         );
 
-        expect(await screen.findByText('Pausable')).toBeInTheDocument();
+        expect(await screen.findByText('Pausable Config')).toBeInTheDocument();
         expect(screen.getByText('paused')).toBeInTheDocument();
     });
 
@@ -498,7 +498,7 @@ describe('TokenExtensionRow', () => {
             </ScrollAnchorProvider>,
         );
 
-        expect(await screen.findByText('Confidential Transfer')).toBeInTheDocument();
+        expect(await screen.findByText('Confidential Transfer Account')).toBeInTheDocument();
         expect(screen.getByText('approved')).toBeInTheDocument();
         expect(screen.getByText('test-pubkey')).toBeInTheDocument();
         expect(screen.getByText(/Confidential Credits/)).toBeInTheDocument();

--- a/app/components/shared/ui/accordion.tsx
+++ b/app/components/shared/ui/accordion.tsx
@@ -15,7 +15,7 @@ function AccordionItem({ className, ...props }: React.ComponentProps<typeof Acco
             data-slot="accordion-item"
             data-value={props.value}
             className={cn(
-                'border-b border-l-0 border-r-0 border-t-0 border-solid border-neutral-700 px-4 last:border-b-0',
+                'border-b border-l-0 border-r-0 border-t-0 border-solid border-neutral-700 px-4 [outline:none] last:border-b-0',
                 className,
             )}
             {...props}
@@ -34,9 +34,9 @@ const AccordionTrigger = React.forwardRef<
                 data-slot="accordion-trigger"
                 className={cn(
                     'flex flex-1 items-start gap-4 rounded-md border-0 bg-transparent py-4',
-                    'text-left text-sm font-medium text-neutral-200 outline-none transition-all',
+                    'appearance-none text-left text-sm font-medium text-neutral-200 [outline:none]',
                     'hover:underline',
-                    'focus-visible:border-neutral-950 focus-visible:ring-2 focus-visible:ring-neutral-950/50',
+                    'focus-visible:ring-1 focus-visible:ring-neutral-600 focus-visible:ring-offset-0',
                     'disabled:pointer-events-none disabled:opacity-50',
                     '[&[data-state=open]>svg]:rotate-90',
                     className,
@@ -59,7 +59,7 @@ const AccordionContent = React.forwardRef<
         <AccordionPrimitive.Content
             ref={ref}
             data-slot="accordion-content"
-            className="[data-state=closed]:animate-accordion-up [data-state=open]:animate-accordion-down overflow-hidden text-sm"
+            className="[data-state=closed]:animate-accordion-up [data-state=open]:animate-accordion-down overflow-hidden text-sm [outline:none]"
             {...props}
         >
             <div className={cn('pb-4 pt-0', className)}>{children}</div>

--- a/app/features/token-extensions/use-token-extension-navigation.ts
+++ b/app/features/token-extensions/use-token-extension-navigation.ts
@@ -92,12 +92,11 @@ export function useTokenExtensionNavigation({ uriComponent }: { uriComponent: st
         if (!isOnDesiredPage()) return;
         const base = `${globalThis.location.pathname}${globalThis.location.search}`;
         const url = activeExtension ? `${base}#${activeExtension}` : base;
-        globalThis.history.replaceState(null, '', url);
+        globalThis.history.replaceState(undefined, '', url);
     }, [activeExtension]);
 
     return {
         activeExtension,
         navigateToExtension,
-        setActiveExtension,
     };
 }

--- a/app/features/token-extensions/use-token-extension-navigation.ts
+++ b/app/features/token-extensions/use-token-extension-navigation.ts
@@ -92,7 +92,8 @@ export function useTokenExtensionNavigation({ uriComponent }: { uriComponent: st
         if (!isOnDesiredPage()) return;
         const base = `${globalThis.location.pathname}${globalThis.location.search}`;
         const url = activeExtension ? `${base}#${activeExtension}` : base;
-        globalThis.history.replaceState(undefined, '', url);
+        // eslint-disable-next-line unicorn/no-null -- history.replaceState expects null as the no-state sentinel per HTML spec
+        globalThis.history.replaceState(null, '', url);
     }, [activeExtension]);
 
     return {

--- a/app/features/token-extensions/use-token-extension-navigation.ts
+++ b/app/features/token-extensions/use-token-extension-navigation.ts
@@ -1,5 +1,5 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { type AddressTabPath } from '@/app/address/[address]/layout';
 import { ParsedTokenExtension } from '@/app/components/account/types';
@@ -48,9 +48,6 @@ export function useTokenExtensionNavigation({ uriComponent }: { uriComponent: st
         // That's because badges with extensions are displayed at the root component and any tab might be active below
         if (!isOnDesiredPage() && extensionName) {
             router.push(populateUri(uriComponent, TOKEN_EXTENSIONS, searchParams, extensionName));
-        } else {
-            // Just update the hash if already on the page
-            globalThis.location.hash = extensionName ?? '';
         }
 
         setActiveExtension(extensionName);
@@ -81,6 +78,21 @@ export function useTokenExtensionNavigation({ uriComponent }: { uriComponent: st
         if (activeExtension && isOnExtensionPage) {
             scrollToExtension(activeExtension);
         }
+    }, [activeExtension]);
+
+    // Sync URL hash after React commits the state change, so Next.js router interception
+    // cannot race against the state update (calling replaceState inline in the event handler
+    // triggers Next.js navigation processing before setActiveExtension can take effect).
+    const skipFirstUrlSync = useRef(true);
+    useEffect(() => {
+        if (skipFirstUrlSync.current) {
+            skipFirstUrlSync.current = false;
+            return;
+        }
+        if (!isOnDesiredPage()) return;
+        const base = `${globalThis.location.pathname}${globalThis.location.search}`;
+        const url = activeExtension ? `${base}#${activeExtension}` : base;
+        globalThis.history.replaceState(null, '', url);
     }, [activeExtension]);
 
     return {

--- a/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
+++ b/app/shared/ui/navigation-tabs/ui/BaseNavigationTabs.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/app/shared/ui/navigation-tabs/model/navigation-tabs-context';
 import { type NavigationTab } from '@/app/shared/ui/navigation-tabs/model/types';
 import { useTabOverflow } from '@/app/shared/ui/navigation-tabs/model/useTabOverflow';
+import { useStickyHeaderHeight } from '@/app/shared/ui/sticky-header/useStickyHeaderHeight';
 
 import { MobileMoreDropdown } from './MobileMoreDropdown';
 import { TabLink } from './TabLink';
@@ -99,24 +100,7 @@ export function BaseNavigationTabs({
         return () => observer.disconnect();
     }, [scrollSpy]);
 
-    useEffect(() => {
-        if (!scrollSpy) return;
-        const el = wrapperRef.current ?? tablistRef.current;
-        if (!el) return;
-        const update = () => {
-            document.documentElement.style.setProperty(
-                '--sticky-header-height',
-                `${el.getBoundingClientRect().height}px`,
-            );
-        };
-        update();
-        const resizeObserver = new ResizeObserver(update);
-        resizeObserver.observe(el);
-        return () => {
-            resizeObserver.disconnect();
-            document.documentElement.style.removeProperty('--sticky-header-height');
-        };
-    }, [scrollSpy, tablistRef]);
+    useStickyHeaderHeight(wrapperRef, !!scrollSpy);
 
     useEffect(() => {
         if (!scrollSpy) return;

--- a/app/shared/ui/sticky-header/StickyHeader.tsx
+++ b/app/shared/ui/sticky-header/StickyHeader.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/app/components/shared/utils';
+
+import { useStickyHeaderHeight } from './useStickyHeaderHeight';
 
 type Props = {
     children: React.ReactNode;
@@ -10,8 +12,9 @@ type Props = {
 };
 
 export function StickyHeader({ children, className }: Props) {
-    const sentinelRef = React.useRef<HTMLDivElement>(null);
-    const [isStuck, setIsStuck] = React.useState(false);
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const headerRef = useRef<HTMLDivElement>(null);
+    const [isStuck, setIsStuck] = useState(false);
 
     useEffect(() => {
         const sentinel = sentinelRef.current;
@@ -25,10 +28,13 @@ export function StickyHeader({ children, className }: Props) {
         return () => observer.disconnect();
     }, []);
 
+    useStickyHeaderHeight(headerRef);
+
     return (
         <>
             <div ref={sentinelRef} aria-hidden="true" />
             <div
+                ref={headerRef}
                 className={cn(
                     'sticky top-0 z-10 mb-8 border-0 border-b border-solid border-neutral-800 bg-heavy-metal-900',
                     className,

--- a/app/shared/ui/sticky-header/useStickyHeaderHeight.ts
+++ b/app/shared/ui/sticky-header/useStickyHeaderHeight.ts
@@ -1,0 +1,32 @@
+import { type RefObject, useEffect } from 'react';
+
+/**
+ * Measures the height of a sticky header element and writes it to the
+ * `--sticky-header-height` CSS custom property on `<html>`. Used to
+ * offset `scroll-margin-top` on anchor targets beneath the sticky header.
+ */
+export function useStickyHeaderHeight(ref: RefObject<HTMLElement | null>, enabled = true) {
+    useEffect(() => {
+        if (!enabled) return;
+        const el = ref.current;
+        if (!el) return;
+
+        // Initial measurement (one-time getBoundingClientRect is acceptable)
+        document.documentElement.style.setProperty('--sticky-header-height', `${el.getBoundingClientRect().height}px`);
+
+        const resizeObserver = new ResizeObserver(entries => {
+            const entry = entries[0];
+            // borderBoxSize avoids a forced reflow; fall back to contentRect for older browsers
+            const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+            document.documentElement.style.setProperty('--sticky-header-height', `${height}px`);
+        });
+        resizeObserver.observe(el, { box: 'border-box' });
+
+        return () => {
+            resizeObserver.disconnect();
+            document.documentElement.style.removeProperty('--sticky-header-height');
+        };
+        // ref is a stable RefObject from useRef — safe to omit from deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled]);
+}

--- a/app/utils/token-extension.ts
+++ b/app/utils/token-extension.ts
@@ -59,7 +59,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('required-memo')),
-                name: 'Required Memo',
+                name: 'Memo Transfer',
                 status: 'active',
                 tooltip: description,
             };
@@ -67,14 +67,14 @@ export function populatePartialParsedTokenExtension(
         case 'nonTransferable': {
             return {
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('non-transferable-token')),
-                name: 'Non-Transferable Token',
+                name: 'Non-Transferable',
                 status: 'active',
             };
         }
         case 'nonTransferableAccount': {
             return {
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('non-transferable-token')),
-                name: 'Non-Transferable Token Account',
+                name: 'Non-Transferable Account',
                 status: 'active',
             };
         }
@@ -113,7 +113,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description: "This is only set to 'transferring' inside the transferHook CPI",
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('transfer-hook')),
-                name: 'Transfer Hook Account Info',
+                name: 'Transfer Hook Account',
                 status: 'active',
             };
         }
@@ -146,7 +146,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: populateExternalLinks('https://spl.solana.com/confidential-token/quickstart'),
-                name: 'Confidential Transfer Token Info',
+                name: 'Confidential Transfer Account',
                 status: 'active',
                 tooltip: description,
             };
@@ -171,7 +171,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: populateExternalLinks('https://spl.solana.com/confidential-token/quickstart'),
-                name: 'Confidential Transfer',
+                name: 'Confidential Transfer Mint',
                 status: 'active',
                 tooltip: description,
             };
@@ -181,7 +181,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('interest-bearing-token')),
-                name: 'Interest Bearing Token Configuration',
+                name: 'Interest Bearing Config',
                 status: 'active',
                 tooltip: description,
             };
@@ -192,7 +192,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: populateExternalLinks(populateSolanaDevelopersLink('transfer-fee')),
-                name: 'Transfer Fee',
+                name: 'Transfer Fee Config',
                 status: 'active',
                 tooltip: description,
             };
@@ -227,7 +227,7 @@ export function populatePartialParsedTokenExtension(
             return {
                 description,
                 externalLinks: [{ label: 'Docs', url: 'https://solana.com/docs/tokens/extensions/scaled-ui-amount' }],
-                name: 'Scaled UI Amount',
+                name: 'Scaled UI Amount Config',
                 status: 'active',
                 tooltip: description,
             };
@@ -250,7 +250,7 @@ export function populatePartialParsedTokenExtension(
                 externalLinks: [
                     { label: 'Docs', url: 'https://www.solana-program.com/docs/token-2022/extensions#pausable' },
                 ],
-                name: 'Pausable',
+                name: 'Pausable Config',
                 status: 'active',
                 tooltip: description,
             };


### PR DESCRIPTION
## Description
- fixing the opening of the page with a preselected extension in the URL hash. Now, the already selected accordion will collapse and the new will open

## Type of change
-   [x] Bug fix

## Screenshots
https://github.com/user-attachments/assets/d6dab331-2969-4dbf-a647-674af52d72e1


## Testing
1. open [address page with extensions](https://explorer-git-fork-hoodieshq-fix-hoo-84-749dd7-solana-foundation.vercel.app/address/2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo/token-extensions)

## Related Issues
[HOO-840](https://linear.app/solana-fndn/issue/HOO-840/preselected-token-extension-blocks-expanding-other-extensions)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes
