### PR TITLE
fix: cluster button sizing

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,4 +1,5 @@
 import { DispatchContext, FetchersContext, type State, StateContext } from '@providers/accounts';
+import type { ClusterState } from '@providers/cluster';
 import { ScrollAnchorProvider } from '@providers/scroll-anchor';
 import { TransactionsProvider } from '@providers/transactions';
 import React, { useLayoutEffect, useRef } from 'react';
@@ -38,6 +39,20 @@ export const withClusterModalOpen: Decorator = Story => (
         <Story />
     </ClusterProvider>
 );
+
+/**
+ * Factory: seeds ClusterProvider with an explicit cluster `state` (cluster, customUrl, status) so consumers of
+ * `useCluster()` render a specific cluster/status. Usage: `decorators: [withClusterState({ cluster, customUrl, status })]`
+ */
+export function withClusterState(state: ClusterState): Decorator {
+    return function WithClusterState(Story) {
+        return (
+            <ClusterProvider state={state}>
+                <Story />
+            </ClusterProvider>
+        );
+    };
+}
 
 /** Wraps stories with the real ScrollAnchorProvider. Usage: `decorators: [withScrollAnchor]` */
 export const withScrollAnchor: Decorator = Story => (

--- a/app/components/ClusterStatusButton.tsx
+++ b/app/components/ClusterStatusButton.tsx
@@ -28,11 +28,12 @@ export const ClusterStatusButton = () => {
     const statusName = cluster !== Cluster.Custom ? `${name}` : getCustomUrlClusterName(customUrl);
 
     const spinnerClasses = 'align-text-top spinner-grow spinner-grow-sm mr-1.5';
+    const buttonClasses = '!block truncate';
 
     switch (status) {
         case ClusterStatus.Connected:
             return (
-                <Button ui="dashkit" variant="primary" className="!block" asChild>
+                <Button ui="dashkit" variant="primary" className={buttonClasses} asChild>
                     <span onClick={onClickHandler}>
                         <CheckCircle className="mr-1.5" size={15} />
                         {statusName}
@@ -42,7 +43,7 @@ export const ClusterStatusButton = () => {
 
         case ClusterStatus.Connecting:
             return (
-                <Button ui="dashkit" variant="warning" className="!block" asChild>
+                <Button ui="dashkit" variant="warning" className={buttonClasses} asChild>
                     <span onClick={onClickHandler}>
                         <span className={spinnerClasses} role="status" aria-hidden="true"></span>
                         {statusName}
@@ -52,7 +53,7 @@ export const ClusterStatusButton = () => {
 
         case ClusterStatus.Failure:
             return (
-                <Button ui="dashkit" variant="danger" className="!block" asChild>
+                <Button ui="dashkit" variant="danger" className={buttonClasses} asChild>
                     <span onClick={onClickHandler}>
                         <AlertCircle className="mr-1.5" size={15} />
                         {statusName}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -92,7 +92,7 @@ export function Navbar({ children }: INavbarProps) {
                     </NavbarList>
                 </div>
 
-                <div className="ml-[3px] hidden shrink-0 lg:block">
+                <div className="ml-[3px] hidden max-w-[210px] shrink-0 lg:block">
                     <ClusterStatusButton />
                 </div>
             </div>

--- a/app/components/__stories__/ClusterStatusButton.responsive.stories.tsx
+++ b/app/components/__stories__/ClusterStatusButton.responsive.stories.tsx
@@ -1,0 +1,33 @@
+import { withClusterState } from '@storybook-config/decorators';
+import { INITIAL_VIEWPORTS, withViewportFromGlobal } from '@storybook-config/responsive-decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { Cluster, ClusterStatus } from '@utils/cluster';
+
+import { ClusterStatusButton } from '../ClusterStatusButton';
+
+const CUSTOM_RPC_URL = 'https://random-helius-fast-mainnet.helius-rpc.com';
+
+const meta = {
+    component: ClusterStatusButton,
+    decorators: [
+        withClusterState({ cluster: Cluster.Custom, customUrl: CUSTOM_RPC_URL, status: ClusterStatus.Connected }),
+        withViewportFromGlobal,
+    ],
+    parameters: {
+        docs: { story: { height: INITIAL_VIEWPORTS.iphonex.styles.height } },
+        viewport: { options: INITIAL_VIEWPORTS },
+    },
+    tags: ['autodocs', 'test'],
+    title: 'Components/ClusterStatusButton@Media',
+} satisfies Meta<typeof ClusterStatusButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Mobile: Story = {
+    globals: { viewport: { value: 'iphonex' } },
+};
+
+export const TabletPortrait: Story = {
+    globals: { viewport: { value: 'ipad' } },
+};

--- a/app/components/__stories__/ClusterStatusButton.stories.tsx
+++ b/app/components/__stories__/ClusterStatusButton.stories.tsx
@@ -1,5 +1,5 @@
 import { withClusterState } from '@storybook-config/decorators';
-import type { Meta, StoryObj } from '@storybook-config/types';
+import type { Decorator, Meta, StoryObj } from '@storybook-config/types';
 import { Cluster, ClusterStatus, DEVNET_URL, MAINNET_BETA_URL, TESTNET_URL } from '@utils/cluster';
 import { expect, within } from 'storybook/test';
 
@@ -8,6 +8,16 @@ import { ClusterStatusButton } from '../ClusterStatusButton';
 // A long custom RPC endpoint (the case that used to make the navbar button overflow and wrap).
 const CUSTOM_RPC_URL = 'https://random-helius-fast-mainnet.helius-rpc.com';
 const LOCALHOST_URL = 'http://localhost:3000';
+
+// Fixes wrapper width for truncation tests.
+const WRAPPER_WIDTH_PX = 210;
+
+// Wrap with fixed width so truncation is observable outside of a full Navbar.
+const withWrapperWidth: Decorator = Story => (
+    <div style={{ maxWidth: `${WRAPPER_WIDTH_PX}px` }}>
+        <Story />
+    </div>
+);
 
 const meta = {
     component: ClusterStatusButton,
@@ -50,11 +60,20 @@ export const Testnet: Story = {
 export const CustomUrlTruncated: Story = {
     decorators: [
         withClusterState({ cluster: Cluster.Custom, customUrl: CUSTOM_RPC_URL, status: ClusterStatus.Connected }),
+        withWrapperWidth,
     ],
     play: async ({ canvasElement }) => {
-        expect(
-            within(canvasElement).getByText('https://random-helius-fast-mainnet.helius-rpc.com'),
-        ).toBeInTheDocument();
+        const button = within(canvasElement).getByText(CUSTOM_RPC_URL);
+        const style = getComputedStyle(button);
+
+        // `truncate` class is overflow-hidden + text-ellipsis + whitespace-nowrap
+        expect(style.overflowX).toBe('hidden');
+        expect(style.textOverflow).toBe('ellipsis');
+        expect(style.whiteSpace).toBe('nowrap');
+
+        // The URL really is clipped: content is wider than the box, and the box stays within the navbar slot.
+        expect(button.scrollWidth).toBeGreaterThan(button.clientWidth);
+        expect(button.getBoundingClientRect().width).toBeLessThanOrEqual(WRAPPER_WIDTH_PX);
     },
 };
 

--- a/app/components/__stories__/ClusterStatusButton.stories.tsx
+++ b/app/components/__stories__/ClusterStatusButton.stories.tsx
@@ -1,0 +1,80 @@
+import { withClusterState } from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { Cluster, ClusterStatus, DEVNET_URL, MAINNET_BETA_URL, TESTNET_URL } from '@utils/cluster';
+import { expect, within } from 'storybook/test';
+
+import { ClusterStatusButton } from '../ClusterStatusButton';
+
+// A long custom RPC endpoint (the case that used to make the navbar button overflow and wrap).
+const CUSTOM_RPC_URL = 'https://random-helius-fast-mainnet.helius-rpc.com';
+const LOCALHOST_URL = 'http://localhost:3000';
+
+const meta = {
+    component: ClusterStatusButton,
+    tags: ['autodocs', 'test'],
+    title: 'Components/ClusterStatusButton',
+} satisfies Meta<typeof ClusterStatusButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MainnetBeta: Story = {
+    decorators: [
+        withClusterState({
+            cluster: Cluster.MainnetBeta,
+            customUrl: MAINNET_BETA_URL,
+            status: ClusterStatus.Connected,
+        }),
+    ],
+    play: async ({ canvasElement }) => {
+        expect(within(canvasElement).getByText('Mainnet Beta')).toBeInTheDocument();
+    },
+};
+
+export const Devnet: Story = {
+    decorators: [withClusterState({ cluster: Cluster.Devnet, customUrl: DEVNET_URL, status: ClusterStatus.Connected })],
+    play: async ({ canvasElement }) => {
+        expect(within(canvasElement).getByText('Devnet')).toBeInTheDocument();
+    },
+};
+
+export const Testnet: Story = {
+    decorators: [
+        withClusterState({ cluster: Cluster.Testnet, customUrl: TESTNET_URL, status: ClusterStatus.Connected }),
+    ],
+    play: async ({ canvasElement }) => {
+        expect(within(canvasElement).getByText('Testnet')).toBeInTheDocument();
+    },
+};
+
+export const CustomUrlTruncated: Story = {
+    decorators: [
+        withClusterState({ cluster: Cluster.Custom, customUrl: CUSTOM_RPC_URL, status: ClusterStatus.Connected }),
+    ],
+    play: async ({ canvasElement }) => {
+        expect(
+            within(canvasElement).getByText('https://random-helius-fast-mainnet.helius-rpc.com'),
+        ).toBeInTheDocument();
+    },
+};
+
+export const CustomLocalhost: Story = {
+    decorators: [
+        withClusterState({ cluster: Cluster.Custom, customUrl: LOCALHOST_URL, status: ClusterStatus.Connected }),
+    ],
+    play: async ({ canvasElement }) => {
+        expect(within(canvasElement).getByText(LOCALHOST_URL)).toBeInTheDocument();
+    },
+};
+
+export const Connecting: Story = {
+    decorators: [
+        withClusterState({ cluster: Cluster.Custom, customUrl: CUSTOM_RPC_URL, status: ClusterStatus.Connecting }),
+    ],
+};
+
+export const Failure: Story = {
+    decorators: [
+        withClusterState({ cluster: Cluster.Custom, customUrl: CUSTOM_RPC_URL, status: ClusterStatus.Failure }),
+    ],
+};

--- a/app/components/__stories__/Navbar.stories.tsx
+++ b/app/components/__stories__/Navbar.stories.tsx
@@ -1,5 +1,6 @@
-import { nextjsParameters, withCluster } from '@storybook-config/decorators';
+import { nextjsParameters, withCluster, withClusterState } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
+import { Cluster, ClusterStatus } from '@utils/cluster';
 
 import { Navbar } from '../Navbar';
 
@@ -24,4 +25,14 @@ export const WithChildren: Story = {
     args: {
         children: <div className="text-dk-gray-700">Page-level slot content (e.g., breadcrumbs)</div>,
     },
+};
+
+export const WithCustomRpcUrl: Story = {
+    decorators: [
+        withClusterState({
+            cluster: Cluster.Custom,
+            customUrl: 'https://random-helius-fast-mainnet.helius-rpc.com',
+            status: ClusterStatus.Connected,
+        }),
+    ],
 };


### PR DESCRIPTION
## Description

Long cluster names (e.g custom RPC URLs) overflowed the navbar. This PR limits the cluster button width in header on Desktop and truncates the label.
- Add truncate to `ClusterStatusButton`.
- Cap the navbar cluster-button wrapper at max-w-[210px] on lg screens, so long urls are truncated and stay on the same one line in header.
- Add Storybook tests.

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix

## Screenshots

### Desktop
<img width="1130" height="72" alt="image" src="https://github.com/user-attachments/assets/b5b8a253-3f8b-4eb4-94a2-05352cec08c4" />

<img width="1109" height="67" alt="image" src="https://github.com/user-attachments/assets/2085e006-a70d-4d68-8b1d-3f45b669373e" />


### Mobile
<img width="676" height="249" alt="image" src="https://github.com/user-attachments/assets/5e8e8578-2b22-436e-aa11-ef02e559db6e" />

<img width="646" height="230" alt="image" src="https://github.com/user-attachments/assets/86004ed8-45e0-4bc4-8a44-5ddadc8dd50c" />


## Testing

- Select custom rpc url and input url.
- Long urls should be truncated, others stay the same.

## Related Issues

Closes [HOO-872](https://linear.app/solana-fndn/issue/HOO-872/fix-button-sizing-for-large-addresses)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes