### PR TITLE
chore(deps): remove stale minimumReleaseAgeExclude entries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,11 +19,3 @@ catalogs:
 autoInstallPeers: true
 ignoreScripts: true
 minimumReleaseAge: 20160
-minimumReleaseAgeExclude:
-  - '@codama/*'
-  - '@solana/idl'
-  - '@solana/security-txt'
-  - codama
-  - '@solana-program/token'
-  - '@solana-program/program-metadata'
-  - '@solana/kit'


### PR DESCRIPTION
Removes the entire `minimumReleaseAgeExclude` block from `pnpm-workspace.yaml`. The exclusions were added to allow installing versions younger than the 14-day `minimumReleaseAge` gate; every excluded package's locked version is now well past that threshold, so the entries are stale bypass holes:

- _@codama/\* family, codama_ — published 2026-04-14 or earlier
- _@solana/kit 6.5.0 / 2.3.0_ — 2026-03-19 / 2025-07-08
- _@solana-program/token 0.13.0_ — 2026-04-01
- _@solana-program/program-metadata 0.7.0_ — 2026-06-17
- _@solana/idl 0.2.0, @solana/security-txt 0.1.0_ — 2026-06-19 (youngest, ~31 days old)

No lockfile changes: the gate only applies at resolution time and all locked versions pass it.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe):

Dependency policy config cleanup.

## Testing

<!-- Describe how you tested your changes -->
<!-- For protocol integrations, explain how you verified the protocol data is correctly displayed -->

- Verified via npm registry publish dates that the newest locked version of every excluded package predates the 14-day cutoff
- `pnpm i --frozen-lockfile` completes cleanly with the block removed

## Related Issues

[HOO-724](https://linear.app/solana-fndn/issue/HOO-724)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR