### PR TITLE
feat(MCP): add mcp endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,18 @@ RUGCHECK_API_KEY=
 ### Configuration for CoinGecko API
 COINGECKO_API_KEY=
 
+## Configuration for "/mcp" endpoint (MCP server). Set "**_ENABLED=true" to enable
+MCP_ENDPOINT_ENABLED=false
+### Comma-separated bearer keys gating /mcp; unset means open access (a warning is logged on startup)
+MCP_ACCESS_KEYS=
+### Comma-separated exact client IPs rejected with 403
+MCP_BLOCKED_IPS=
+### RPC endpoints used exclusively by /mcp (separate quota from the app RPC); public endpoints used when unset
+MCP_SOLANA_RPC_URL_MAINNET_BETA=
+MCP_SOLANA_RPC_URL_DEVNET=
+MCP_SOLANA_RPC_URL_TESTNET=
+MCP_SOLANA_RPC_URL_SIMD296=
+
 ## Configuration for Sentry feature enabled
 ### Sentry is disabled by default. To enable error reporting, set SENTRY_DSN to
 ### your project's DSN (found in Sentry under Settings > Projects > Client Keys).

--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,6 @@ SEARCH_JUPITER_API_KEY=
 RUGCHECK_API_KEY=
 ### Configuration for CoinGecko API
 COINGECKO_API_KEY=
-
 ## Configuration for "/mcp" endpoint (MCP server). Set "**_ENABLED=true" to enable
 MCP_ENDPOINT_ENABLED=false
 ### Comma-separated bearer keys gating /mcp; unset means open access (a warning is logged on startup)
@@ -67,7 +66,6 @@ MCP_SOLANA_RPC_URL_MAINNET_BETA=
 MCP_SOLANA_RPC_URL_DEVNET=
 MCP_SOLANA_RPC_URL_TESTNET=
 MCP_SOLANA_RPC_URL_SIMD296=
-
 ## Configuration for Sentry feature enabled
 ### Sentry is disabled by default. To enable error reporting, set SENTRY_DSN to
 ### your project's DSN (found in Sentry under Settings > Projects > Client Keys).

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ cache/
 coverage/
 node_modules/
 dist/
+packages/entity-inspector/
 build/
 .pnpm-store/
 .claude/

--- a/app/mcp/__tests__/route.open-access.spec.ts
+++ b/app/mcp/__tests__/route.open-access.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import { POST } from '../route';
+
+vi.hoisted(() => {
+    delete process.env.MCP_ACCESS_KEYS;
+    delete process.env.MCP_BLOCKED_IPS;
+    process.env.MCP_ENDPOINT_ENABLED = 'true';
+});
+
+const { handlerMock } = vi.hoisted(() => ({ handlerMock: vi.fn() }));
+
+vi.mock('../dependencies', () => ({
+    getMcpRequestHandler: async () => handlerMock,
+}));
+
+describe('POST /mcp — MCP_ACCESS_KEYS unset (open access)', () => {
+    beforeEach(() => {
+        // No clearAllMocks here — it would erase the module-scope Logger.warn recorded at import time.
+        handlerMock.mockReset();
+        handlerMock.mockResolvedValue(new Response('{"ok":true}', { status: 200 }));
+    });
+
+    it('should log a startup warning that authentication is disabled', () => {
+        expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith(
+            '[mcp] MCP_ACCESS_KEYS is unset — /mcp is enabled without authentication',
+        );
+    });
+
+    it('should serve requests without an Authorization header', async () => {
+        const request = new Request('http://localhost:3000/mcp', {
+            body: '{}',
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
+        expect(handlerMock).toHaveBeenCalledWith(request);
+    });
+});

--- a/app/mcp/__tests__/route.spec.ts
+++ b/app/mcp/__tests__/route.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import { OPTIONS, POST } from '../route';
+
+vi.hoisted(() => {
+    process.env.MCP_ACCESS_KEYS = 'test-key, spare-key';
+    process.env.MCP_BLOCKED_IPS = '203.0.113.7';
+    process.env.MCP_ENDPOINT_ENABLED = 'true';
+});
+
+const { handlerMock } = vi.hoisted(() => ({ handlerMock: vi.fn() }));
+
+vi.mock('../dependencies', () => ({
+    getMcpRequestHandler: async () => handlerMock,
+}));
+
+function makeRequest(init?: { authorization?: string; ip?: string }) {
+    const headers = new Headers({ 'content-type': 'application/json' });
+    if (init?.authorization) headers.set('authorization', init.authorization);
+    if (init?.ip) headers.set('x-forwarded-for', init.ip);
+    return new Request('http://localhost:3000/mcp', { body: '{}', headers, method: 'POST' });
+}
+
+describe('POST /mcp', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        handlerMock.mockResolvedValue(
+            new Response('{"ok":true}', { headers: { 'mcp-session-id': 'session-1' }, status: 200 }),
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('should return 403 for a blacklisted IP without invoking the MCP handler', async () => {
+        const response = await POST(makeRequest({ authorization: 'Bearer test-key', ip: '203.0.113.7, 10.0.0.1' }));
+
+        expect(response.status).toBe(403);
+        expect(handlerMock).not.toHaveBeenCalled();
+        expect(vi.mocked(Logger.warn)).toHaveBeenCalledWith('[mcp] rejected request from blocked ip', {
+            clientIp: '203.0.113.7',
+        });
+    });
+
+    it('should return 503 with a disabled message when the endpoint flag is off', async () => {
+        vi.stubEnv('MCP_ENDPOINT_ENABLED', 'false');
+
+        const response = await POST(makeRequest({ authorization: 'Bearer test-key' }));
+
+        expect(response.status).toBe(503);
+        expect(handlerMock).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ error: 'MCP endpoint is disabled' });
+    });
+
+    it('should return 401 when the Authorization header is missing', async () => {
+        const response = await POST(makeRequest());
+
+        expect(response.status).toBe(401);
+        expect(handlerMock).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    });
+
+    it('should return 401 for a key outside the allow-list', async () => {
+        const response = await POST(makeRequest({ authorization: 'Bearer wrong-key' }));
+
+        expect(response.status).toBe(401);
+        expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    it('should delegate to the MCP handler and append CORS headers for a valid key', async () => {
+        const request = makeRequest({ authorization: 'Bearer spare-key' });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
+        expect(handlerMock).toHaveBeenCalledWith(request);
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+        expect(response.headers.get('mcp-session-id')).toBe('session-1');
+        await expect(response.json()).resolves.toEqual({ ok: true });
+    });
+});
+
+describe('OPTIONS /mcp', () => {
+    it('should return 204 with CORS headers', () => {
+        const response = OPTIONS();
+
+        expect(response.status).toBe(204);
+        expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+});

--- a/app/mcp/__tests__/route.spec.ts
+++ b/app/mcp/__tests__/route.spec.ts
@@ -55,19 +55,48 @@ describe('POST /mcp', () => {
         await expect(response.json()).resolves.toEqual({ error: 'MCP endpoint is disabled' });
     });
 
-    it('should return 401 when the Authorization header is missing', async () => {
+    it('should return 403 for a blacklisted IP even when the endpoint is disabled', async () => {
+        vi.stubEnv('MCP_ENDPOINT_ENABLED', 'false');
+
+        const response = await POST(makeRequest({ authorization: 'Bearer test-key', ip: '203.0.113.7' }));
+
+        expect(response.status).toBe(403);
+        expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 with CORS headers when the Authorization header is missing', async () => {
         const response = await POST(makeRequest());
 
         expect(response.status).toBe(401);
         expect(handlerMock).not.toHaveBeenCalled();
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
         await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
     });
 
-    it('should return 401 for a key outside the allow-list', async () => {
-        const response = await POST(makeRequest({ authorization: 'Bearer wrong-key' }));
+    it('should return 401 for a non-Bearer Authorization scheme', async () => {
+        const response = await POST(makeRequest({ authorization: 'Basic dGVzdC1rZXk=' }));
 
         expect(response.status).toBe(401);
         expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for a same-length key that is not in the allow-list', async () => {
+        // spore-key matches spare-key's length, forcing the timingSafeEqual (not the length short-circuit) path.
+        const response = await POST(makeRequest({ authorization: 'Bearer spore-key' }));
+
+        expect(response.status).toBe(401);
+        expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 with CORS when the MCP handler throws', async () => {
+        handlerMock.mockRejectedValue(new Error('handler boom'));
+
+        const response = await POST(makeRequest({ authorization: 'Bearer test-key' }));
+
+        expect(response.status).toBe(500);
+        expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+        expect(vi.mocked(Logger.error)).toHaveBeenCalledWith(expect.any(Error), { sentry: true });
+        await expect(response.json()).resolves.toEqual({ error: 'Internal error' });
     });
 
     it('should delegate to the MCP handler and append CORS headers for a valid key', async () => {

--- a/app/mcp/dependencies.ts
+++ b/app/mcp/dependencies.ts
@@ -3,20 +3,24 @@ import { clusterApiUrl } from '@solana/web3.js';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-// Dedicated MCP RPC endpoints — separate quota/provider from the app's RPC; public endpoints as fallback.
-const rpcEndpoints: EntityInspectorConfig['rpcEndpoints'] = {
-    devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || clusterApiUrl('devnet'),
-    'mainnet-beta': process.env.MCP_SOLANA_RPC_URL_MAINNET_BETA || clusterApiUrl('mainnet-beta'),
-    // simd296 is not a web3.js cluster, so its public endpoint stays a literal
-    simd296: process.env.MCP_SOLANA_RPC_URL_SIMD296 || 'https://simd-0296.surfnet.dev:8899',
-    testnet: process.env.MCP_SOLANA_RPC_URL_TESTNET || clusterApiUrl('testnet'),
-};
-
 const logger: EntityInspectorConfig['logger'] = {
     debug: (message, context) => Logger.debug(message, context),
     info: (message, context) => Logger.info(message, context),
     warn: (message, context) => Logger.warn(message, context),
 };
+
+// Dedicated MCP RPC endpoints — separate quota/provider from the app's RPC; public endpoints as fallback.
+// Resolved at request time (not module scope) so the key-bearing URLs are read from the Vercel runtime
+// env and never baked into a build artifact.
+function resolveRpcEndpoints(): EntityInspectorConfig['rpcEndpoints'] {
+    return {
+        devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || clusterApiUrl('devnet'),
+        'mainnet-beta': process.env.MCP_SOLANA_RPC_URL_MAINNET_BETA || clusterApiUrl('mainnet-beta'),
+        // simd296 is not a web3.js cluster, so its public endpoint stays a literal
+        simd296: process.env.MCP_SOLANA_RPC_URL_SIMD296 || 'https://simd-0296.surfnet.dev:8899',
+        testnet: process.env.MCP_SOLANA_RPC_URL_TESTNET || clusterApiUrl('testnet'),
+    };
+}
 
 let handlerPromise: Promise<McpRequestHandler> | undefined;
 
@@ -28,5 +32,5 @@ export function getMcpRequestHandler(): Promise<McpRequestHandler> {
 
 async function importRequestHandler(): Promise<McpRequestHandler> {
     const { createMcpRequestHandler } = await import('@explorer/entity-inspector');
-    return createMcpRequestHandler({ logger, rpcEndpoints });
+    return createMcpRequestHandler({ logger, rpcEndpoints: resolveRpcEndpoints() });
 }

--- a/app/mcp/dependencies.ts
+++ b/app/mcp/dependencies.ts
@@ -5,13 +5,12 @@ import { Logger } from '@/app/shared/lib/logger';
 
 const logger: EntityInspectorConfig['logger'] = {
     debug: (message, context) => Logger.debug(message, context),
+    error: (message, context) => Logger.error(message, context),
     info: (message, context) => Logger.info(message, context),
     warn: (message, context) => Logger.warn(message, context),
 };
 
-// Dedicated MCP RPC endpoints — separate quota/provider from the app's RPC; public endpoints as fallback.
-// Resolved at request time (not module scope) so the key-bearing URLs are read from the Vercel runtime
-// env and never baked into a build artifact.
+// Resolved per-request (not at module scope) so key-bearing URLs come from runtime env, never a build artifact.
 function resolveRpcEndpoints(): EntityInspectorConfig['rpcEndpoints'] {
     return {
         devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || clusterApiUrl('devnet'),
@@ -24,9 +23,15 @@ function resolveRpcEndpoints(): EntityInspectorConfig['rpcEndpoints'] {
 
 let handlerPromise: Promise<McpRequestHandler> | undefined;
 
-/** Imports the MCP package lazily so a disabled endpoint never loads it. */
+/** Lazy so a disabled endpoint never loads the MCP package. */
 export function getMcpRequestHandler(): Promise<McpRequestHandler> {
-    handlerPromise = handlerPromise ?? importRequestHandler();
+    if (!handlerPromise) {
+        handlerPromise = importRequestHandler().catch(error => {
+            // Clear the cache on failure so a transient import error isn't stuck until redeploy.
+            handlerPromise = undefined;
+            throw error;
+        });
+    }
     return handlerPromise;
 }
 

--- a/app/mcp/dependencies.ts
+++ b/app/mcp/dependencies.ts
@@ -5,12 +5,13 @@ import { Logger } from '@/app/shared/lib/logger';
 
 const logger: EntityInspectorConfig['logger'] = {
     debug: (message, context) => Logger.debug(message, context),
-    error: (message, context) => Logger.error(message, context),
+    // Wrap in Error: Logger.error replaces a bare string with a sentinel, losing the message in Sentry.
+    error: (message, context) => Logger.error(new Error(message), context),
     info: (message, context) => Logger.info(message, context),
     warn: (message, context) => Logger.warn(message, context),
 };
 
-// Resolved per-request (not at module scope) so key-bearing URLs come from runtime env, never a build artifact.
+// Resolved at handler init (cold start), not module scope, so key-bearing URLs come from runtime env, never a build artifact.
 function resolveRpcEndpoints(): EntityInspectorConfig['rpcEndpoints'] {
     return {
         devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || clusterApiUrl('devnet'),

--- a/app/mcp/dependencies.ts
+++ b/app/mcp/dependencies.ts
@@ -1,0 +1,32 @@
+import type { EntityInspectorConfig, McpRequestHandler } from '@explorer/entity-inspector';
+import { clusterApiUrl } from '@solana/web3.js';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+// Dedicated MCP RPC endpoints — separate quota/provider from the app's RPC; public endpoints as fallback.
+const rpcEndpoints: EntityInspectorConfig['rpcEndpoints'] = {
+    devnet: process.env.MCP_SOLANA_RPC_URL_DEVNET || clusterApiUrl('devnet'),
+    'mainnet-beta': process.env.MCP_SOLANA_RPC_URL_MAINNET_BETA || clusterApiUrl('mainnet-beta'),
+    // simd296 is not a web3.js cluster, so its public endpoint stays a literal
+    simd296: process.env.MCP_SOLANA_RPC_URL_SIMD296 || 'https://simd-0296.surfnet.dev:8899',
+    testnet: process.env.MCP_SOLANA_RPC_URL_TESTNET || clusterApiUrl('testnet'),
+};
+
+const logger: EntityInspectorConfig['logger'] = {
+    debug: (message, context) => Logger.debug(message, context),
+    info: (message, context) => Logger.info(message, context),
+    warn: (message, context) => Logger.warn(message, context),
+};
+
+let handlerPromise: Promise<McpRequestHandler> | undefined;
+
+/** Imports the MCP package lazily so a disabled endpoint never loads it. */
+export function getMcpRequestHandler(): Promise<McpRequestHandler> {
+    handlerPromise = handlerPromise ?? importRequestHandler();
+    return handlerPromise;
+}
+
+async function importRequestHandler(): Promise<McpRequestHandler> {
+    const { createMcpRequestHandler } = await import('@explorer/entity-inspector');
+    return createMcpRequestHandler({ logger, rpcEndpoints });
+}

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -1,0 +1,85 @@
+import { timingSafeEqual } from 'node:crypto';
+
+import { isEnvEnabled } from '@utils/env';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import { getMcpRequestHandler } from './dependencies';
+
+export const maxDuration = 60;
+
+const CORS_HEADERS = {
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type, mcp-session-id, mcp-protocol-version, Last-Event-ID',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Expose-Headers': 'mcp-session-id, mcp-protocol-version',
+};
+
+// Both lists are deploy-time configuration — parsed once at module scope.
+const blockedIps = parseCsvList(process.env.MCP_BLOCKED_IPS);
+const accessKeys = parseCsvList(process.env.MCP_ACCESS_KEYS);
+
+if (isEnvEnabled(process.env.MCP_ENDPOINT_ENABLED) && accessKeys.length === 0) {
+    Logger.warn('[mcp] MCP_ACCESS_KEYS is unset — /mcp is enabled without authentication');
+}
+
+async function handleMcpRequest(request: Request): Promise<Response> {
+    const clientIp = resolveClientIp(request);
+    if (clientIp !== undefined && blockedIps.includes(clientIp)) {
+        Logger.warn('[mcp] rejected request from blocked ip', { clientIp });
+        return jsonError(403, 'Forbidden');
+    }
+    if (!isEnvEnabled(process.env.MCP_ENDPOINT_ENABLED)) {
+        return jsonError(503, 'MCP endpoint is disabled');
+    }
+    if (!isAuthorized(request)) {
+        return jsonError(401, 'Unauthorized');
+    }
+    const handler = await getMcpRequestHandler();
+    return withCorsHeaders(await handler(request));
+}
+
+export { handleMcpRequest as DELETE, handleMcpRequest as GET, handleMcpRequest as POST };
+
+export function OPTIONS(): Response {
+    return new Response(undefined, { headers: CORS_HEADERS, status: 204 });
+}
+
+function parseCsvList(value: string | undefined): string[] {
+    return (value ?? '')
+        .split(',')
+        .map(entry => entry.trim())
+        .filter(entry => entry.length > 0);
+}
+
+// On Vercel the first x-forwarded-for entry is the platform-set client IP.
+function resolveClientIp(request: Request): string | undefined {
+    const [firstEntry = ''] = (request.headers.get('x-forwarded-for') ?? '').split(',');
+    const clientIp = firstEntry.trim();
+    return clientIp.length > 0 ? clientIp : undefined;
+}
+
+// Unset MCP_ACCESS_KEYS deliberately means open access (see the module-scope warning above).
+function isAuthorized(request: Request): boolean {
+    if (accessKeys.length === 0) return true;
+    const authorization = request.headers.get('authorization') ?? '';
+    if (!authorization.startsWith('Bearer ')) return false;
+    const presentedKey = authorization.slice('Bearer '.length);
+    return accessKeys.some(key => isEqualConstantTime(key, presentedKey));
+}
+
+function isEqualConstantTime(expected: string, presented: string): boolean {
+    const expectedBytes = Buffer.from(expected);
+    const presentedBytes = Buffer.from(presented);
+    return expectedBytes.length === presentedBytes.length && timingSafeEqual(expectedBytes, presentedBytes);
+}
+
+function jsonError(status: number, error: string): Response {
+    return Response.json({ error }, { headers: CORS_HEADERS, status });
+}
+
+function withCorsHeaders(response: Response): Response {
+    const headers = new Headers(response.headers);
+    Object.entries(CORS_HEADERS).forEach(([name, value]) => headers.set(name, value));
+    return new Response(response.body, { headers, status: response.status, statusText: response.statusText });
+}

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -35,8 +35,14 @@ async function handleMcpRequest(request: Request): Promise<Response> {
     if (!isAuthorized(request)) {
         return jsonError(401, 'Unauthorized');
     }
-    const handler = await getMcpRequestHandler();
-    return withCorsHeaders(await handler(request));
+    try {
+        const handler = await getMcpRequestHandler();
+        return withCorsHeaders(await handler(request));
+    } catch (error) {
+        // Controlled, CORS-consistent 500 (Next's default 500 omits CORS); also reports to Sentry.
+        Logger.error(error, { sentry: true });
+        return jsonError(500, 'Internal error');
+    }
 }
 
 export { handleMcpRequest as DELETE, handleMcpRequest as GET, handleMcpRequest as POST };

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -51,10 +51,11 @@
 | Dynamic | `/block/[slot]/rewards` | 210 kB | 1.24 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |
 | Static | `/feature-gates` | 50 kB | 1.07 MB |
+| Dynamic | `/mcp` | — | — |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 890 B | 1.03 MB |
-| Dynamic | `/tx/[signature]` | 500 kB | 1.51 MB |
-| Dynamic | `/tx/[signature]/inspect` | 370 kB | 1.39 MB |
-| Static | `/tx/inspector` | 370 kB | 1.39 MB |
+| Static | `/tos` | 880 B | 1.04 MB |
+| Dynamic | `/tx/[signature]` | 440 kB | 1.46 MB |
+| Dynamic | `/tx/[signature]/inspect` | 360 kB | 1.38 MB |
+| Static | `/tx/inspector` | 360 kB | 1.38 MB |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -209,7 +209,13 @@ export default tseslint.config(
 
     // Allow console in logger, scripts, standalone files, pnpmfile
     {
-        files: ['app/shared/lib/logger.ts', 'scripts/**', '**/*.mjs', '**/*.cjs'],
+        files: [
+            'app/shared/lib/logger.ts',
+            'packages/entity-inspector/src/logger.ts',
+            'scripts/**',
+            '**/*.mjs',
+            '**/*.cjs',
+        ],
         rules: {
             'no-console': 'off',
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ const TEST_AND_STORY_FILES = [
 export default tseslint.config(
     // Global ignores.
     // packages/* are intentionally not ignored: root `eslint .` (like prettier's `**/*.ts` glob) lints their source with this shared config — only built output is excluded.
+    // Exception: packages/entity-inspector lints itself with oxlint (see its .oxlintrc.json), wired into root `pnpm lint`.
     {
         ignores: [
             '**/dist/**',
@@ -32,6 +33,7 @@ export default tseslint.config(
             'coverage/**',
             '.claude/**',
             '.worktrees/**',
+            'packages/entity-inspector/**',
             'storybook-static/**',
             'storybook-static-*/**',
             'public/mockServiceWorker.js',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "format": "pnpm pretty:format '**/*.{ts,tsx,mts,mjs,cjs}' '*.json'",
         "format:ci": "pnpm format",
         "gen": "pnpx shadcn@^2.4.0 add",
-        "lint": "pnpm eslint:lint .",
+        "lint": "pnpm eslint:lint . && pnpm -r --filter './packages/**' run lint",
         "openspec:validate": "openspec validate --all --strict --no-interactive",
         "pretty:format": "prettier --config .prettierrc.cjs --check",
         "sb": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@coral-xyz/anchor": "0.30.1",
         "@explorer/decoder-mango": "workspace:*",
         "@explorer/decoder-serum": "workspace:*",
+        "@explorer/entity-inspector": "workspace:*",
         "@fast-csv/format": "5.0.5",
         "@mantine/hooks": "7.17.3",
         "@metaplex-foundation/mpl-token-metadata": "3.4.0",

--- a/packages/entity-inspector/.gitignore
+++ b/packages/entity-inspector/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/packages/entity-inspector/.gitignore
+++ b/packages/entity-inspector/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /dist
+/coverage

--- a/packages/entity-inspector/.oxfmtrc.json
+++ b/packages/entity-inspector/.oxfmtrc.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "arrowParens": "avoid",
+    "ignorePatterns": ["**/*.md"],
+    "printWidth": 120,
+    "quoteProps": "as-needed",
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 4
+}

--- a/packages/entity-inspector/.oxlintrc.json
+++ b/packages/entity-inspector/.oxlintrc.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "plugins": ["import", "oxc", "typescript", "unicorn"],
+    "categories": {
+        "correctness": "error",
+        "suspicious": "error"
+    },
+    "rules": {
+        "typescript/consistent-type-assertions": ["error", { "assertionStyle": "never" }],
+        "typescript/no-explicit-any": "error",
+        "typescript/no-non-null-assertion": "error"
+    },
+    "overrides": [
+        {
+            "files": ["**/__tests__/**/*.ts"],
+            "rules": {
+                "no-new": "off",
+                "typescript/consistent-type-assertions": "off"
+            }
+        }
+    ],
+    "ignorePatterns": ["dist/**", "node_modules/**"]
+}

--- a/packages/entity-inspector/package.json
+++ b/packages/entity-inspector/package.json
@@ -2,7 +2,11 @@
     "name": "@explorer/entity-inspector",
     "version": "0.0.0",
     "private": true,
+    "files": [
+        "dist"
+    ],
     "type": "module",
+    "sideEffects": false,
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -10,12 +14,18 @@
             "default": "./dist/index.js"
         }
     },
-    "files": [
-        "dist"
-    ],
     "scripts": {
+        "prebuild": "rm -rf dist",
         "build": "tsc",
-        "test": "vitest run",
+        "format": "oxfmt --check .",
+        "format:fix": "oxfmt .",
+        "lint": "oxlint && oxfmt --check .",
+        "lint:fix": "oxlint --fix",
+        "pretest": "pnpm run build",
+        "test": "pnpm run typecheck && vitest run && pnpm run test:treeshakability && pnpm run test:node-esm && pnpm run test:coverage",
+        "test:coverage": "vitest run --config vitest.coverage.config.ts",
+        "test:node-esm": "for entry in dist/index.js; do node --input-type=module -e \"import('./$entry')\" || exit 1; done",
+        "test:treeshakability": "for file in dist/index.js; do agadoo $file || exit 1; done",
         "test:watch": "vitest",
         "typecheck": "tsc --noEmit"
     },
@@ -24,6 +34,10 @@
         "zod": "4.3.6"
     },
     "devDependencies": {
+        "@vitest/coverage-v8": "catalog:vitest",
+        "agadoo": "^3.0.0",
+        "oxfmt": "^0.56.0",
+        "oxlint": "^1.71.0",
         "typescript": "catalog:tooling",
         "vitest": "catalog:vitest"
     }

--- a/packages/entity-inspector/package.json
+++ b/packages/entity-inspector/package.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "prebuild": "rm -rf dist",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.build.json",
         "format": "oxfmt --check .",
         "format:fix": "oxfmt .",
         "lint": "oxlint && oxfmt --check .",

--- a/packages/entity-inspector/package.json
+++ b/packages/entity-inspector/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@explorer/entity-inspector",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "1.27.1",
+        "zod": "4.3.6"
+    },
+    "devDependencies": {
+        "typescript": "catalog:tooling",
+        "vitest": "catalog:vitest"
+    }
+}

--- a/packages/entity-inspector/src/__tests__/config.spec.ts
+++ b/packages/entity-inspector/src/__tests__/config.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { SUPPORTED_CLUSTERS } from '../config.js';
+
+describe('SUPPORTED_CLUSTERS', () => {
+    it('should list the clusters the inspector can query', () => {
+        expect(SUPPORTED_CLUSTERS).toEqual(['mainnet-beta', 'devnet', 'testnet', 'simd296']);
+    });
+});

--- a/packages/entity-inspector/src/__tests__/logger.spec.ts
+++ b/packages/entity-inspector/src/__tests__/logger.spec.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { consoleLogger } from '../logger.js';
+
+describe('consoleLogger', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should forward to the matching console method, passing context only when provided', () => {
+        const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        consoleLogger.debug('debug with', { a: 1 });
+        consoleLogger.debug('debug without');
+        consoleLogger.info('info with', { b: 2 });
+        consoleLogger.info('info without');
+        consoleLogger.warn('warn with', { c: 3 });
+        consoleLogger.warn('warn without');
+
+        expect(debug).toHaveBeenNthCalledWith(1, 'debug with', { a: 1 });
+        expect(debug).toHaveBeenNthCalledWith(2, 'debug without');
+        expect(info).toHaveBeenNthCalledWith(1, 'info with', { b: 2 });
+        expect(info).toHaveBeenNthCalledWith(2, 'info without');
+        expect(warn).toHaveBeenNthCalledWith(1, 'warn with', { c: 3 });
+        expect(warn).toHaveBeenNthCalledWith(2, 'warn without');
+    });
+});

--- a/packages/entity-inspector/src/__tests__/logger.spec.ts
+++ b/packages/entity-inspector/src/__tests__/logger.spec.ts
@@ -10,11 +10,14 @@ describe('consoleLogger', () => {
 
     it('should forward to the matching console method, passing context only when provided', () => {
         const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        const error = vi.spyOn(console, 'error').mockImplementation(() => {});
         const info = vi.spyOn(console, 'info').mockImplementation(() => {});
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         consoleLogger.debug('debug with', { a: 1 });
         consoleLogger.debug('debug without');
+        consoleLogger.error('error with', { d: 4 });
+        consoleLogger.error('error without');
         consoleLogger.info('info with', { b: 2 });
         consoleLogger.info('info without');
         consoleLogger.warn('warn with', { c: 3 });
@@ -22,6 +25,8 @@ describe('consoleLogger', () => {
 
         expect(debug).toHaveBeenNthCalledWith(1, 'debug with', { a: 1 });
         expect(debug).toHaveBeenNthCalledWith(2, 'debug without');
+        expect(error).toHaveBeenNthCalledWith(1, 'error with', { d: 4 });
+        expect(error).toHaveBeenNthCalledWith(2, 'error without');
         expect(info).toHaveBeenNthCalledWith(1, 'info with', { b: 2 });
         expect(info).toHaveBeenNthCalledWith(2, 'info without');
         expect(warn).toHaveBeenNthCalledWith(1, 'warn with', { c: 3 });

--- a/packages/entity-inspector/src/config.ts
+++ b/packages/entity-inspector/src/config.ts
@@ -1,0 +1,4 @@
+// Clusters the inspector can query — the single source of truth for the SupportedCluster type.
+export const SUPPORTED_CLUSTERS = ['mainnet-beta', 'devnet', 'testnet', 'simd296'] as const;
+
+export type SupportedCluster = (typeof SUPPORTED_CLUSTERS)[number];

--- a/packages/entity-inspector/src/index.ts
+++ b/packages/entity-inspector/src/index.ts
@@ -1,0 +1,5 @@
+export type { InspectorLogger } from './logger.js';
+export { createMcpRequestHandler } from './mcp/handler.js';
+export type { McpRequestHandler } from './mcp/handler.js';
+export { SUPPORTED_CLUSTERS } from './types.js';
+export type { EntityInspectorConfig, SupportedCluster } from './types.js';

--- a/packages/entity-inspector/src/index.ts
+++ b/packages/entity-inspector/src/index.ts
@@ -1,5 +1,6 @@
+export { SUPPORTED_CLUSTERS } from './config.js';
+export type { SupportedCluster } from './config.js';
 export type { InspectorLogger } from './logger.js';
 export { createMcpRequestHandler } from './mcp/handler.js';
 export type { McpRequestHandler } from './mcp/handler.js';
-export { SUPPORTED_CLUSTERS } from './types.js';
-export type { EntityInspectorConfig, SupportedCluster } from './types.js';
+export type { EntityInspectorConfig } from './types.js';

--- a/packages/entity-inspector/src/logger.ts
+++ b/packages/entity-inspector/src/logger.ts
@@ -1,0 +1,13 @@
+type LogContext = Record<string, unknown>;
+
+export type InspectorLogger = {
+    debug(message: string, context?: LogContext): void;
+    info(message: string, context?: LogContext): void;
+    warn(message: string, context?: LogContext): void;
+};
+
+export const consoleLogger: InspectorLogger = {
+    debug: (message, context) => (context ? console.debug(message, context) : console.debug(message)),
+    info: (message, context) => (context ? console.info(message, context) : console.info(message)),
+    warn: (message, context) => (context ? console.warn(message, context) : console.warn(message)),
+};

--- a/packages/entity-inspector/src/logger.ts
+++ b/packages/entity-inspector/src/logger.ts
@@ -2,12 +2,14 @@ type LogContext = Record<string, unknown>;
 
 export type InspectorLogger = {
     debug(message: string, context?: LogContext): void;
+    error(message: string, context?: LogContext): void;
     info(message: string, context?: LogContext): void;
     warn(message: string, context?: LogContext): void;
 };
 
 export const consoleLogger: InspectorLogger = {
     debug: (message, context) => (context ? console.debug(message, context) : console.debug(message)),
+    error: (message, context) => (context ? console.error(message, context) : console.error(message)),
     info: (message, context) => (context ? console.info(message, context) : console.info(message)),
     warn: (message, context) => (context ? console.warn(message, context) : console.warn(message)),
 };

--- a/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
@@ -1,5 +1,8 @@
 // @vitest-environment node
-import { describe, expect, it } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { EntityInspectorConfig } from '../../types.js';
 import { createMcpRequestHandler } from '../handler.js';
@@ -13,8 +16,6 @@ const TEST_CONFIG: EntityInspectorConfig = {
     },
 };
 
-const PROTOCOL_VERSION = '2025-11-05';
-
 const MCP_HEADERS = {
     accept: 'application/json, text/event-stream',
     'content-type': 'application/json',
@@ -26,7 +27,7 @@ function initializeRequest(id: number): Request {
         {
             capabilities: {},
             clientInfo: { name: 'vitest-client', version: '0.1.0' },
-            protocolVersion: PROTOCOL_VERSION,
+            protocolVersion: LATEST_PROTOCOL_VERSION,
         },
         id,
     );
@@ -60,7 +61,7 @@ async function negotiatedToolRequest(
     });
 }
 
-describe('createMcpRequestHandler', () => {
+describe('createMcpRequestHandler — real MCP SDK transport', () => {
     const handler = createMcpRequestHandler(TEST_CONFIG);
 
     it('should respond to initialize with the server identity', async () => {
@@ -93,5 +94,31 @@ describe('createMcpRequestHandler', () => {
             jsonrpc: '2.0',
             result: { content: [{ text: 'pong', type: 'text' }] },
         });
+    });
+});
+
+// Real SDK, but transport/server close is spied to reject — so these stay in the same file as the
+// round-trip cases above (a whole-module vi.mock would break those; a targeted spy does not).
+describe('createMcpRequestHandler — real MCP SDK transport, close failures', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should log both close failures via the injected logger and still return the response', async () => {
+        vi.spyOn(WebStandardStreamableHTTPServerTransport.prototype, 'close').mockRejectedValue(
+            new Error('transport boom'),
+        );
+        vi.spyOn(McpServer.prototype, 'close').mockRejectedValue(new Error('server boom'));
+        const warn = vi.fn();
+        const handler = createMcpRequestHandler({
+            logger: { debug: vi.fn(), info: vi.fn(), warn },
+            rpcEndpoints: TEST_CONFIG.rpcEndpoints,
+        });
+
+        const response = await handler(initializeRequest(1));
+
+        expect(response.status).toBe(200);
+        expect(warn).toHaveBeenCalledWith('[entity-inspector] transport close failed', { error: expect.any(Error) });
+        expect(warn).toHaveBeenCalledWith('[entity-inspector] server close failed', { error: expect.any(Error) });
     });
 });

--- a/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/handler.integration.spec.ts
@@ -97,8 +97,7 @@ describe('createMcpRequestHandler — real MCP SDK transport', () => {
     });
 });
 
-// Real SDK, but transport/server close is spied to reject — so these stay in the same file as the
-// round-trip cases above (a whole-module vi.mock would break those; a targeted spy does not).
+// Spy (not vi.mock) so these close-failure cases can share a file with the round-trips above.
 describe('createMcpRequestHandler — real MCP SDK transport, close failures', () => {
     afterEach(() => {
         vi.restoreAllMocks();
@@ -111,7 +110,7 @@ describe('createMcpRequestHandler — real MCP SDK transport, close failures', (
         vi.spyOn(McpServer.prototype, 'close').mockRejectedValue(new Error('server boom'));
         const warn = vi.fn();
         const handler = createMcpRequestHandler({
-            logger: { debug: vi.fn(), info: vi.fn(), warn },
+            logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn },
             rpcEndpoints: TEST_CONFIG.rpcEndpoints,
         });
 

--- a/packages/entity-inspector/src/mcp/__tests__/handler.spec.ts
+++ b/packages/entity-inspector/src/mcp/__tests__/handler.spec.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import type { EntityInspectorConfig } from '../../types.js';
+import { createMcpRequestHandler } from '../handler.js';
+
+const TEST_CONFIG: EntityInspectorConfig = {
+    rpcEndpoints: {
+        devnet: 'https://api.devnet.solana.com',
+        'mainnet-beta': 'https://api.mainnet-beta.solana.com',
+        simd296: 'https://simd-0296.surfnet.dev:8899',
+        testnet: 'https://api.testnet.solana.com',
+    },
+};
+
+const PROTOCOL_VERSION = '2025-11-05';
+
+const MCP_HEADERS = {
+    accept: 'application/json, text/event-stream',
+    'content-type': 'application/json',
+};
+
+function initializeRequest(id: number): Request {
+    return mcpRequest(
+        'initialize',
+        {
+            capabilities: {},
+            clientInfo: { name: 'vitest-client', version: '0.1.0' },
+            protocolVersion: PROTOCOL_VERSION,
+        },
+        id,
+    );
+}
+
+function mcpRequest(
+    method: string,
+    params: Record<string, unknown>,
+    id: number,
+    headers: Record<string, string> = MCP_HEADERS,
+): Request {
+    return new Request('http://localhost/mcp', {
+        body: JSON.stringify({ id, jsonrpc: '2.0', method, params }),
+        headers,
+        method: 'POST',
+    });
+}
+
+// Stateless transport: negotiate the protocol version once, then send it with every tool request.
+async function negotiatedToolRequest(
+    handler: ReturnType<typeof createMcpRequestHandler>,
+    method: string,
+    params: Record<string, unknown>,
+    id: number,
+): Promise<Request> {
+    const initResponse = await handler(initializeRequest(0));
+    const initPayload = await initResponse.json();
+    return mcpRequest(method, params, id, {
+        ...MCP_HEADERS,
+        'mcp-protocol-version': initPayload.result.protocolVersion,
+    });
+}
+
+describe('createMcpRequestHandler', () => {
+    const handler = createMcpRequestHandler(TEST_CONFIG);
+
+    it('should respond to initialize with the server identity', async () => {
+        const response = await handler(initializeRequest(1));
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+            id: 1,
+            jsonrpc: '2.0',
+            result: { serverInfo: { name: 'explorer-mcp', version: '0.1.0' } },
+        });
+    });
+
+    it('should list the ping tool', async () => {
+        const response = await handler(await negotiatedToolRequest(handler, 'tools/list', {}, 2));
+
+        expect(response.status).toBe(200);
+        const payload = await response.json();
+        expect(payload.result.tools).toMatchObject([{ name: 'ping' }]);
+    });
+
+    it('should answer a ping tool call with pong', async () => {
+        const response = await handler(
+            await negotiatedToolRequest(handler, 'tools/call', { arguments: {}, name: 'ping' }, 3),
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+            id: 3,
+            jsonrpc: '2.0',
+            result: { content: [{ text: 'pong', type: 'text' }] },
+        });
+    });
+});

--- a/packages/entity-inspector/src/mcp/handler.ts
+++ b/packages/entity-inspector/src/mcp/handler.ts
@@ -1,0 +1,23 @@
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+
+import { consoleLogger } from '../logger.js';
+import type { EntityInspectorConfig } from '../types.js';
+import { createMcpServer } from './server.js';
+
+export type McpRequestHandler = (request: Request) => Promise<Response>;
+
+/** Stateless transport: a fresh server + transport pair per request, both closed in `finally`. */
+export function createMcpRequestHandler(config: EntityInspectorConfig): McpRequestHandler {
+    const logger = config.logger ?? consoleLogger;
+    return async request => {
+        const server = createMcpServer();
+        const transport = new WebStandardStreamableHTTPServerTransport({ enableJsonResponse: true });
+        try {
+            await server.connect(transport);
+            return await transport.handleRequest(request);
+        } finally {
+            await transport.close().catch(error => logger.warn('[entity-inspector] transport close failed', { error }));
+            await server.close().catch(error => logger.warn('[entity-inspector] server close failed', { error }));
+        }
+    };
+}

--- a/packages/entity-inspector/src/mcp/schemas.ts
+++ b/packages/entity-inspector/src/mcp/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// All MCP tool input schemas live here so the validation library is confined to one module.
+// @modelcontextprotocol/sdk requires Zod for `inputSchema`, so these stay Zod-based while we're on
+// the SDK; swapping to another validator is a change scoped to this file.
+// Factories (not module-scope constants) keep importing the package side-effect-free / tree-shakeable.
+export function pingInputSchema() {
+    return z.object({}).strict().optional().default({});
+}

--- a/packages/entity-inspector/src/mcp/schemas.ts
+++ b/packages/entity-inspector/src/mcp/schemas.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod';
 
-// All MCP tool input schemas live here so the validation library is confined to one module.
-// @modelcontextprotocol/sdk requires Zod for `inputSchema`, so these stay Zod-based while we're on
-// the SDK; swapping to another validator is a change scoped to this file.
-// Factories (not module-scope constants) keep importing the package side-effect-free / tree-shakeable.
+// Zod confined here: the MCP SDK requires it for inputSchema; a swap-out stays local to this file.
+// Factory (not a module-scope const) keeps importing the package side-effect-free for tree-shaking.
 export function pingInputSchema() {
     return z.object({}).strict().optional().default({});
 }

--- a/packages/entity-inspector/src/mcp/server.ts
+++ b/packages/entity-inspector/src/mcp/server.ts
@@ -1,7 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 
-const pingInputSchema = z.object({}).strict().optional().default({});
+import { pingInputSchema } from './schemas.js';
 
 export function createMcpServer(): McpServer {
     const server = new McpServer({
@@ -14,7 +13,7 @@ export function createMcpServer(): McpServer {
         'ping',
         {
             description: 'Basic scaffold health tool',
-            inputSchema: pingInputSchema,
+            inputSchema: pingInputSchema(),
         },
         async () => ({
             content: [

--- a/packages/entity-inspector/src/mcp/server.ts
+++ b/packages/entity-inspector/src/mcp/server.ts
@@ -1,0 +1,30 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const pingInputSchema = z.object({}).strict().optional().default({});
+
+export function createMcpServer(): McpServer {
+    const server = new McpServer({
+        name: 'explorer-mcp',
+        // Mirrors the explorer's root package.json version (kept as a literal — the package imports no app code)
+        version: '0.1.0',
+    });
+
+    server.registerTool(
+        'ping',
+        {
+            description: 'Basic scaffold health tool',
+            inputSchema: pingInputSchema,
+        },
+        async () => ({
+            content: [
+                {
+                    text: 'pong',
+                    type: 'text',
+                },
+            ],
+        }),
+    );
+
+    return server;
+}

--- a/packages/entity-inspector/src/types.ts
+++ b/packages/entity-inspector/src/types.ts
@@ -1,8 +1,5 @@
+import type { SupportedCluster } from './config.js';
 import type { InspectorLogger } from './logger.js';
-
-export const SUPPORTED_CLUSTERS = ['mainnet-beta', 'devnet', 'testnet', 'simd296'] as const;
-
-export type SupportedCluster = (typeof SUPPORTED_CLUSTERS)[number];
 
 export type EntityInspectorConfig = {
     logger?: InspectorLogger;

--- a/packages/entity-inspector/src/types.ts
+++ b/packages/entity-inspector/src/types.ts
@@ -3,5 +3,6 @@ import type { InspectorLogger } from './logger.js';
 
 export type EntityInspectorConfig = {
     logger?: InspectorLogger;
+    // Scaffolding for the inspect_entity tool (plan Steps 5/6); not read yet — only ping ships today.
     rpcEndpoints: Record<SupportedCluster, string>;
 };

--- a/packages/entity-inspector/src/types.ts
+++ b/packages/entity-inspector/src/types.ts
@@ -1,0 +1,10 @@
+import type { InspectorLogger } from './logger.js';
+
+export const SUPPORTED_CLUSTERS = ['mainnet-beta', 'devnet', 'testnet', 'simd296'] as const;
+
+export type SupportedCluster = (typeof SUPPORTED_CLUSTERS)[number];
+
+export type EntityInspectorConfig = {
+    logger?: InspectorLogger;
+    rpcEndpoints: Record<SupportedCluster, string>;
+};

--- a/packages/entity-inspector/tsconfig.build.json
+++ b/packages/entity-inspector/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.spec.ts"]
+}

--- a/packages/entity-inspector/tsconfig.json
+++ b/packages/entity-inspector/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "es2020",
+        "lib": ["es2020", "dom"],
+        "module": "es2022",
+        "moduleResolution": "bundler",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "isolatedModules": true
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/entity-inspector/vitest.config.ts
+++ b/packages/entity-inspector/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.spec.ts'],
+    },
+});

--- a/packages/entity-inspector/vitest.coverage.config.ts
+++ b/packages/entity-inspector/vitest.coverage.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// Coverage harness over src. Thresholds are the gate, not a report — the figure decays silently
+// from the first uncovered PR otherwise.
+export default defineConfig({
+    test: {
+        coverage: {
+            enabled: true,
+            // client sources only — colocated specs are not the measured code
+            exclude: ['src/**/__tests__/**'],
+            include: ['src/**'],
+            thresholds: { branches: 100, functions: 100, lines: 100, statements: 100 },
+        },
+        include: ['src/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@explorer/decoder-serum':
         specifier: workspace:*
         version: link:packages/decoder-serum
+      '@explorer/entity-inspector':
+        specifier: workspace:*
+        version: link:packages/entity-inspector
       '@fast-csv/format':
         specifier: 5.0.5
         version: 5.0.5
@@ -613,6 +616,22 @@ importers:
       '@types/bn.js':
         specifier: 5.1.0
         version: 5.1.0
+      typescript:
+        specifier: catalog:tooling
+        version: 5.7.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.15.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.0.0(bufferutil@4.0.7)(utf-8-validate@5.0.10))(msw@2.14.6(@types/node@22.15.3)(typescript@5.7.3))(vite@6.3.6(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.53.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/entity-inspector:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.27.1
+        version: 1.27.1(zod@4.3.6)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
       typescript:
         specifier: catalog:tooling
         version: 5.7.3
@@ -1883,6 +1902,12 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2468,6 +2493,16 @@ packages:
 
   '@minhducsun2002/leb128@1.0.0':
     resolution: {integrity: sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -5739,6 +5774,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -6064,6 +6107,10 @@ packages:
   bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
@@ -6180,6 +6227,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -6441,8 +6492,28 @@ packages:
   constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -6456,6 +6527,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   countup.js@2.6.2:
     resolution: {integrity: sha512-PRvoilkebwr1MKaRAllyJl2cD7mgunGZWXLaSFL+YqHXlJpjLX7SHTWonRfIx2xg1Xf7SPbo92bOOonSIomRYQ==}
@@ -7119,6 +7194,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -7139,6 +7222,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -7249,6 +7342,10 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -7309,12 +7406,20 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
@@ -7558,6 +7663,10 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -7699,6 +7808,14 @@ packages:
 
   iobuffer@5.4.0:
     resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
@@ -7863,6 +7980,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -8088,6 +8208,9 @@ packages:
   joi@17.9.2:
     resolution: {integrity: sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   jotai@2.15.1:
     resolution: {integrity: sha512-yHT1HAZ3ba2Q8wgaUQ+xfBzEtcS8ie687I8XVCBinfg4bNniyqLIN+utPXWKQE93LMF5fPbQSVRZqgpcN5yd6Q==}
     engines: {node: '>=12.20.0'}
@@ -8176,6 +8299,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -8485,8 +8611,16 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -9094,6 +9228,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -9148,6 +9285,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
@@ -9359,6 +9500,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -9389,6 +9534,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
@@ -9414,6 +9563,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-base16-styling@0.10.0:
     resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
@@ -9705,6 +9858,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.0.2:
     resolution: {integrity: sha512-YzggvfItxMY3Lwuax5rC18inhbjJv9Py7JXRHxTIi94JOLrqBsSsUUc5bbl5W6c11tXhdfpDPK0KzBhoGe8jjw==}
 
@@ -9806,6 +9963,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -9813,6 +9974,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -9863,6 +10028,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -9880,6 +10049,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -10450,6 +10623,10 @@ packages:
     resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -10658,6 +10835,10 @@ packages:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -11062,14 +11243,19 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -12777,7 +12963,7 @@ snapshots:
       ora: 8.2.0
       posthog-node: 5.34.1(rxjs@7.8.1)
       yaml: 2.8.3
-      zod: 4.4.3
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@types/node'
       - rxjs
@@ -12804,6 +12990,10 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@humanfs/core@0.19.1': {}
 
@@ -13494,6 +13684,28 @@ snapshots:
       - '@types/react'
 
   '@minhducsun2002/leb128@1.0.0': {}
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mswjs/interceptors@0.41.9':
     dependencies:
@@ -17528,6 +17740,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
@@ -17983,6 +18199,20 @@ snapshots:
 
   bn.js@5.2.1: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   borsh@0.7.0:
     dependencies:
       bn.js: 5.2.1
@@ -18130,6 +18360,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -18392,7 +18624,17 @@ snapshots:
 
   constants-browserify@1.0.0: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -18404,6 +18646,11 @@ snapshots:
     optional: true
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   countup.js@2.6.2: {}
 
@@ -19194,8 +19441,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.4.2)
       hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -19421,6 +19668,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -19451,6 +19704,44 @@ snapshots:
   exponential-backoff@3.1.1: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -19575,6 +19866,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
@@ -19641,9 +19943,13 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0: {}
+
   fraction.js@4.3.7: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   from@0.1.7: {}
 
@@ -19912,6 +20218,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hono@4.12.27: {}
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
@@ -20081,6 +20389,10 @@ snapshots:
 
   iobuffer@5.4.0: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.2.0: {}
 
   is-alphabetical@2.0.1: {}
@@ -20229,6 +20541,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -20546,6 +20860,8 @@ snapshots:
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
 
+  jose@6.2.3: {}
+
   jotai@2.15.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6):
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -20654,6 +20970,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -21050,7 +21368,11 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -21931,6 +22253,8 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -21976,6 +22300,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@5.0.0:
     dependencies:
@@ -22114,6 +22440,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   ps-tree@1.2.0:
@@ -22145,6 +22476,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   querystring-es3@0.2.1: {}
 
   querystringify@2.2.0: {}
@@ -22170,6 +22506,13 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-base16-styling@0.10.0:
     dependencies:
@@ -22599,6 +22942,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.0.2:
     dependencies:
       '@swc/helpers': 0.5.15
@@ -22731,6 +23084,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@2.1.0: {}
 
   serve-static@1.16.3:
@@ -22739,6 +23108,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -22823,6 +23201,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -22856,6 +23239,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -23417,6 +23808,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -23664,6 +24061,8 @@ snapshots:
     optional: true
 
   uuid@9.0.0: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -24067,10 +24466,14 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zod-validation-error@4.0.2(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
-      zod: 4.4.3
+      zod: 4.3.6
 
-  zod@4.4.3: {}
+  zod-validation-error@4.0.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,18 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: catalog:vitest
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      agadoo:
+        specifier: ^3.0.0
+        version: 3.0.0
+      oxfmt:
+        specifier: ^0.56.0
+        version: 0.56.0
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.72.0
       typescript:
         specifier: catalog:tooling
         version: 5.7.3
@@ -978,16 +990,6 @@ packages:
 
   '@babel/parser@7.26.10':
     resolution: {integrity: sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.28.4':
-    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2824,6 +2826,250 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    resolution: {integrity: sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    resolution: {integrity: sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    resolution: {integrity: sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    resolution: {integrity: sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    resolution: {integrity: sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    resolution: {integrity: sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    resolution: {integrity: sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    resolution: {integrity: sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    resolution: {integrity: sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    resolution: {integrity: sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    resolution: {integrity: sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    resolution: {integrity: sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    resolution: {integrity: sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    resolution: {integrity: sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    resolution: {integrity: sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    resolution: {integrity: sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    resolution: {integrity: sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    resolution: {integrity: sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    resolution: {integrity: sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.72.0':
+    resolution: {integrity: sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.72.0':
+    resolution: {integrity: sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.72.0':
+    resolution: {integrity: sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.72.0':
+    resolution: {integrity: sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.72.0':
+    resolution: {integrity: sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
+    resolution: {integrity: sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.72.0':
+    resolution: {integrity: sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.72.0':
+    resolution: {integrity: sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.72.0':
+    resolution: {integrity: sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.72.0':
+    resolution: {integrity: sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.72.0':
+    resolution: {integrity: sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.72.0':
+    resolution: {integrity: sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.72.0':
+    resolution: {integrity: sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.72.0':
+    resolution: {integrity: sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.72.0':
+    resolution: {integrity: sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.72.0':
+    resolution: {integrity: sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.72.0':
+    resolution: {integrity: sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.72.0':
+    resolution: {integrity: sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.72.0':
+    resolution: {integrity: sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -3584,6 +3830,15 @@ packages:
 
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-virtual@3.0.2':
+    resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -5736,23 +5991,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+
+  agadoo@3.0.0:
+    resolution: {integrity: sha512-gq+fjT3Ilrhb88Jf+vYMjdO/+3znYfa7vJ4IMLPFsBPUxglnr40Ed3yCLrW6IABdJAedB94b2BkqR6I04lh3dg==}
+    hasBin: true
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -9145,6 +9394,32 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.56.0:
+    resolution: {integrity: sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint@1.72.0:
+    resolution: {integrity: sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -9853,6 +10128,11 @@ packages:
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
+  rollup@3.30.0:
+    resolution: {integrity: sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rollup@4.50.1:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -10457,6 +10737,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -11831,7 +12115,7 @@ snapshots:
 
   '@babel/generator@7.26.10':
     dependencies:
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -11970,14 +12254,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.28.4':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.7
-
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -12076,7 +12352,7 @@ snapshots:
   '@babel/template@7.26.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
   '@babel/template@7.27.2':
@@ -12095,7 +12371,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.10
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.7
       '@babel/template': 7.26.9
       '@babel/types': 7.29.7
       debug: 4.4.3
@@ -14055,6 +14331,120 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
 
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.72.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.72.0':
+    optional: true
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -14818,9 +15208,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.50.1
 
+  '@rollup/plugin-virtual@3.0.2(rollup@3.30.0)':
+    optionalDependencies:
+      rollup: 3.30.0
+
   '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -17027,7 +17421,7 @@ snapshots:
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.18.5':
@@ -17697,7 +18091,7 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.2.0
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
@@ -17708,21 +18102,23 @@ snapshots:
     dependencies:
       acorn: 7.4.1
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn-walk@8.2.0: {}
 
   acorn@7.4.1: {}
 
-  acorn@8.15.0: {}
-
   acorn@8.16.0: {}
 
-  acorn@8.8.2: {}
-
   aes-js@3.0.0: {}
+
+  agadoo@3.0.0:
+    dependencies:
+      '@rollup/plugin-virtual': 3.0.2(rollup@3.30.0)
+      acorn: 8.16.0
+      rollup: 3.30.0
 
   agent-base@6.0.2:
     dependencies:
@@ -19438,7 +19834,7 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.4.2)
       hermes-parser: 0.25.1
       zod: 4.3.6
@@ -19578,8 +19974,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@6.2.1:
@@ -20546,7 +20942,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.1.4:
     dependencies:
@@ -20899,7 +21295,7 @@ snapshots:
   jsdom@20.0.3(bufferutil@4.0.7)(utf-8-validate@5.0.10):
     dependencies:
       abab: 2.0.6
-      acorn: 8.8.2
+      acorn: 8.16.0
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -22172,6 +22568,52 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.56.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.56.0
+      '@oxfmt/binding-android-arm64': 0.56.0
+      '@oxfmt/binding-darwin-arm64': 0.56.0
+      '@oxfmt/binding-darwin-x64': 0.56.0
+      '@oxfmt/binding-freebsd-x64': 0.56.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.56.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.56.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.56.0
+      '@oxfmt/binding-linux-arm64-musl': 0.56.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.56.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-musl': 0.56.0
+      '@oxfmt/binding-openharmony-arm64': 0.56.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.56.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.56.0
+      '@oxfmt/binding-win32-x64-msvc': 0.56.0
+
+  oxlint@1.72.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.72.0
+      '@oxlint/binding-android-arm64': 1.72.0
+      '@oxlint/binding-darwin-arm64': 1.72.0
+      '@oxlint/binding-darwin-x64': 1.72.0
+      '@oxlint/binding-freebsd-x64': 1.72.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.72.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.72.0
+      '@oxlint/binding-linux-arm64-gnu': 1.72.0
+      '@oxlint/binding-linux-arm64-musl': 1.72.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.72.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.72.0
+      '@oxlint/binding-linux-riscv64-musl': 1.72.0
+      '@oxlint/binding-linux-s390x-gnu': 1.72.0
+      '@oxlint/binding-linux-x64-gnu': 1.72.0
+      '@oxlint/binding-linux-x64-musl': 1.72.0
+      '@oxlint/binding-openharmony-arm64': 1.72.0
+      '@oxlint/binding-win32-arm64-msvc': 1.72.0
+      '@oxlint/binding-win32-ia32-msvc': 1.72.0
+      '@oxlint/binding-win32-x64-msvc': 1.72.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -22914,6 +23356,10 @@ snapshots:
     dependencies:
       hash-base: 3.1.0
       inherits: 2.0.4
+
+  rollup@3.30.0:
+    optionalDependencies:
+      fsevents: 2.3.3
 
   rollup@4.50.1:
     dependencies:
@@ -23673,6 +24119,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@2.1.0: {}
+
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -23954,7 +24402,7 @@ snapshots:
 
   unplugin@1.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       chokidar: 3.6.0
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0


### PR DESCRIPTION
## Description

First slice of the MCP-endpoint roadmap: a first-class `/mcp` endpoint inside the explorer, so the MCP server ships with the explorer deployment instead of living in the standalone `explorer-mcp` project.

- *New workspace package* — `@explorer/entity-inspector`: MCP transport glue and tool registration, following the `decoder-*` package conventions (dist build, own tests). Serves only `ping` for now; `inspect_entity` lands in follow-up PRs.
- *Stateless transport* — a fresh `McpServer` + `WebStandardStreamableHTTPServerTransport` per request (the pattern proven in production by the standalone server), which is what makes the endpoint safe on serverless.
- *Route gates* (`app/mcp/route.ts`, in order): IP blocklist (`MCP_BLOCKED_IPS`, 403) → feature flag (`MCP_ENDPOINT_ENABLED`, explicit 503 "disabled" when off) → bearer access keys (`MCP_ACCESS_KEYS`, constant-time compare, 401; unset means open access with a startup warning). CORS on every response, `maxDuration = 60` scoped to this route only.
- The endpoint lives at `/mcp` (not `/api/*`) deliberately — it escapes the BotID proxy matcher so automated MCP clients can connect.
- *Dedicated RPC config* — `MCP_SOLANA_RPC_URL_*` env vars (public endpoints as fallback) keep future MCP traffic off the app's RPC quota; documented in `.env.example`.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

No UI changes — server-side endpoint only.

## Testing

- Package spec exercises the real transport over JSON-RPC: `initialize` (server identity), `tools/list`, `tools/call ping` → `pong`.
- Route specs cover every gate outcome (403 blocked IP, 503 flag off, 401 missing/wrong key, delegation + CORS on success) and the open-access mode when `MCP_ACCESS_KEYS` is unset, asserting the handler is only invoked when all gates pass.
- Full suite green locally: `pnpm test` (301 files / 3669 tests), `pnpm typecheck` (includes `next build`), `pnpm lint`.
- Live smoke test against `next dev` via curl: all gate responses and a successful `ping` round-trip verified.

## Related Issues

<!-- Link to any related issues this PR addresses -->
<!-- Example: Fixes #123, Addresses #456 -->

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR

## Additional Notes

- The endpoint is inert until `MCP_ENDPOINT_ENABLED=true` is set (Vercel env + redeploy); production rollout also needs `MCP_ACCESS_KEYS` and the `MCP_SOLANA_RPC_URL_*` values.
- `maxDuration = 60` is per-route segment config — it does not change limits for any other function.
- Auth is app-owned on purpose (not Vercel deployment protection): keys rotate via the comma-separated list without downtime, and the deployment itself can stay public.
- Transport reference: [MCP Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http).
- `packages/entity-inspector/.gitignore` mirrors the decoder packages; the package is intentionally free of explorer app imports so the standalone repo can consume it later.
