### PR TITLE
Feat: add support for batch instructions for p token program (for triton response)

### DIFF
--- a/app/features/token-batch/index.ts
+++ b/app/features/token-batch/index.ts
@@ -1,4 +1,5 @@
 export { isTokenBatchInstruction } from './lib/batch-parser';
 export { resolveInnerBatchInstructions } from './lib/resolve-inner-batch-instructions';
+export { isRpcParsedBatchInstruction } from './lib/rpc-parsed-batch';
 export { RpcParsedTokenBatchCard } from './ui/RpcParsedTokenBatchCard';
 export { TokenBatchCard } from './ui/TokenBatchCard';

--- a/app/features/token-batch/index.ts
+++ b/app/features/token-batch/index.ts
@@ -1,3 +1,4 @@
 export { isTokenBatchInstruction } from './lib/batch-parser';
 export { resolveInnerBatchInstructions } from './lib/resolve-inner-batch-instructions';
+export { RpcParsedTokenBatchCard } from './ui/RpcParsedTokenBatchCard';
 export { TokenBatchCard } from './ui/TokenBatchCard';

--- a/app/features/token-batch/lib/__tests__/batch-parser.spec.ts
+++ b/app/features/token-batch/lib/__tests__/batch-parser.spec.ts
@@ -15,10 +15,15 @@ import {
     makeBatchIx,
     makeBatchIxWithKeys,
     makeBurnCheckedData,
+    makeInitializeAccount2Data,
+    makeInitializeAccountData,
+    makeInitializeMintData,
     makeMintToCheckedData,
     makeSetAuthorityData,
+    makeSyncNativeData,
     makeTransferCheckedData,
     makeTransferData,
+    makeWithdrawExcessLamportsData,
 } from './test-utils';
 
 describe('isTokenBatchInstruction', () => {
@@ -308,5 +313,91 @@ describe('formatParsedInstruction', () => {
         ]);
         expect(decoded?.accounts[3].isSigner).toBe(true);
         expect(decoded?.accounts[4].isSigner).toBe(true);
+    });
+
+    it('should format InitializeMint with freeze authority', () => {
+        const mintAuth = Keypair.generate().publicKey;
+        const freezeAuth = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeMintData(9, mintAuth, freezeAuth), numAccounts: 2 }],
+            [makeAccount(), makeAccount(false, false)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([
+            { label: 'Decimals', value: '9' },
+            { isAddress: true, label: 'Mint Authority', value: mintAuth.toBase58() },
+            { isAddress: true, label: 'Freeze Authority', value: freezeAuth.toBase58() },
+        ]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Mint', 'Rent Sysvar']);
+    });
+
+    it('should format InitializeMint without freeze authority', () => {
+        const mintAuth = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeMintData(6, mintAuth), numAccounts: 2 }],
+            [makeAccount(), makeAccount(false, false)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([
+            { label: 'Decimals', value: '6' },
+            { isAddress: true, label: 'Mint Authority', value: mintAuth.toBase58() },
+            { label: 'Freeze Authority', value: '(none)' },
+        ]);
+    });
+
+    it('should format InitializeAccount v1', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeAccountData(), numAccounts: 4 }],
+            [makeAccount(), makeAccount(false, false), makeAccount(false, true), makeAccount(false, false)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint', 'Owner', 'Rent Sysvar']);
+    });
+
+    it('should format InitializeAccount2 with owner in data', () => {
+        const owner = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeAccount2Data(owner), numAccounts: 3 }],
+            [makeAccount(), makeAccount(false, false), makeAccount(false, false)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([{ isAddress: true, label: 'Owner', value: owner.toBase58() }]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint', 'Rent Sysvar']);
+    });
+
+    it('should format SyncNative', () => {
+        const ix = makeBatchIxWithKeys([{ data: makeSyncNativeData(), numAccounts: 1 }], [makeAccount()]);
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account']);
+    });
+
+    it('should format WithdrawExcessLamports', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeWithdrawExcessLamportsData(), numAccounts: 3 }],
+            [makeAccount(), makeAccount(), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Source', 'Destination', 'Authority']);
     });
 });

--- a/app/features/token-batch/lib/__tests__/batch-parser.spec.ts
+++ b/app/features/token-batch/lib/__tests__/batch-parser.spec.ts
@@ -15,12 +15,19 @@ import {
     makeBatchIx,
     makeBatchIxWithKeys,
     makeBurnCheckedData,
+    makeBurnData,
+    makeFreezeAccountData,
     makeInitializeAccount2Data,
+    makeInitializeAccount3Data,
     makeInitializeAccountData,
+    makeInitializeMint2Data,
     makeInitializeMintData,
     makeMintToCheckedData,
+    makeMintToData,
+    makeRevokeData,
     makeSetAuthorityData,
     makeSyncNativeData,
+    makeThawAccountData,
     makeTransferCheckedData,
     makeTransferData,
     makeWithdrawExcessLamportsData,
@@ -399,5 +406,133 @@ describe('formatParsedInstruction', () => {
         expect(decoded).toBeDefined();
         expect(decoded?.fields).toEqual([]);
         expect(decoded?.accounts.map(a => a.label)).toEqual(['Source', 'Destination', 'Authority']);
+    });
+
+    it('should format MintTo without decimals', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeMintToData(100000n), numAccounts: 3 }],
+            [makeAccount(false, false), makeAccount(), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([{ label: 'Amount', value: '100000' }]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Mint', 'Destination', 'Mint Authority']);
+    });
+
+    it('should format MintTo with external decimals', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeMintToData(500000n), numAccounts: 3 }],
+            [makeAccount(false, false), makeAccount(), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed, { decimals: 6 });
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([{ label: 'Amount', value: '0.5' }]);
+    });
+
+    it('should format Burn without decimals', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeBurnData(500n), numAccounts: 3 }],
+            [makeAccount(), makeAccount(false, false), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([{ label: 'Amount', value: '500' }]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint', 'Owner/Delegate']);
+    });
+
+    it('should format FreezeAccount', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeFreezeAccountData(), numAccounts: 3 }],
+            [makeAccount(), makeAccount(false, false), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint', 'Freeze Authority']);
+    });
+
+    it('should format ThawAccount', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeThawAccountData(), numAccounts: 3 }],
+            [makeAccount(), makeAccount(false, false), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint', 'Freeze Authority']);
+    });
+
+    it('should format Revoke', () => {
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeRevokeData(), numAccounts: 2 }],
+            [makeAccount(), makeAccount(false, true)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Source', 'Owner']);
+    });
+
+    it('should format InitializeMint2 with freeze authority', () => {
+        const mintAuth = Keypair.generate().publicKey;
+        const freezeAuth = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeMint2Data(9, mintAuth, freezeAuth), numAccounts: 1 }],
+            [makeAccount()],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([
+            { label: 'Decimals', value: '9' },
+            { isAddress: true, label: 'Mint Authority', value: mintAuth.toBase58() },
+            { isAddress: true, label: 'Freeze Authority', value: freezeAuth.toBase58() },
+        ]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Mint']);
+    });
+
+    it('should format InitializeMint2 without freeze authority', () => {
+        const mintAuth = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeMint2Data(6, mintAuth), numAccounts: 1 }],
+            [makeAccount()],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([
+            { label: 'Decimals', value: '6' },
+            { isAddress: true, label: 'Mint Authority', value: mintAuth.toBase58() },
+            { label: 'Freeze Authority', value: '(none)' },
+        ]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Mint']);
+    });
+
+    it('should format InitializeAccount3 with owner in data', () => {
+        const owner = Keypair.generate().publicKey;
+        const ix = makeBatchIxWithKeys(
+            [{ data: makeInitializeAccount3Data(owner), numAccounts: 2 }],
+            [makeAccount(), makeAccount(false, false)],
+        );
+        const { instructions } = parseBatchInstruction(ix);
+        const decoded = formatParsedInstruction(instructions[0].parsed);
+
+        expect(decoded).toBeDefined();
+        expect(decoded?.fields).toEqual([{ isAddress: true, label: 'Owner', value: owner.toBase58() }]);
+        expect(decoded?.accounts.map(a => a.label)).toEqual(['Account', 'Mint']);
     });
 });

--- a/app/features/token-batch/lib/__tests__/rpc-parsed-batch.spec.ts
+++ b/app/features/token-batch/lib/__tests__/rpc-parsed-batch.spec.ts
@@ -1,0 +1,185 @@
+import { Keypair, type ParsedInstruction } from '@solana/web3.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import {
+    decodeRpcBatchInstructions,
+    extractSubInstructions,
+    isRpcParsedBatchInstruction,
+    rpcInfoToDecodedParams,
+    safeLabel,
+    stringifyValue,
+} from '../rpc-parsed-batch';
+
+const ADDRESS = Keypair.generate().publicKey.toBase58();
+
+// Only `parsed` is read; the rest satisfies the ParsedInstruction shape.
+function makeParsedIx(parsed: unknown): ParsedInstruction {
+    return { parsed, program: 'spl-token', programId: Keypair.generate().publicKey } as unknown as ParsedInstruction;
+}
+
+beforeEach(() => {
+    // Silence Logger and give every test a fresh call history to assert against.
+    vi.spyOn(Logger, 'error').mockImplementation(() => {});
+    vi.clearAllMocks();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('isRpcParsedBatchInstruction', () => {
+    it('should return true for a parsed object with type "batch"', () => {
+        expect(isRpcParsedBatchInstruction({ info: {}, type: 'batch' })).toBe(true);
+    });
+
+    it('should return false for other types, strings, null/undefined, and missing type', () => {
+        expect(isRpcParsedBatchInstruction({ type: 'transfer' })).toBe(false);
+        expect(isRpcParsedBatchInstruction('batch')).toBe(false);
+        expect(isRpcParsedBatchInstruction(null)).toBe(false);
+        expect(isRpcParsedBatchInstruction(undefined)).toBe(false);
+        expect(isRpcParsedBatchInstruction({})).toBe(false);
+    });
+});
+
+describe('stringifyValue', () => {
+    it('should pass strings through', () => {
+        expect(stringifyValue('hello')).toBe('hello');
+    });
+
+    it('should stringify numbers, bigints, and booleans', () => {
+        expect(stringifyValue(42)).toBe('42');
+        expect(stringifyValue(100000n)).toBe('100000');
+        expect(stringifyValue(true)).toBe('true');
+    });
+
+    it('should unwrap RPC token-amount objects to uiAmountString', () => {
+        expect(stringifyValue({ amount: '5000000', decimals: 6, uiAmount: 5, uiAmountString: '5' })).toBe('5');
+    });
+
+    it('should fall back to amount when uiAmountString is absent', () => {
+        expect(stringifyValue({ amount: '123', decimals: 0 })).toBe('123');
+    });
+
+    it('should join arrays with a comma', () => {
+        expect(stringifyValue(['a', 'b', 'c'])).toBe('a, b, c');
+    });
+
+    it('should JSON-stringify opaque objects', () => {
+        expect(stringifyValue({ foo: 'bar' })).toBe('{"foo":"bar"}');
+    });
+
+    it('should return empty string for null and undefined', () => {
+        expect(stringifyValue(null)).toBe('');
+        expect(stringifyValue(undefined)).toBe('');
+    });
+});
+
+describe('safeLabel', () => {
+    it('should capital-case non-empty strings', () => {
+        expect(safeLabel('mintAuthority', 'Unknown')).toBe('Mint Authority');
+    });
+
+    it('should return the fallback for non-strings and empty strings', () => {
+        expect(safeLabel(undefined, 'Unknown')).toBe('Unknown');
+        expect(safeLabel(7, 'Unknown')).toBe('Unknown');
+        expect(safeLabel('', 'Unknown')).toBe('Unknown');
+        expect(safeLabel(null, 'Unknown')).toBe('Unknown');
+    });
+});
+
+describe('rpcInfoToDecodedParams', () => {
+    it('should flag base58 pubkey values as addresses and scalars as plain fields', () => {
+        const result = rpcInfoToDecodedParams({ amount: '1000', authority: ADDRESS });
+        expect(result.accounts).toEqual([]);
+        expect(result.fields).toEqual([
+            { isAddress: false, label: 'Amount', value: '1000' },
+            { isAddress: true, label: 'Authority', value: ADDRESS },
+        ]);
+    });
+
+    it('should return no fields for empty info', () => {
+        expect(rpcInfoToDecodedParams({})).toEqual({ accounts: [], fields: [] });
+    });
+
+    it('should format nested token-amount objects as their ui value', () => {
+        const result = rpcInfoToDecodedParams({
+            tokenAmount: { amount: '5000000', decimals: 6, uiAmountString: '5' },
+        });
+        expect(result.fields).toEqual([{ isAddress: false, label: 'Token Amount', value: '5' }]);
+    });
+});
+
+describe('extractSubInstructions', () => {
+    it('should return the sub-instructions under parsed.info.instructions', () => {
+        const subs = [
+            { info: {}, type: 'transfer' },
+            { info: {}, type: 'mintTo' },
+        ];
+        expect(extractSubInstructions(makeParsedIx({ info: { instructions: subs }, type: 'batch' }))).toEqual(subs);
+    });
+
+    it('should return [] when parsed is a string', () => {
+        expect(extractSubInstructions(makeParsedIx('batch'))).toEqual([]);
+    });
+
+    it('should return [] when info.instructions is missing', () => {
+        expect(extractSubInstructions(makeParsedIx({ info: {}, type: 'batch' }))).toEqual([]);
+    });
+
+    it('should log and return [] when info.instructions is not an array', () => {
+        expect(extractSubInstructions(makeParsedIx({ info: { instructions: 'oops' }, type: 'batch' }))).toEqual([]);
+        expect(Logger.error).toHaveBeenCalledOnce();
+    });
+
+    it('should filter out non-object sub-instructions without logging', () => {
+        const subs = [{ info: {}, type: 'transfer' }, null, 'bad', 42];
+        expect(extractSubInstructions(makeParsedIx({ info: { instructions: subs }, type: 'batch' }))).toEqual([
+            { info: {}, type: 'transfer' },
+        ]);
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+});
+
+describe('decodeRpcBatchInstructions', () => {
+    it('should map each sub-instruction to a typeName and decoded fields', () => {
+        const ix = makeParsedIx({
+            info: {
+                instructions: [
+                    { info: { amount: '1000', authority: ADDRESS }, type: 'transfer' },
+                    { info: {}, type: 'syncNative' },
+                ],
+            },
+            type: 'batch',
+        });
+        expect(decodeRpcBatchInstructions(ix)).toEqual([
+            {
+                decoded: {
+                    accounts: [],
+                    fields: [
+                        { isAddress: false, label: 'Amount', value: '1000' },
+                        { isAddress: true, label: 'Authority', value: ADDRESS },
+                    ],
+                },
+                typeName: 'Transfer',
+            },
+            { decoded: { accounts: [], fields: [] }, typeName: 'Sync Native' },
+        ]);
+    });
+
+    it('should not throw and should label a sub-instruction with a missing type as "Unknown"', () => {
+        const ix = makeParsedIx({ info: { instructions: [{ info: { amount: '5' } }] }, type: 'batch' });
+        expect(decodeRpcBatchInstructions(ix)).toEqual([
+            {
+                decoded: { accounts: [], fields: [{ isAddress: false, label: 'Amount', value: '5' }] },
+                typeName: 'Unknown',
+            },
+        ]);
+    });
+
+    it('should coerce a non-object sub-instruction info to empty fields', () => {
+        const ix = makeParsedIx({ info: { instructions: [{ info: 'not-an-object', type: 'foo' }] }, type: 'batch' });
+        expect(decodeRpcBatchInstructions(ix)).toEqual([{ decoded: { accounts: [], fields: [] }, typeName: 'Foo' }]);
+    });
+});

--- a/app/features/token-batch/lib/__tests__/test-utils.ts
+++ b/app/features/token-batch/lib/__tests__/test-utils.ts
@@ -99,6 +99,48 @@ export function makeWithdrawExcessLamportsData(): Uint8Array {
     return new Uint8Array([38]);
 }
 
+// MintTo: [discriminator(7), amount(u64_le)]
+export function makeMintToData(amount: bigint): Uint8Array {
+    return concatBytes(new Uint8Array([7]), writeU64LE(amount));
+}
+
+// FreezeAccount: [discriminator(10)]
+export function makeFreezeAccountData(): Uint8Array {
+    return new Uint8Array([10]);
+}
+
+// ThawAccount: [discriminator(11)]
+export function makeThawAccountData(): Uint8Array {
+    return new Uint8Array([11]);
+}
+
+// Revoke: [discriminator(5)]
+export function makeRevokeData(): Uint8Array {
+    return new Uint8Array([5]);
+}
+
+// InitializeMint2: [discriminator(20), decimals(u8), mintAuthority(32), option_tag(u8), ?freezeAuthority(32)]
+export function makeInitializeMint2Data(
+    decimals: number,
+    mintAuthority: PublicKey,
+    freezeAuthority?: PublicKey,
+): Uint8Array {
+    if (freezeAuthority) {
+        return concatBytes(
+            new Uint8Array([20, decimals]),
+            mintAuthority.toBytes(),
+            new Uint8Array([1]),
+            freezeAuthority.toBytes(),
+        );
+    }
+    return concatBytes(new Uint8Array([20, decimals]), mintAuthority.toBytes(), new Uint8Array([0]));
+}
+
+// InitializeAccount3: [discriminator(18), owner(32)]
+export function makeInitializeAccount3Data(owner: PublicKey): Uint8Array {
+    return concatBytes(new Uint8Array([18]), owner.toBytes());
+}
+
 // SetAuthority: [discriminator(6), authority_type(u8), option_tag(u8), ?new_authority(32)]
 export function makeSetAuthorityData(authorityType: number, newAuthority?: PublicKey): Uint8Array {
     if (newAuthority) {

--- a/app/features/token-batch/lib/__tests__/test-utils.ts
+++ b/app/features/token-batch/lib/__tests__/test-utils.ts
@@ -62,6 +62,43 @@ export function makeBurnCheckedData(amount: bigint, decimals: number): Uint8Arra
     return concatBytes(new Uint8Array([15]), writeU64LE(amount), new Uint8Array([decimals]));
 }
 
+// InitializeMint: [discriminator(0), decimals(u8), mintAuthority(32), option_tag(u8), ?freezeAuthority(32)]
+export function makeInitializeMintData(
+    decimals: number,
+    mintAuthority: PublicKey,
+    freezeAuthority?: PublicKey,
+): Uint8Array {
+    if (freezeAuthority) {
+        return concatBytes(
+            new Uint8Array([0, decimals]),
+            mintAuthority.toBytes(),
+            new Uint8Array([1]),
+            freezeAuthority.toBytes(),
+        );
+    }
+    return concatBytes(new Uint8Array([0, decimals]), mintAuthority.toBytes(), new Uint8Array([0]));
+}
+
+// InitializeAccount v1: [discriminator(1)] — owner is account[2]
+export function makeInitializeAccountData(): Uint8Array {
+    return new Uint8Array([1]);
+}
+
+// InitializeAccount2: [discriminator(16), owner(32)]
+export function makeInitializeAccount2Data(owner: PublicKey): Uint8Array {
+    return concatBytes(new Uint8Array([16]), owner.toBytes());
+}
+
+// SyncNative: [discriminator(17)]
+export function makeSyncNativeData(): Uint8Array {
+    return new Uint8Array([17]);
+}
+
+// WithdrawExcessLamports: [discriminator(38)]
+export function makeWithdrawExcessLamportsData(): Uint8Array {
+    return new Uint8Array([38]);
+}
+
 // SetAuthority: [discriminator(6), authority_type(u8), option_tag(u8), ?new_authority(32)]
 export function makeSetAuthorityData(authorityType: number, newAuthority?: PublicKey): Uint8Array {
     if (newAuthority) {

--- a/app/features/token-batch/lib/format-sub-instruction.ts
+++ b/app/features/token-batch/lib/format-sub-instruction.ts
@@ -254,6 +254,21 @@ function formatByType(
                 ],
             };
 
+        case TokenInstruction.InitializeMint:
+            return {
+                accounts: labelMetas([
+                    { label: 'Mint', meta: parsed.accounts.mint },
+                    { label: 'Rent Sysvar', meta: parsed.accounts.rent },
+                ]),
+                fields: [
+                    { label: 'Decimals', value: parsed.data.decimals.toString() },
+                    { isAddress: true, label: 'Mint Authority', value: parsed.data.mintAuthority },
+                    ...(isSome(parsed.data.freezeAuthority)
+                        ? [{ isAddress: true, label: 'Freeze Authority', value: parsed.data.freezeAuthority.value }]
+                        : [{ label: 'Freeze Authority', value: '(none)' }]),
+                ],
+            };
+
         case TokenInstruction.InitializeMint2:
             return {
                 accounts: labelMetas([{ label: 'Mint', meta: parsed.accounts.mint }]),
@@ -266,6 +281,27 @@ function formatByType(
                 ],
             };
 
+        case TokenInstruction.InitializeAccount:
+            return {
+                accounts: labelMetas([
+                    { label: 'Account', meta: parsed.accounts.account },
+                    { label: 'Mint', meta: parsed.accounts.mint },
+                    { label: 'Owner', meta: parsed.accounts.owner },
+                    { label: 'Rent Sysvar', meta: parsed.accounts.rent },
+                ]),
+                fields: [],
+            };
+
+        case TokenInstruction.InitializeAccount2:
+            return {
+                accounts: labelMetas([
+                    { label: 'Account', meta: parsed.accounts.account },
+                    { label: 'Mint', meta: parsed.accounts.mint },
+                    { label: 'Rent Sysvar', meta: parsed.accounts.rent },
+                ]),
+                fields: [{ isAddress: true, label: 'Owner', value: parsed.data.owner }],
+            };
+
         case TokenInstruction.InitializeAccount3:
             return {
                 accounts: labelMetas([
@@ -273,6 +309,26 @@ function formatByType(
                     { label: 'Mint', meta: parsed.accounts.mint },
                 ]),
                 fields: [{ isAddress: true, label: 'Owner', value: parsed.data.owner }],
+            };
+
+        case TokenInstruction.SyncNative: {
+            const entries: { label: string; meta: AccountMeta<string> }[] = [
+                { label: 'Account', meta: parsed.accounts.account },
+            ];
+            if (parsed.accounts.rent) {
+                entries.push({ label: 'Rent Sysvar', meta: parsed.accounts.rent });
+            }
+            return { accounts: labelMetas(entries), fields: [] };
+        }
+
+        case TokenInstruction.WithdrawExcessLamports:
+            return {
+                accounts: labelMetas([
+                    { label: 'Source', meta: parsed.accounts.source },
+                    { label: 'Destination', meta: parsed.accounts.destination },
+                    { label: 'Authority', meta: parsed.accounts.authority },
+                ]),
+                fields: [],
             };
 
         default:

--- a/app/features/token-batch/lib/rpc-parsed-batch.ts
+++ b/app/features/token-batch/lib/rpc-parsed-batch.ts
@@ -1,0 +1,80 @@
+// Parsing for Token / Token-2022 batch instructions that the RPC has already
+// decoded into structured JSON — a ParsedInstruction whose `parsed.type` is
+// "batch" — as opposed to the raw-bytes form handled by batch-parser.ts.
+
+import { isAddress } from '@solana/kit';
+import type { ParsedInstruction } from '@solana/web3.js';
+import { capitalCase } from 'change-case';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import type { DecodedParams } from './types';
+
+export const RPC_PARSED_BATCH_TYPE = 'batch';
+
+type RpcSubInstruction = { type?: unknown; info?: unknown };
+
+export type RpcSubInstructionView = { typeName: string; decoded: DecodedParams };
+
+export function isRpcParsedBatchInstruction(parsed: unknown): boolean {
+    return (
+        typeof parsed === 'object' && parsed !== null && (parsed as { type?: unknown }).type === RPC_PARSED_BATCH_TYPE
+    );
+}
+
+// Turns an RPC-parsed batch instruction into per-sub-instruction view models.
+// Every value is derived defensively — the shape is RPC-provided and untyped.
+export function decodeRpcBatchInstructions(ix: ParsedInstruction): RpcSubInstructionView[] {
+    return extractSubInstructions(ix).map(sub => ({
+        decoded: rpcInfoToDecodedParams(isRecord(sub.info) ? sub.info : {}),
+        typeName: safeLabel(sub.type, 'Unknown'),
+    }));
+}
+
+// ix.parsed is `string | ParsedInfo`; for a batch it carries the sub-instructions
+// under info.instructions.
+export function extractSubInstructions(ix: ParsedInstruction): RpcSubInstruction[] {
+    const parsed = ix.parsed as unknown;
+    const info = typeof parsed !== 'string' && isRecord(parsed) ? parsed.info : undefined;
+    const instructions = isRecord(info) ? info.instructions : undefined;
+    if (instructions === undefined) return [];
+    if (!Array.isArray(instructions)) {
+        Logger.error(new Error('[token-batch:rpc-parsed-batch] batch info.instructions is not an array'), {
+            parsed,
+        });
+        return [];
+    }
+    return instructions.filter((sub): sub is RpcSubInstruction => isRecord(sub));
+}
+
+// capitalCase throws on non-strings; RPC JSON is untyped, so guard before use.
+export function safeLabel(value: unknown, fallback: string): string {
+    return typeof value === 'string' && value.length > 0 ? capitalCase(value) : fallback;
+}
+
+export function rpcInfoToDecodedParams(info: Record<string, unknown>): DecodedParams {
+    return {
+        accounts: [],
+        fields: Object.entries(info).map(([key, value]) => {
+            const str = stringifyValue(value);
+            return { isAddress: isAddress(str), label: safeLabel(key, key), value: str };
+        }),
+    };
+}
+
+export function stringifyValue(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') return String(value);
+    if (Array.isArray(value)) return value.map(stringifyValue).join(', ');
+    // RPC nests token amounts as { amount, decimals, uiAmount, uiAmountString }.
+    if (isRecord(value)) {
+        const amount = value.uiAmountString ?? value.amount;
+        if (typeof amount === 'string' || typeof amount === 'number') return String(amount);
+        return JSON.stringify(value) ?? '';
+    }
+    return value === null || value === undefined ? '' : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/app/features/token-batch/ui/BatchInstructionCard.tsx
+++ b/app/features/token-batch/ui/BatchInstructionCard.tsx
@@ -1,0 +1,45 @@
+// Shared shell for the two batch-instruction cards: the raw-decode path
+// (TokenBatchCard) and the RPC-parsed path (RpcParsedTokenBatchCard). Keeps the
+// title format and table frame in one place so the two paths can't drift.
+
+import { InstructionCard } from '@components/instruction/InstructionCard';
+import type { ParsedInstruction, SignatureResult, TransactionInstruction } from '@solana/web3.js';
+import type { ReactNode } from 'react';
+
+import { BaseTable } from '@/app/shared/ui/Table';
+
+export function BatchInstructionCard({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+    count,
+    children,
+}: {
+    ix: TransactionInstruction | ParsedInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: ReactNode[];
+    childIndex?: number;
+    count: number;
+    children: ReactNode;
+}) {
+    return (
+        <InstructionCard
+            title={batchInstructionTitle(count)}
+            collapsible
+            {...{ childIndex, index, innerCards, ix, result }}
+        >
+            <BaseTable.Row>
+                <BaseTable.Cell colSpan={3} className="p-0">
+                    <div className="pb-2">{children}</div>
+                </BaseTable.Cell>
+            </BaseTable.Row>
+        </InstructionCard>
+    );
+}
+
+function batchInstructionTitle(count: number): string {
+    return `Token Program: Batch (${count} instruction${count !== 1 ? 's' : ''})`;
+}

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -1,44 +1,14 @@
 // Renders a Token / Token-2022 batch instruction that the Solana RPC has
 // already parsed into structured JSON. Used when the transaction page receives
 // a ParsedInstruction (type "batch") instead of a PartiallyDecodedInstruction
-// with raw bytes.
+// with raw bytes. All parsing lives in lib/rpc-parsed-batch; this stays presentational.
 
-import { InstructionCard } from '@components/instruction/InstructionCard';
-import { ParsedInstruction, PublicKey, SignatureResult } from '@solana/web3.js';
-import { capitalCase } from 'change-case';
+import type { ParsedInstruction, SignatureResult } from '@solana/web3.js';
 import type { ReactNode } from 'react';
 
-import { BaseTable } from '@/app/shared/ui/Table';
-
-import type { DecodedParams } from '../lib/types';
+import { decodeRpcBatchInstructions } from '../lib/rpc-parsed-batch';
+import { BatchInstructionCard } from './BatchInstructionCard';
 import { SubInstructionRowView } from './SubInstructionRow';
-
-type RpcSubInstruction = { type: string; info: Record<string, unknown> };
-
-function isValidPublicKey(value: string): boolean {
-    try {
-        new PublicKey(value);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-function stringifyValue(value: unknown): string {
-    if (typeof value === 'string') return value;
-    if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') return String(value);
-    return JSON.stringify(value) ?? '';
-}
-
-function rpcInfoToDecodedParams(info: Record<string, unknown>): DecodedParams {
-    return {
-        accounts: [],
-        fields: Object.entries(info).map(([key, value]) => {
-            const str = stringifyValue(value);
-            return { isAddress: isValidPublicKey(str), label: capitalCase(key), value: str };
-        }),
-    };
-}
 
 export function RpcParsedTokenBatchCard({
     ix,
@@ -53,27 +23,13 @@ export function RpcParsedTokenBatchCard({
     innerCards?: ReactNode[];
     childIndex?: number;
 }) {
-    // ix.parsed is string | ParsedInfo; for batch it's always ParsedInfo
-    const parsedInfo = typeof ix.parsed !== 'string' ? ix.parsed : undefined;
-    const instructions: RpcSubInstruction[] = parsedInfo?.info?.instructions ?? [];
-    const title = `Token Program: Batch (${instructions.length} instruction${instructions.length !== 1 ? 's' : ''})`;
+    const instructions = decodeRpcBatchInstructions(ix);
 
     return (
-        <InstructionCard title={title} collapsible {...{ childIndex, index, innerCards, ix, result }}>
-            <BaseTable.Row>
-                <BaseTable.Cell colSpan={3} className="p-0">
-                    <div className="pb-2">
-                        {instructions.map((sub, i) => (
-                            <SubInstructionRowView
-                                key={i}
-                                index={i}
-                                typeName={capitalCase(sub.type)}
-                                decoded={rpcInfoToDecodedParams(sub.info ?? {})}
-                            />
-                        ))}
-                    </div>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
+        <BatchInstructionCard {...{ childIndex, index, innerCards, ix, result }} count={instructions.length}>
+            {instructions.map((sub, i) => (
+                <SubInstructionRowView key={i} index={i} typeName={sub.typeName} decoded={sub.decoded} />
+            ))}
+        </BatchInstructionCard>
     );
 }

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -13,7 +13,7 @@ import { BaseTable } from '@/app/shared/ui/Table';
 import type { DecodedParams } from '../lib/types';
 import { SubInstructionRowView } from './SubInstructionRow';
 
-type RpcSubInstruction = { type: string; info: Record<string, string> };
+type RpcSubInstruction = { type: string; info: Record<string, unknown> };
 
 function isValidPublicKey(value: string): boolean {
     try {
@@ -24,14 +24,19 @@ function isValidPublicKey(value: string): boolean {
     }
 }
 
-function rpcInfoToDecodedParams(info: Record<string, string>): DecodedParams {
+function stringifyValue(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') return String(value);
+    return JSON.stringify(value);
+}
+
+function rpcInfoToDecodedParams(info: Record<string, unknown>): DecodedParams {
     return {
         accounts: [],
-        fields: Object.entries(info).map(([key, value]) => ({
-            isAddress: isValidPublicKey(value),
-            label: capitalCase(key),
-            value,
-        })),
+        fields: Object.entries(info).map(([key, value]) => {
+            const str = stringifyValue(value);
+            return { isAddress: isValidPublicKey(str), label: capitalCase(key), value: str };
+        }),
     };
 }
 

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -27,7 +27,7 @@ function isValidPublicKey(value: string): boolean {
 function stringifyValue(value: unknown): string {
     if (typeof value === 'string') return value;
     if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') return String(value);
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? '';
 }
 
 function rpcInfoToDecodedParams(info: Record<string, unknown>): DecodedParams {

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -1,0 +1,73 @@
+// Renders a Token / Token-2022 batch instruction that the Solana RPC has
+// already parsed into structured JSON. Used when the transaction page receives
+// a ParsedInstruction (type "batch") instead of a PartiallyDecodedInstruction
+// with raw bytes.
+
+import { InstructionCard } from '@components/instruction/InstructionCard';
+import { ParsedInstruction, PublicKey, SignatureResult } from '@solana/web3.js';
+import { capitalCase } from 'change-case';
+
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import type { DecodedParams } from '../lib/types';
+import { SubInstructionRowView } from './SubInstructionRow';
+
+type RpcSubInstruction = { type: string; info: Record<string, string> };
+
+function isValidPublicKey(value: string): boolean {
+    try {
+        new PublicKey(value);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function rpcInfoToDecodedParams(info: Record<string, string>): DecodedParams {
+    return {
+        accounts: [],
+        fields: Object.entries(info).map(([key, value]) => ({
+            isAddress: isValidPublicKey(value),
+            label: capitalCase(key),
+            value,
+        })),
+    };
+}
+
+export function RpcParsedTokenBatchCard({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+}: {
+    ix: ParsedInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: JSX.Element[];
+    childIndex?: number;
+}) {
+    // ix.parsed is string | ParsedInfo; for batch it's always ParsedInfo
+    const parsedInfo = typeof ix.parsed !== 'string' ? ix.parsed : undefined;
+    const instructions: RpcSubInstruction[] = parsedInfo?.info?.instructions ?? [];
+    const title = `Token Program: Batch (${instructions.length} instruction${instructions.length !== 1 ? 's' : ''})`;
+
+    return (
+        <InstructionCard title={title} collapsible {...{ childIndex, index, innerCards, ix, result }}>
+            <BaseTable.Row>
+                <BaseTable.Cell colSpan={3} className="p-0">
+                    <div className="pb-2">
+                        {instructions.map((sub, i) => (
+                            <SubInstructionRowView
+                                key={i}
+                                index={i}
+                                typeName={capitalCase(sub.type)}
+                                decoded={rpcInfoToDecodedParams(sub.info ?? {})}
+                            />
+                        ))}
+                    </div>
+                </BaseTable.Cell>
+            </BaseTable.Row>
+        </InstructionCard>
+    );
+}

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -27,9 +27,15 @@ export function RpcParsedTokenBatchCard({
 
     return (
         <BatchInstructionCard {...{ childIndex, index, innerCards, ix, result }} count={instructions.length}>
-            {instructions.map((sub, i) => (
-                <SubInstructionRowView key={i} index={i} typeName={sub.typeName} decoded={sub.decoded} />
-            ))}
+            {instructions.length === 0 ? (
+                <div className="text-sm text-neutral-500" data-testid="batch-empty">
+                    No sub-instructions found
+                </div>
+            ) : (
+                instructions.map((sub, i) => (
+                    <SubInstructionRowView key={i} index={i} typeName={sub.typeName} decoded={sub.decoded} />
+                ))
+            )}
         </BatchInstructionCard>
     );
 }

--- a/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
+++ b/app/features/token-batch/ui/RpcParsedTokenBatchCard.tsx
@@ -6,6 +6,7 @@
 import { InstructionCard } from '@components/instruction/InstructionCard';
 import { ParsedInstruction, PublicKey, SignatureResult } from '@solana/web3.js';
 import { capitalCase } from 'change-case';
+import type { ReactNode } from 'react';
 
 import { BaseTable } from '@/app/shared/ui/Table';
 
@@ -44,7 +45,7 @@ export function RpcParsedTokenBatchCard({
     ix: ParsedInstruction;
     index: number;
     result: SignatureResult;
-    innerCards?: JSX.Element[];
+    innerCards?: ReactNode[];
     childIndex?: number;
 }) {
     // ix.parsed is string | ParsedInfo; for batch it's always ParsedInfo

--- a/app/features/token-batch/ui/SubInstructionRow.tsx
+++ b/app/features/token-batch/ui/SubInstructionRow.tsx
@@ -23,6 +23,18 @@ export function SubInstructionRow({
     const decoded = formatParsedInstruction(parsed, mintInfo, extraSigners);
     const typeName = TokenInstruction[parsed.instructionType] ?? 'Unknown';
 
+    return <SubInstructionRowView decoded={decoded ?? undefined} index={index} typeName={typeName} />;
+}
+
+export function SubInstructionRowView({
+    index,
+    typeName,
+    decoded,
+}: {
+    index: number;
+    typeName: string;
+    decoded?: DecodedParams;
+}) {
     return (
         <div className="border-b border-neutral-700 py-3 last:border-b-0" data-testid={`sub-ix-${index}`}>
             <div className="mb-2 flex items-center gap-2">

--- a/app/features/token-batch/ui/SubInstructionRow.tsx
+++ b/app/features/token-batch/ui/SubInstructionRow.tsx
@@ -9,7 +9,6 @@ import { formatParsedInstruction } from '../lib/format-sub-instruction';
 import type { DecodedField, DecodedParams, LabeledAccount } from '../lib/types';
 import { useSubInstructionMintInfo } from '../model/use-sub-instruction-mint-info';
 
-// FIXME: missing Storybook story — needs useSubInstructionMintInfo (useAccountQuery chain) mocked.
 export function SubInstructionRow({
     parsed,
     extraSigners,

--- a/app/features/token-batch/ui/TokenBatchCard.tsx
+++ b/app/features/token-batch/ui/TokenBatchCard.tsx
@@ -1,10 +1,8 @@
-import { InstructionCard } from '@components/instruction/InstructionCard';
 import type { SignatureResult, TransactionInstruction } from '@solana/web3.js';
-
-import { BaseTable } from '@/app/shared/ui/Table';
 
 import { parseBatchInstruction, type ParsedSubInstruction } from '../lib/batch-parser';
 import { BatchMintRegistryProvider } from '../model/batch-mint-registry';
+import { BatchInstructionCard } from './BatchInstructionCard';
 import { SubInstructionRow } from './SubInstructionRow';
 
 export function TokenBatchCard({
@@ -29,38 +27,25 @@ export function TokenBatchCard({
         }
     })();
 
-    const title = `Token Program: Batch (${instructions.length} instruction${instructions.length !== 1 ? 's' : ''})`;
-
     return (
-        <InstructionCard title={title} collapsible {...{ childIndex, index, innerCards, ix, result }}>
-            <BaseTable.Row>
-                <BaseTable.Cell colSpan={3} className="p-0">
-                    <div className="pb-2">
-                        {error && (
-                            <div className="mb-2 text-sm text-red-500" data-testid="batch-error">
-                                Parse error: {error}
-                            </div>
-                        )}
-                        {instructions.length > 0 && (
-                            <BatchMintRegistryProvider>
-                                {instructions.map((sub, i) => (
-                                    <SubInstructionRow
-                                        key={i}
-                                        parsed={sub.parsed}
-                                        extraSigners={sub.extraSigners}
-                                        index={i}
-                                    />
-                                ))}
-                            </BatchMintRegistryProvider>
-                        )}
-                        {instructions.length === 0 && !error && (
-                            <div className="text-sm text-neutral-500" data-testid="batch-empty">
-                                No sub-instructions found
-                            </div>
-                        )}
-                    </div>
-                </BaseTable.Cell>
-            </BaseTable.Row>
-        </InstructionCard>
+        <BatchInstructionCard {...{ childIndex, index, innerCards, ix, result }} count={instructions.length}>
+            {error && (
+                <div className="mb-2 text-sm text-red-500" data-testid="batch-error">
+                    Parse error: {error}
+                </div>
+            )}
+            {instructions.length > 0 && (
+                <BatchMintRegistryProvider>
+                    {instructions.map((sub, i) => (
+                        <SubInstructionRow key={i} parsed={sub.parsed} extraSigners={sub.extraSigners} index={i} />
+                    ))}
+                </BatchMintRegistryProvider>
+            )}
+            {instructions.length === 0 && !error && (
+                <div className="text-sm text-neutral-500" data-testid="batch-empty">
+                    No sub-instructions found
+                </div>
+            )}
+        </BatchInstructionCard>
     );
 }

--- a/app/features/token-batch/ui/__stories__/SubInstructionRow.stories.tsx
+++ b/app/features/token-batch/ui/__stories__/SubInstructionRow.stories.tsx
@@ -1,0 +1,86 @@
+import { PublicKey } from '@solana/web3.js';
+import { withTokenInfoBatch } from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import { SubInstructionRowView } from '../SubInstructionRow';
+
+const meta = {
+    component: SubInstructionRowView,
+    decorators: [withTokenInfoBatch],
+    tags: ['autodocs', 'test'],
+    title: 'Features/TokenBatch/SubInstructionRow',
+} satisfies Meta<typeof SubInstructionRowView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SOURCE = new PublicKey('So11111111111111111111111111111111111111112');
+const DEST = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const AUTHORITY = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+// Transfer: amount field only, no accounts listed
+export const Transfer: Story = {
+    args: {
+        decoded: {
+            accounts: [],
+            fields: [{ isAddress: false, label: 'Amount', value: '1000000' }],
+        },
+        index: 0,
+        typeName: 'Transfer',
+    },
+};
+
+// TransferChecked: amount + decimals fields
+export const TransferChecked: Story = {
+    args: {
+        decoded: {
+            accounts: [],
+            fields: [
+                { isAddress: false, label: 'Amount', value: '5000000' },
+                { isAddress: false, label: 'Decimals', value: '6' },
+            ],
+        },
+        index: 1,
+        typeName: 'TransferChecked',
+    },
+};
+
+// SetAuthority: field with an address value
+export const SetAuthority: Story = {
+    args: {
+        decoded: {
+            accounts: [],
+            fields: [
+                { isAddress: false, label: 'Authority Type', value: 'MintTokens' },
+                { isAddress: true, label: 'New Authority', value: AUTHORITY.toBase58() },
+            ],
+        },
+        index: 2,
+        typeName: 'SetAuthority',
+    },
+};
+
+// WithAccounts: labeled accounts with writable / signer badges
+export const WithAccounts: Story = {
+    args: {
+        decoded: {
+            accounts: [
+                { isSigner: false, isWritable: true, label: 'Source', pubkey: SOURCE },
+                { isSigner: false, isWritable: true, label: 'Destination', pubkey: DEST },
+                { isSigner: true, isWritable: false, label: 'Authority', pubkey: AUTHORITY },
+            ],
+            fields: [{ isAddress: false, label: 'Amount', value: '7500' }],
+        },
+        index: 3,
+        typeName: 'Transfer',
+    },
+};
+
+// NoDecoded: hook hasn't resolved yet or instruction unknown
+export const NoDecoded: Story = {
+    args: {
+        decoded: undefined,
+        index: 4,
+        typeName: 'SyncNative',
+    },
+};

--- a/app/features/token-batch/ui/__stories__/SubInstructionRow.stories.tsx
+++ b/app/features/token-batch/ui/__stories__/SubInstructionRow.stories.tsx
@@ -1,12 +1,12 @@
 import { PublicKey } from '@solana/web3.js';
-import { withTokenInfoBatch } from '@storybook-config/decorators';
+import { withClusterAccountsAndTokenInfo } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
 
 import { SubInstructionRowView } from '../SubInstructionRow';
 
 const meta = {
     component: SubInstructionRowView,
-    decorators: [withTokenInfoBatch],
+    decorators: [withClusterAccountsAndTokenInfo],
     tags: ['autodocs', 'test'],
     title: 'Features/TokenBatch/SubInstructionRow',
 } satisfies Meta<typeof SubInstructionRowView>;

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -36,7 +36,12 @@ import { isZkElGamalProofInstruction } from '@entities/zk-elgamal-proof';
 import { isLighthouseInstruction, LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { isStakeInstruction, RawStakeDetailsCard, StakeDetailsCard } from '@features/stake';
-import { isTokenBatchInstruction, RpcParsedTokenBatchCard, TokenBatchCard } from '@features/token-batch';
+import {
+    isRpcParsedBatchInstruction,
+    isTokenBatchInstruction,
+    RpcParsedTokenBatchCard,
+    TokenBatchCard,
+} from '@features/token-batch';
 import { VoteDetailsCard } from '@features/vote';
 import { MPL_TOKEN_METADATA_PROGRAM_ID } from '@metaplex-foundation/mpl-token-metadata';
 import { useCluster } from '@providers/cluster';
@@ -151,10 +156,6 @@ export function InstructionsSection({ signature }: SignatureProps) {
     );
 }
 
-function isBatchInstruction(parsed: unknown): boolean {
-    return typeof parsed !== 'string' && (parsed as { type?: string } | null)?.type === 'batch';
-}
-
 function InstructionCard({
     ix,
     tx,
@@ -202,7 +203,7 @@ function InstructionCard({
                 // The RPC parses batch instructions (disc 0xff) as ParsedInstruction
                 // with type "batch". Route them to the batch card before TokenDetailsCard
                 // throws on the unrecognised type.
-                if (isBatchInstruction(ix.parsed)) {
+                if (isRpcParsedBatchInstruction(ix.parsed)) {
                     return (
                         <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
                             <RpcParsedTokenBatchCard

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -36,7 +36,7 @@ import { isZkElGamalProofInstruction } from '@entities/zk-elgamal-proof';
 import { isLighthouseInstruction, LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { isStakeInstruction, RawStakeDetailsCard, StakeDetailsCard } from '@features/stake';
-import { isTokenBatchInstruction, TokenBatchCard } from '@features/token-batch';
+import { isTokenBatchInstruction, RpcParsedTokenBatchCard, TokenBatchCard } from '@features/token-batch';
 import { VoteDetailsCard } from '@features/vote';
 import { MPL_TOKEN_METADATA_PROGRAM_ID } from '@metaplex-foundation/mpl-token-metadata';
 import { useCluster } from '@providers/cluster';
@@ -194,12 +194,29 @@ function InstructionCard({
 
         switch (ix.program) {
             case 'spl-token':
-            case 'spl-token-2022':
+            case 'spl-token-2022': {
+                // The RPC parses batch instructions (disc 0xff) as ParsedInstruction
+                // with type "batch". Route them to the batch card before TokenDetailsCard
+                // throws on the unrecognised type.
+                if (typeof ix.parsed !== 'string' && ix.parsed.type === 'batch') {
+                    return (
+                        <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
+                            <RpcParsedTokenBatchCard
+                                ix={ix}
+                                index={index}
+                                result={result}
+                                innerCards={innerCards}
+                                childIndex={childIndex}
+                            />
+                        </ErrorBoundary>
+                    );
+                }
                 return (
                     <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
                         <TokenDetailsCard {...props} key={key} />
                     </ErrorBoundary>
                 );
+            }
             case 'bpf-loader':
                 return <BpfLoaderDetailsCard {...props} key={key} />;
             case 'bpf-upgradeable-loader':

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -151,6 +151,10 @@ export function InstructionsSection({ signature }: SignatureProps) {
     );
 }
 
+function isBatchInstruction(parsed: unknown): boolean {
+    return typeof parsed !== 'string' && (parsed as { type?: string } | null)?.type === 'batch';
+}
+
 function InstructionCard({
     ix,
     tx,
@@ -198,7 +202,7 @@ function InstructionCard({
                 // The RPC parses batch instructions (disc 0xff) as ParsedInstruction
                 // with type "batch". Route them to the batch card before TokenDetailsCard
                 // throws on the unrecognised type.
-                if (typeof ix.parsed !== 'string' && ix.parsed.type === 'batch') {
+                if (isBatchInstruction(ix.parsed)) {
                     return (
                         <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
                             <RpcParsedTokenBatchCard


### PR DESCRIPTION
## Description
- adding condition based on parsed.type === 'batch'
for response form triron we need an extra condition to show the batch instruction
- adding more test cases
- adding new sub instruction formatters

## Type of change
-   [x] New feature

## Testing

The demo transaction ends with a batch instruction — on the transaction page it is the **third instruction card, `Token Program: Batch (2 instructions)`**. Expand it and compare the two sub-instructions, `InitializeMint` and `InitializeAccount2`, across the two deployments below.

Both use the Triton RPC, so both receive the batch already parsed (`parsed.type === "batch"`); the only difference is what the code renders.

1. **Preview (this PR):** [open the transaction](https://explorer-git-fork-hoodieshq-feat-hoo-8-fe5a28-solana-foundation.vercel.app/tx/Qk4naQ5FLJTfypCmKwwVcKFJVtTb9PhLRZhV4r2duTKvWLZ8HmLSHUJym43mLAQ9cqhJ4u4CGqS7r3ZjTsxQBDf?cluster=devnet)
   Each sub-instruction shows its decoded fields — `InitializeMint`: Decimals / Mint Authority / Freeze Authority; `InitializeAccount2`: Owner.

2. **Production (current explorer):** [open the same transaction](https://explorer.solana.com/tx/Qk4naQ5FLJTfypCmKwwVcKFJVtTb9PhLRZhV4r2duTKvWLZ8HmLSHUJym43mLAQ9cqhJ4u4CGqS7r3ZjTsxQBDf?cluster=devnet)
   The same sub-instructions are missing those fields.

## Screenshots

| Before — production explorer | After — this PR (preview) |
| --- | --- |
| <img width="846" height="352" alt="Screenshot 2026-07-21 at 18 10 43" src="https://github.com/user-attachments/assets/8b4c5e5e-fd19-453d-8391-48eaafb14eb1" /> | <img width="849" height="451" alt="Screenshot 2026-07-21 at 18 10 51" src="https://github.com/user-attachments/assets/76e115f6-b48b-4553-bf26-ef22904dd034" /> |

## Related Issues
[HOO-821](https://linear.app/solana-fndn/issue/HOO-821/add-support-for-batch-instructions-for-p-token-program)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] For security-related features, I have included links to related information







