### PR TITLE
refactor(cluster): extract shared `useClusterResourceSearch` hook and UI

### DIFF
--- a/app/components/account/UnknownAccountCard.tsx
+++ b/app/components/account/UnknownAccountCard.tsx
@@ -2,15 +2,12 @@
 
 import { Address } from '@components/common/Address';
 import { SolBalance } from '@components/common/SolBalance';
+import { AdjacentClusterLink, SearchingClusterIndicator, useClusterResourceSearch } from '@entities/cluster';
 import { AccountCard } from '@features/account';
 import { Account } from '@providers/accounts';
 import { useCluster } from '@providers/cluster';
 import { address as createAddress, createSolanaRpc } from '@solana/kit';
-import { Cluster, clusterName, clusterSlug, clusterUrl } from '@utils/cluster';
 import { addressLabel } from '@utils/tx';
-import { useClusterPath } from '@utils/url';
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
 
 import { BaseTable } from '@/app/shared/ui/Table';
 
@@ -65,101 +62,6 @@ export function UnknownAccountCard({ account }: { account: Account }) {
     );
 }
 
-type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
-
-function useClusterAccountSearch(address: string, currentCluster: Cluster, _enableCustomClsuter?: boolean) {
-    const searchParams = useSearchParams();
-    const [status, setStatus] = useState<SearchStatus>('idle');
-    const [searchingCluster, setSearchingCluster] = useState<Cluster | null>(null);
-    const [foundCluster, setFoundCluster] = useState<Cluster | null>(null);
-    const searchIdRef = useRef(0);
-
-    const sleep = () => new Promise(res => setTimeout(res, 700));
-
-    // Extract the customUrl value to avoid re-running effect on searchParams object change
-    const customUrl = searchParams?.get('customUrl');
-
-    useEffect(() => {
-        // Increment search ID to track this specific search
-        const currentSearchId = ++searchIdRef.current;
-
-        // NOTE: This ref-based approach prevents duplicate requests within a single component instance,
-        // but if multiple instances of UnknownAccountCard are rendered (e.g., as both a Suspense fallback
-        // and returned from CompressedNftCard), each instance will still make its own RPC requests.
-        // Consider moving the search logic to a parent component or using React Context to share state
-        // between instances if duplicate requests become a performance issue.
-
-        const clusters = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet].filter(c => c !== currentCluster);
-
-        const hasCustomUrlEnabled = Boolean(customUrl);
-
-        // add custom url if parameter is present
-        if (hasCustomUrlEnabled) {
-            clusters.push(Cluster.Custom);
-        }
-
-        const searchClusters = async () => {
-            // Check if this search is still the current one
-            if (searchIdRef.current !== currentSearchId) return;
-
-            setStatus('searching');
-
-            // search cluster one by one to not make extra requests
-            for (const cluster of clusters) {
-                // Check if this search has been superseded
-                if (searchIdRef.current !== currentSearchId) return;
-
-                setSearchingCluster(cluster);
-
-                try {
-                    let url = clusterUrl(cluster, '');
-
-                    // adjust url for a custom cluster as `clusterUrl` does not return one
-                    if (customUrl && cluster === Cluster.Custom) {
-                        url = customUrl;
-                    }
-
-                    const rpc = createSolanaRpc(url);
-                    const accountInfo = await rpc.getAccountInfo(createAddress(address), { encoding: 'base64' }).send();
-
-                    // Check again before updating state
-                    if (searchIdRef.current !== currentSearchId) return;
-
-                    if (accountInfo.value !== null) {
-                        setFoundCluster(cluster);
-                        setStatus('found');
-                        return;
-                    } else {
-                        // not only prevent span but allow component to react properly without making the structure complex
-                        await sleep();
-                    }
-                } catch (_error) {
-                    // Check if this search is still active before continuing
-                    if (searchIdRef.current !== currentSearchId) return;
-                    // Continue to next cluster
-                }
-            }
-
-            // Final check before updating not-found status
-            if (searchIdRef.current === currentSearchId) {
-                setStatus('not-found');
-                setSearchingCluster(null);
-            }
-        };
-
-        searchClusters();
-
-        // Cleanup function to mark this search as cancelled
-        return () => {
-            if (searchIdRef.current === currentSearchId) {
-                searchIdRef.current += 1;
-            }
-        };
-    }, [address, currentCluster, customUrl]);
-
-    return { foundCluster, searchingCluster, status };
-}
-
 const LABELS = {
     'not-found': 'Account does not exist',
 };
@@ -167,59 +69,37 @@ const LABELS = {
 function AccountNofFound({ account, labels = LABELS }: { account: Account; labels?: typeof LABELS }) {
     const { cluster } = useCluster();
     const address = account.pubkey.toBase58();
-    const { status, searchingCluster, foundCluster } = useClusterAccountSearch(address, cluster);
+    const { status, searchingCluster, foundCluster } = useClusterResourceSearch({
+        currentCluster: cluster,
+        probe: probeAccount,
+        resourceId: address,
+    });
 
-    if (status === 'searching' && searchingCluster !== null) {
+    if (status === 'searching' && searchingCluster !== undefined) {
         return (
             <span>
-                <SearchingAddressIndicator searchingCluster={searchingCluster} />
+                <SearchingClusterIndicator searchingCluster={searchingCluster} />
                 <span className="align-middle">{labels['not-found']}</span>
             </span>
         );
     }
 
-    const isAddressFoundOnAnotherClsuter = status === 'found' && foundCluster !== null;
-
-    return isAddressFoundOnAnotherClsuter ? (
-        <span>
-            <AdjacentAddressLink address={address} foundCluster={foundCluster} />
-            <span className="align-middle">{labels['not-found']}</span>
-        </span>
-    ) : (
-        <span>{labels['not-found']}</span>
-    );
-}
-
-function AdjacentAddressLink({ address, foundCluster }: { address: string; foundCluster: Cluster }) {
-    const moniker = clusterSlug(foundCluster);
-    const foundClusterPath = useClusterPath({
-        additionalParams: new URLSearchParams(`cluster=${moniker}`),
-        pathname: `/address/${address}`,
-    });
-
-    return (
-        <a href={foundClusterPath} className="align-middle text-dk-info" style={{ marginRight: '5px' }}>
-            Found on {clusterName(foundCluster)}
-        </a>
-    );
-}
-
-function SearchingAddressIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
-    const spinnerCls = 'spinner-grow spinner-grow-sm';
-
-    return (
-        <>
-            <span
-                style={{
-                    height: '10px',
-                    marginRight: '5px',
-                    width: '10px',
-                }}
-                className={`${spinnerCls} inline-block align-middle`}
-            />
-            <span className="align-middle text-dk-gray-700" style={{ marginRight: '10px', verticalAlign: 'middle' }}>
-                checking {clusterName(searchingCluster).toLowerCase()}
+    if (status === 'found' && foundCluster !== undefined) {
+        return (
+            <span>
+                <AdjacentClusterLink foundCluster={foundCluster} pathname={`/address/${address}`} />
+                <span className="align-middle">{labels['not-found']}</span>
             </span>
-        </>
-    );
+        );
+    }
+
+    return <span>{labels['not-found']}</span>;
+}
+
+async function probeAccount(url: string, address: string): Promise<boolean> {
+    const rpc = createSolanaRpc(url);
+    const { value } = await rpc.getAccountInfo(createAddress(address), { encoding: 'base64' }).send();
+
+    // RPC returns literal null when the account does not exist on that cluster
+    return value !== null;
 }

--- a/app/entities/cluster/index.ts
+++ b/app/entities/cluster/index.ts
@@ -5,5 +5,13 @@ export { customUrlEnabledAtom, rememberedCustomUrlAtom } from './model/cluster-s
 export { useCluster, useUpdateCustomUrl } from './model/use-cluster';
 export { useClusterInfo } from './model/use-cluster-info';
 export { clusterModalOpenAtom, useClusterModal } from './model/use-cluster-modal';
+export {
+    type ClusterResourceProbe,
+    type ClusterResourceSearch,
+    type ClusterSearchStatus,
+    useClusterResourceSearch,
+} from './model/use-cluster-resource-search';
 export { buildExplorerLink, useExplorerLink } from './model/use-explorer-link';
+export { AdjacentClusterLink } from './ui/AdjacentClusterLink';
 export { ExplorerLink } from './ui/ExplorerLink';
+export { SearchingClusterIndicator } from './ui/SearchingClusterIndicator';

--- a/app/entities/cluster/model/__tests__/use-cluster-resource-search.spec.ts
+++ b/app/entities/cluster/model/__tests__/use-cluster-resource-search.spec.ts
@@ -106,4 +106,22 @@ describe('useClusterResourceSearch', () => {
         // First probe (Devnet) rejects, second probe (Testnet) resolves as found
         expect(result.current.foundCluster).toBe(Cluster.Testnet);
     });
+
+    it('should report not-found when every cluster probe throws', async () => {
+        const probe = vi.fn().mockRejectedValue(new Error('RPC unreachable'));
+
+        const { result } = renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        await waitFor(() => expect(result.current.status).toBe('not-found'));
+        expect(result.current.foundCluster).toBeUndefined();
+        expect(result.current.searchingCluster).toBeUndefined();
+        // Every non-current public cluster was attempted before falling through to not-found
+        expect(probe).toHaveBeenCalledTimes(2);
+    });
 });

--- a/app/entities/cluster/model/__tests__/use-cluster-resource-search.spec.ts
+++ b/app/entities/cluster/model/__tests__/use-cluster-resource-search.spec.ts
@@ -1,0 +1,109 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useSearchParams } from 'next/navigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Cluster } from '@/app/utils/cluster';
+
+import { useClusterResourceSearch } from '../use-cluster-resource-search';
+
+const RESOURCE_ID = 'test-resource-id';
+
+vi.mock('next/navigation', () => ({
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+describe('useClusterResourceSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.clearAllMocks();
+        vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as ReturnType<typeof useSearchParams>);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should start in the searching state on the first non-current cluster', async () => {
+        // Keep the probe pending so the hook stays in "searching"
+        const probe = vi.fn(() => new Promise<boolean>(() => {}));
+
+        const { result } = renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await waitFor(() => expect(result.current.status).toBe('searching'));
+        expect(result.current.searchingCluster).toBe(Cluster.Devnet);
+    });
+
+    it('should report the cluster where the resource is found', async () => {
+        const probe = vi.fn().mockResolvedValueOnce(true);
+
+        const { result } = renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.Devnet, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await waitFor(() => expect(result.current.status).toBe('found'));
+        // Devnet is the current cluster and excluded, so MainnetBeta is probed first
+        expect(result.current.foundCluster).toBe(Cluster.MainnetBeta);
+    });
+
+    it('should report not-found after probing every public cluster', async () => {
+        const probe = vi.fn().mockResolvedValue(false);
+
+        const { result } = renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        await waitFor(() => expect(result.current.status).toBe('not-found'));
+        expect(result.current.foundCluster).toBeUndefined();
+        expect(result.current.searchingCluster).toBeUndefined();
+    });
+
+    it('should exclude the current cluster from the probe list', async () => {
+        const probe = vi.fn().mockResolvedValue(false);
+
+        renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        // MainnetBeta is current, so only Devnet + Testnet are probed
+        expect(probe).toHaveBeenCalledTimes(2);
+    });
+
+    it('should probe the custom RPC URL with the resource id when customUrl is present', async () => {
+        vi.mocked(useSearchParams).mockReturnValue(
+            new URLSearchParams('customUrl=https://my.custom.rpc') as ReturnType<typeof useSearchParams>,
+        );
+        const probe = vi.fn().mockResolvedValue(false);
+
+        renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(probe).toHaveBeenCalledWith('https://my.custom.rpc', RESOURCE_ID);
+    });
+
+    it('should continue probing when a cluster probe throws', async () => {
+        const probe = vi.fn().mockRejectedValueOnce(new Error('RPC unreachable')).mockResolvedValueOnce(true);
+
+        const { result } = renderHook(() =>
+            useClusterResourceSearch({ currentCluster: Cluster.MainnetBeta, probe, resourceId: RESOURCE_ID }),
+        );
+
+        await waitFor(() => expect(result.current.status).toBe('found'));
+        // First probe (Devnet) rejects, second probe (Testnet) resolves as found
+        expect(result.current.foundCluster).toBe(Cluster.Testnet);
+    });
+});

--- a/app/entities/cluster/model/use-cluster-resource-search.ts
+++ b/app/entities/cluster/model/use-cluster-resource-search.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import { Cluster, clusterUrl } from '@utils/cluster';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+export type ClusterSearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
+
+export interface ClusterResourceSearch {
+    status: ClusterSearchStatus;
+    searchingCluster: Cluster | undefined;
+    foundCluster: Cluster | undefined;
+}
+
+/**
+ * Probes a single cluster (reachable at `url`) for `resourceId`, resolving to whether it exists
+ * there. Implementations differ only in the RPC call — e.g. getAccountInfo vs getSignatureStatuses.
+ */
+export type ClusterResourceProbe = (url: string, resourceId: string) => Promise<boolean>;
+
+// Canonical, durable public clusters. Cluster.Simd296 is a temporary surfnet, so matches there
+// aren't linkable later; Cluster.Custom is appended only when a custom RPC URL is configured.
+const PUBLIC_CLUSTERS = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet];
+const PROBE_DELAY_MS = 700;
+
+/**
+ * Sequentially probes the other public clusters (and an optional custom RPC) for a resource that
+ * was not found on the current cluster, reporting which cluster is being checked and where it was
+ * found. Shared by the transaction and account "not found" cards; callers inject the `probe`.
+ */
+export function useClusterResourceSearch({
+    resourceId,
+    currentCluster,
+    probe,
+}: {
+    resourceId: string;
+    currentCluster: Cluster;
+    probe: ClusterResourceProbe;
+}): ClusterResourceSearch {
+    const searchParams = useSearchParams();
+    const customUrl = searchParams?.get('customUrl');
+
+    const [status, setStatus] = useState<ClusterSearchStatus>('idle');
+    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
+    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
+
+    // Monotonic id used to cancel a search whose inputs changed before it finished.
+    const searchIdRef = useRef(0);
+    // Track the latest probe without making it an effect dependency, so callers can pass an inline
+    // function without restarting the search on every render.
+    const probeRef = useRef(probe);
+    probeRef.current = probe;
+
+    useEffect(() => {
+        const searchId = ++searchIdRef.current;
+        const isStale = () => searchIdRef.current !== searchId;
+        const clusters = getClustersToProbe(currentCluster, customUrl);
+
+        async function searchClusters() {
+            setStatus('searching');
+            setFoundCluster(undefined);
+
+            for (const [index, cluster] of clusters.entries()) {
+                if (isStale()) return;
+                setSearchingCluster(cluster);
+
+                let found: boolean;
+                try {
+                    found = await probeRef.current(resolveClusterUrl(cluster, customUrl), resourceId);
+                } catch {
+                    // Ignore probe errors (unreachable RPC, etc.) and try the next cluster
+                    continue;
+                }
+
+                if (isStale()) return;
+
+                if (found) {
+                    setFoundCluster(cluster);
+                    setStatus('found');
+                    return;
+                }
+
+                // Only pace between checks; skip the trailing delay so not-found shows immediately
+                const isLastCluster = index === clusters.length - 1;
+                if (!isLastCluster) await sleep(PROBE_DELAY_MS);
+            }
+
+            if (isStale()) return;
+            setStatus('not-found');
+            setSearchingCluster(undefined);
+        }
+
+        searchClusters();
+
+        return () => {
+            // Invalidate this run so an in-flight probe cannot commit stale state after cleanup.
+            if (!isStale()) searchIdRef.current += 1;
+        };
+    }, [resourceId, currentCluster, customUrl]);
+
+    return { foundCluster, searchingCluster, status };
+}
+
+function getClustersToProbe(currentCluster: Cluster, customUrl: string | null | undefined): Cluster[] {
+    const clusters = PUBLIC_CLUSTERS.filter(cluster => cluster !== currentCluster);
+    if (customUrl) {
+        clusters.push(Cluster.Custom);
+    }
+    return clusters;
+}
+
+function resolveClusterUrl(cluster: Cluster, customUrl: string | null | undefined): string {
+    // clusterUrl has no entry for a custom RPC, so resolve the custom URL explicitly.
+    if (customUrl && cluster === Cluster.Custom) {
+        return customUrl;
+    }
+    return clusterUrl(cluster, '');
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/app/entities/cluster/model/use-cluster-resource-search.ts
+++ b/app/entities/cluster/model/use-cluster-resource-search.ts
@@ -57,7 +57,10 @@ export function useClusterResourceSearch({
         const clusters = getClustersToProbe(currentCluster, customUrl);
 
         async function searchClusters() {
+            // Reset every output up front so a re-fired search never surfaces stale state, instead
+            // of relying on React batching the synchronous setSearchingCluster below into the same flush.
             setStatus('searching');
+            setSearchingCluster(undefined);
             setFoundCluster(undefined);
 
             for (const [index, cluster] of clusters.entries()) {

--- a/app/entities/cluster/model/use-cluster-resource-search.ts
+++ b/app/entities/cluster/model/use-cluster-resource-search.ts
@@ -69,7 +69,7 @@ export function useClusterResourceSearch({
 
                 let found: boolean;
                 try {
-                    found = await probeRef.current(resolveClusterUrl(cluster, customUrl), resourceId);
+                    found = await probeRef.current(clusterUrl(cluster, customUrl ?? ''), resourceId);
                 } catch {
                     // Ignore probe errors (unreachable RPC, etc.) and try the next cluster
                     continue;
@@ -110,14 +110,6 @@ function getClustersToProbe(currentCluster: Cluster, customUrl: string | null | 
         clusters.push(Cluster.Custom);
     }
     return clusters;
-}
-
-function resolveClusterUrl(cluster: Cluster, customUrl: string | null | undefined): string {
-    // clusterUrl has no entry for a custom RPC, so resolve the custom URL explicitly.
-    if (customUrl && cluster === Cluster.Custom) {
-        return customUrl;
-    }
-    return clusterUrl(cluster, '');
 }
 
 function sleep(ms: number): Promise<void> {

--- a/app/entities/cluster/ui/AdjacentClusterLink.tsx
+++ b/app/entities/cluster/ui/AdjacentClusterLink.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Cluster, clusterName, clusterSlug } from '@utils/cluster';
+import { useClusterPath } from '@utils/url';
+
+/**
+ * "Found on <cluster>" link to the same resource on the cluster where it was located.
+ * `pathname` is the resource path on that cluster, e.g. `/tx/<signature>` or `/address/<address>`.
+ */
+export function AdjacentClusterLink({ foundCluster, pathname }: { foundCluster: Cluster; pathname: string }) {
+    const moniker = clusterSlug(foundCluster);
+    const foundClusterPath = useClusterPath({
+        additionalParams: new URLSearchParams(`cluster=${moniker}`),
+        pathname,
+    });
+
+    return (
+        <a href={foundClusterPath} className="align-middle text-dk-info" style={{ marginRight: '5px' }}>
+            Found on {clusterName(foundCluster)}
+        </a>
+    );
+}

--- a/app/entities/cluster/ui/SearchingClusterIndicator.tsx
+++ b/app/entities/cluster/ui/SearchingClusterIndicator.tsx
@@ -1,0 +1,18 @@
+import { Cluster, clusterName } from '@utils/cluster';
+
+/** Spinner + "checking <cluster>" shown while probing other clusters for a missing resource. */
+export function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
+    const spinnerCls = 'spinner-grow spinner-grow-sm';
+
+    return (
+        <>
+            <span
+                style={{ height: '10px', marginRight: '5px', width: '10px' }}
+                className={`${spinnerCls} inline-block align-middle`}
+            />
+            <span className="align-middle text-dk-gray-700" style={{ marginRight: '10px', verticalAlign: 'middle' }}>
+                checking {clusterName(searchingCluster).toLowerCase()}
+            </span>
+        </>
+    );
+}

--- a/app/entities/cluster/ui/SearchingClusterIndicator.tsx
+++ b/app/entities/cluster/ui/SearchingClusterIndicator.tsx
@@ -1,14 +1,13 @@
+import { cn } from '@components/shared/utils';
 import { Cluster, clusterName } from '@utils/cluster';
 
 /** Spinner + "checking <cluster>" shown while probing other clusters for a missing resource. */
 export function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
-    const spinnerCls = 'spinner-grow spinner-grow-sm';
-
     return (
         <>
             <span
                 style={{ height: '10px', marginRight: '5px', width: '10px' }}
-                className={`${spinnerCls} inline-block align-middle`}
+                className={cn('spinner-grow spinner-grow-sm', 'inline-block align-middle')}
             />
             <span className="align-middle text-dk-gray-700" style={{ marginRight: '10px', verticalAlign: 'middle' }}>
                 checking {clusterName(searchingCluster).toLowerCase()}

--- a/app/features/transaction/model/use-cluster-transaction-search.ts
+++ b/app/features/transaction/model/use-cluster-transaction-search.ts
@@ -1,102 +1,18 @@
 'use client';
 
+import { type ClusterResourceSearch, useClusterResourceSearch } from '@entities/cluster';
 import { createSolanaRpc, signature as createSignature } from '@solana/kit';
-import { Cluster, clusterUrl } from '@utils/cluster';
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
-
-export type SearchStatus = 'idle' | 'searching' | 'found' | 'not-found';
-
-export interface ClusterTransactionSearch {
-    status: SearchStatus;
-    searchingCluster: Cluster | undefined;
-    foundCluster: Cluster | undefined;
-}
-
-// Canonical, durable public clusters. Cluster.Simd296 is a temporary surfnet, so matches there
-// aren't linkable later; Cluster.Custom is appended only when a custom RPC URL is configured.
-const PUBLIC_CLUSTERS = [Cluster.MainnetBeta, Cluster.Devnet, Cluster.Testnet];
-const PROBE_DELAY_MS = 700;
+import { Cluster } from '@utils/cluster';
 
 /**
- * Probes the other public clusters (and an optional custom RPC) for a signature that was not
- * found on the current cluster, reporting which cluster is being checked and where it was found.
+ * Probes the other public clusters (and an optional custom RPC) for a signature that was not found
+ * on the current cluster. Thin wrapper over the shared {@link useClusterResourceSearch}.
  */
-export function useClusterTransactionSearch(signature: string, currentCluster: Cluster): ClusterTransactionSearch {
-    const searchParams = useSearchParams();
-    const customUrl = searchParams?.get('customUrl');
-
-    const [status, setStatus] = useState<SearchStatus>('idle');
-    const [searchingCluster, setSearchingCluster] = useState<Cluster | undefined>(undefined);
-    const [foundCluster, setFoundCluster] = useState<Cluster | undefined>(undefined);
-
-    // Monotonic id used to cancel a search whose inputs changed before it finished.
-    const searchIdRef = useRef(0);
-
-    useEffect(() => {
-        const searchId = ++searchIdRef.current;
-        const isStale = () => searchIdRef.current !== searchId;
-        const clusters = getClustersToProbe(currentCluster, customUrl);
-
-        async function searchClusters() {
-            setStatus('searching');
-            setFoundCluster(undefined);
-
-            for (const [index, cluster] of clusters.entries()) {
-                if (isStale()) return;
-                setSearchingCluster(cluster);
-
-                let found: boolean;
-                try {
-                    found = await probeClusterForSignature(signature, cluster, customUrl);
-                } catch {
-                    // Ignore probe errors (unreachable RPC, etc.) and try the next cluster
-                    continue;
-                }
-
-                if (isStale()) return;
-
-                if (found) {
-                    setFoundCluster(cluster);
-                    setStatus('found');
-                    return;
-                }
-
-                // Only pace between checks; skip the trailing delay so not-found shows immediately
-                const isLastCluster = index === clusters.length - 1;
-                if (!isLastCluster) await sleep(PROBE_DELAY_MS);
-            }
-
-            if (isStale()) return;
-            setStatus('not-found');
-            setSearchingCluster(undefined);
-        }
-
-        searchClusters();
-
-        return () => {
-            // Invalidate this run so an in-flight probe cannot commit stale state after cleanup.
-            if (!isStale()) searchIdRef.current += 1;
-        };
-    }, [signature, currentCluster, customUrl]);
-
-    return { foundCluster, searchingCluster, status };
+export function useClusterTransactionSearch(signature: string, currentCluster: Cluster): ClusterResourceSearch {
+    return useClusterResourceSearch({ currentCluster, probe: probeSignature, resourceId: signature });
 }
 
-function getClustersToProbe(currentCluster: Cluster, customUrl: string | null | undefined): Cluster[] {
-    const clusters = PUBLIC_CLUSTERS.filter(cluster => cluster !== currentCluster);
-    if (customUrl) {
-        clusters.push(Cluster.Custom);
-    }
-    return clusters;
-}
-
-async function probeClusterForSignature(
-    signature: string,
-    cluster: Cluster,
-    customUrl: string | null | undefined,
-): Promise<boolean> {
-    const url = customUrl && cluster === Cluster.Custom ? customUrl : clusterUrl(cluster, '');
+async function probeSignature(url: string, signature: string): Promise<boolean> {
     const rpc = createSolanaRpc(url);
     const { value } = await rpc
         .getSignatureStatuses([createSignature(signature)], { searchTransactionHistory: true })
@@ -104,8 +20,4 @@ async function probeClusterForSignature(
 
     // RPC returns literal null for missing signatures per JSON-RPC spec
     return value[0] !== null;
-}
-
-function sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/app/features/transaction/ui/TransactionNotFoundCard.tsx
+++ b/app/features/transaction/ui/TransactionNotFoundCard.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import { AdjacentClusterLink, SearchingClusterIndicator } from '@entities/cluster';
 import { useCluster } from '@providers/cluster';
-import { Cluster, clusterName, clusterSlug } from '@utils/cluster';
-import { useClusterPath } from '@utils/url';
 import React from 'react';
 
 import { useClusterTransactionSearch } from '../model/use-cluster-transaction-search';
@@ -34,7 +33,7 @@ export function TransactionNotFoundCard({
             <span>
                 <span className="align-middle">Transaction does not exist</span>
                 <br />
-                <AdjacentTransactionLink signature={signature} foundCluster={foundCluster} />
+                <AdjacentClusterLink foundCluster={foundCluster} pathname={`/tx/${signature}`} />
             </span>
         );
     } else if (status === 'not-found' && firstAvailableBlock !== undefined && firstAvailableBlock > 0n) {
@@ -42,34 +41,4 @@ export function TransactionNotFoundCard({
     }
 
     return <BaseTransactionNotFoundCard retry={retry} subtext={subtext} />;
-}
-
-function AdjacentTransactionLink({ signature, foundCluster }: { signature: string; foundCluster: Cluster }) {
-    const moniker = clusterSlug(foundCluster);
-    const foundClusterPath = useClusterPath({
-        additionalParams: new URLSearchParams(`cluster=${moniker}`),
-        pathname: `/tx/${signature}`,
-    });
-
-    return (
-        <a href={foundClusterPath} className="align-middle text-dk-info" style={{ marginRight: '5px' }}>
-            Found on {clusterName(foundCluster)}
-        </a>
-    );
-}
-
-function SearchingClusterIndicator({ searchingCluster }: { searchingCluster: Cluster }) {
-    const spinnerCls = 'spinner-grow spinner-grow-sm';
-
-    return (
-        <>
-            <span
-                style={{ height: '10px', marginRight: '5px', width: '10px' }}
-                className={`${spinnerCls} inline-block align-middle`}
-            />
-            <span className="align-middle text-dk-gray-700" style={{ marginRight: '10px', verticalAlign: 'middle' }}>
-                checking {clusterName(searchingCluster).toLowerCase()}
-            </span>
-        </>
-    );
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -559,7 +559,6 @@ export default tseslint.config(
             'app/components/account/TokenAccountSection.tsx',
             'app/components/account/TokenExtensionsSection.tsx',
             'app/components/account/TokenHistoryCard.tsx',
-            'app/components/account/UnknownAccountCard.tsx',
             'app/components/account/UpgradeableLoaderAccountSection.tsx',
             'app/components/account/VerifiedBuildCard.tsx',
             'app/components/account/history/TokenInstructionsCard.tsx',


### PR DESCRIPTION
## Description

Extracts the near-identical cross-cluster "search on other clusters" logic that was duplicated between the transaction and account **not found** cards into a shared hook and shared UI components, as suggested in review of [#1089](https://github.com/solana-foundation/explorer/pull/1089#discussion_r3441716003).

Previously `useClusterTransactionSearch` / `SearchingClusterIndicator` / `AdjacentTransactionLink` (transaction) and the inline `useClusterAccountSearch` / `SearchingAddressIndicator` / `AdjacentAddressLink` (account) were copies that differed only in:
- the probe RPC — `getSignatureStatuses` vs `getAccountInfo`
- the resource link path — `/tx/<signature>` vs `/address/<address>`

This PR introduces, in the `cluster` entity:

- **`useClusterResourceSearch({ resourceId, currentCluster, probe })`** — owns the cluster list, 700 ms pacing, `searchIdRef` cancellation and custom-URL handling; callers inject only the `probe`.
- **`SearchingClusterIndicator`** and **`AdjacentClusterLink`** — the shared spinner and "Found on &lt;cluster&gt;" link.

Both cards now consume the shared code:

- `useClusterTransactionSearch` becomes a wrapper that injects a `getSignatureStatuses` probe.
- `UnknownAccountCard` drops its ~90-line inline hook and local components, injecting a `getAccountInfo` probe.

Behavior is preserved, the account card also gains the small fix of not waiting an extra 700 ms before showing "not found".

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): **Refactor / code deduplication (no behavior change)**

## Screenshots

No visual change — the rendered output of both cards is identical.

## Testing

- New `useClusterResourceSearch` unit tests (searching / found / not-found / current-cluster exclusion / custom-URL probing / error-continue).
- Existing `useClusterTransactionSearch` and `TransactionNotFoundCard` tests pass unchanged (the wrapper preserves the public API).
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, and the full `pnpm test` suite pass locally.

## Related Issues

Addresses review feedback on [#1089](https://github.com/solana-foundation/explorer/pull/1089#discussion_r3441716003)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information

## Additional Notes

- Shared code lives in `app/entities/cluster` (`model/use-cluster-resource-search.ts`, `ui/SearchingClusterIndicator.tsx`, `ui/AdjacentClusterLink.tsx`), exported from the entity barrel
- Cleanup: `UnknownAccountCard.tsx` is removed from the `unicorn/no-null` exemption list in `eslint.config.mjs`, since the refactor eliminates its flagged `null` usages (it now lints clean under the rule)
