### PR TITLE
feat: add verified builds for devnet

### DIFF
--- a/app/components/common/VerifiedProgramBadge.tsx
+++ b/app/components/common/VerifiedProgramBadge.tsx
@@ -4,9 +4,8 @@ import Link from 'next/link';
 import { Badge } from '@/app/components/shared/ui/badge';
 import { useCluster } from '@/app/providers/cluster';
 import { CardTitle } from '@/app/shared/ui/Card';
-import { Cluster } from '@/app/utils/cluster';
 import { useClusterPath } from '@/app/utils/url';
-import { useIsProgramVerified } from '@/app/utils/verified-builds';
+import { supportsVerifiedBuilds, useIsProgramVerified } from '@/app/utils/verified-builds';
 import { ProgramDataAccountInfo } from '@/app/validators/accounts/upgradeable-program';
 
 type BadgeVariant = NonNullable<Parameters<typeof Badge>[0]['variant']>;
@@ -29,11 +28,11 @@ export function VerifiedProgramBadge({
     });
     const verifiedBuildTabPath = useClusterPath({ pathname: `/address/${pubkey.toBase58()}/verified-build` });
 
-    if (cluster !== Cluster.MainnetBeta) {
+    if (!supportsVerifiedBuilds(cluster)) {
         return (
             <CardTitle as="h3" ui="dashkit">
                 <Badge ui="dashkit" variant="warning">
-                    Verified Builds only available on Mainnet
+                    Verified Builds only available on Mainnet and Devnet
                 </Badge>
             </CardTitle>
         );

--- a/app/components/common/__stories__/VerifiedProgramBadge.stories.tsx
+++ b/app/components/common/__stories__/VerifiedProgramBadge.stories.tsx
@@ -23,12 +23,17 @@ const expectedHash = hashProgramData(programData);
 
 type OsecOutcome = 'verified' | 'unverified' | 'loading' | 'error';
 
+// Matches any OSEC registry request (mainnet verify.osec.io + devnet verify-devnet.osec.io).
+function isOsecRequest(input: RequestInfo | URL): boolean {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    return url.includes('osec.io');
+}
+
 const withMockedOsec = (outcome: OsecOutcome, state?: ClusterState): Decorator =>
     function WithMockedOsec(Story) {
         const originalFetch = window.fetch;
         window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-            const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-            if (!url.includes('osec.io')) return originalFetch(input as any, init);
+            if (!isOsecRequest(input)) return originalFetch(input as any, init);
             if (outcome === 'loading') return new Promise<Response>(() => {});
             if (outcome === 'error') throw new Error('mocked OSEC failure');
             return new Response(JSON.stringify({ is_verified: outcome === 'verified', on_chain_hash: expectedHash }), {

--- a/app/components/common/__stories__/VerifiedProgramBadge.stories.tsx
+++ b/app/components/common/__stories__/VerifiedProgramBadge.stories.tsx
@@ -23,12 +23,12 @@ const expectedHash = hashProgramData(programData);
 
 type OsecOutcome = 'verified' | 'unverified' | 'loading' | 'error';
 
-const withMockedOsec = (outcome: OsecOutcome): Decorator =>
+const withMockedOsec = (outcome: OsecOutcome, state?: ClusterState): Decorator =>
     function WithMockedOsec(Story) {
         const originalFetch = window.fetch;
         window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
             const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-            if (!url.includes('verify.osec.io')) return originalFetch(input as any, init);
+            if (!url.includes('osec.io')) return originalFetch(input as any, init);
             if (outcome === 'loading') return new Promise<Response>(() => {});
             if (outcome === 'error') throw new Error('mocked OSEC failure');
             return new Response(JSON.stringify({ is_verified: outcome === 'verified', on_chain_hash: expectedHash }), {
@@ -38,7 +38,7 @@ const withMockedOsec = (outcome: OsecOutcome): Decorator =>
         }) as typeof window.fetch;
         return (
             <SWRConfig value={{ provider: () => new Map() }}>
-                <MockClusterProvider>
+                <MockClusterProvider state={state}>
                     <Story />
                 </MockClusterProvider>
             </SWRConfig>
@@ -51,8 +51,14 @@ const devnetState: ClusterState = {
     status: ClusterStatus.Connected,
 };
 
-const withDevnet: Decorator = Story => (
-    <MockClusterProvider state={devnetState}>
+const testnetState: ClusterState = {
+    cluster: Cluster.Testnet,
+    customUrl: 'https://api.testnet.solana.com',
+    status: ClusterStatus.Connected,
+};
+
+const withUnsupportedCluster: Decorator = Story => (
+    <MockClusterProvider state={testnetState}>
         <Story />
     </MockClusterProvider>
 );
@@ -68,13 +74,19 @@ const meta: Meta<typeof VerifiedProgramBadge> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Cluster guard short-circuits before any RPC; exercises `badge bg-warning-soft rank`.
-export const NonMainnet: Story = {
-    decorators: [withDevnet],
+// Cluster guard short-circuits before any RPC on clusters without an OSEC registry
+// (here: Testnet); exercises `badge bg-warning-soft rank`.
+export const UnsupportedCluster: Story = {
+    decorators: [withUnsupportedCluster],
 };
 
 export const Verified: Story = {
     decorators: [withMockedOsec('verified')],
+};
+
+// Devnet is a supported cluster: the badge resolves against verify-devnet.osec.io.
+export const DevnetVerified: Story = {
+    decorators: [withMockedOsec('verified', devnetState)],
 };
 
 export const NotVerified: Story = {

--- a/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
+++ b/app/components/common/__tests__/VerifiedProgramBadge.spec.tsx
@@ -15,8 +15,9 @@ vi.mock('@/app/utils/url', () => ({
     useClusterPath: vi.fn(() => '/address/mock/verified-build'),
 }));
 
-// Mock the useIsProgramVerified hook
-vi.mock('@/app/utils/verified-builds', () => ({
+// Mock only the useIsProgramVerified hook; keep the real cluster-support helpers.
+vi.mock('@/app/utils/verified-builds', async importOriginal => ({
+    ...(await importOriginal<typeof import('@/app/utils/verified-builds')>()),
     useIsProgramVerified: vi.fn(),
 }));
 
@@ -75,5 +76,27 @@ describe('VerifiedProgramBadge (mocked useIsProgramVerified)', () => {
         });
         render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
         expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    });
+
+    it('should show the verified badge on devnet (a supported cluster)', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.Devnet });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: true,
+            error: false,
+            isLoading: false,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/Program Source Verified/i)).toBeInTheDocument();
+    });
+
+    it('should show the unsupported-cluster notice on testnet', () => {
+        (useCluster as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ cluster: Cluster.Testnet });
+        (useIsProgramVerified as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: false,
+            error: false,
+            isLoading: false,
+        });
+        render(<VerifiedProgramBadge programData={mockProgramData} pubkey={mockPubkey} />);
+        expect(screen.getByText(/only available on Mainnet and Devnet/i)).toBeInTheDocument();
     });
 });

--- a/app/features/search/model/verified-programs-search-provider.ts
+++ b/app/features/search/model/verified-programs-search-provider.ts
@@ -20,8 +20,8 @@ const programs: VerifiedProgramEntry[] = verifiedPrograms as VerifiedProgramEntr
  *
  * Searches against a pre-built JSON file of verified programs (updated daily
  * via GitHub Action). Matches program name or address, and marks results as
- * verified. Only returns results on mainnet since verification data is
- * mainnet-only.
+ * verified. Only returns results on mainnet: the pre-built snapshot covers
+ * mainnet programs, even though OSEC also verifies builds on devnet.
  */
 export const verifiedProgramsSearchProvider: SearchProvider = {
     kind: 'local',

--- a/app/utils/__tests__/verified-builds.spec.ts
+++ b/app/utils/__tests__/verified-builds.spec.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from 'vitest';
 import { Cluster } from '../cluster';
 import {
     buildEnrichedOsecInfo,
+    getOsecRegistryUrl,
     hashProgramBuffer,
     hashProgramData,
     type OsecInfo,
+    supportsVerifiedBuilds,
     VerificationStatus,
 } from '../verified-builds';
 
@@ -173,6 +175,30 @@ describe('hashProgramBuffer', () => {
     });
 });
 
+describe('getOsecRegistryUrl', () => {
+    it('should return the mainnet registry for Mainnet Beta', () => {
+        expect(getOsecRegistryUrl(Cluster.MainnetBeta)).toBe('https://verify.osec.io');
+    });
+
+    it('should return the devnet registry for Devnet', () => {
+        expect(getOsecRegistryUrl(Cluster.Devnet)).toBe('https://verify-devnet.osec.io');
+    });
+
+    it('should return undefined for clusters without a registry', () => {
+        expect(getOsecRegistryUrl(Cluster.Testnet)).toBeUndefined();
+        expect(getOsecRegistryUrl(Cluster.Custom)).toBeUndefined();
+    });
+});
+
+describe('supportsVerifiedBuilds', () => {
+    it('should support Mainnet Beta and Devnet only', () => {
+        expect(supportsVerifiedBuilds(Cluster.MainnetBeta)).toBe(true);
+        expect(supportsVerifiedBuilds(Cluster.Devnet)).toBe(true);
+        expect(supportsVerifiedBuilds(Cluster.Testnet)).toBe(false);
+        expect(supportsVerifiedBuilds(Cluster.Custom)).toBe(false);
+    });
+});
+
 describe('buildEnrichedOsecInfo', () => {
     const PROGRAM_ID = new PublicKey('BUYuxRfhCMWavaUWxhGtPP3ksKEDZxCD5gzknk3JfAya');
     const FOUNDATION_SIGNER = '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r';
@@ -231,14 +257,36 @@ describe('buildEnrichedOsecInfo', () => {
         expect(info.verify_command).toBe('Program does not have a verify PDA uploaded.');
     });
 
-    it('should note the verify command is mainnet-only off mainnet when the PDA is unavailable', () => {
+    it('should compose the verify command with the devnet moniker (-ud) from the PDA', () => {
+        const info = buildEnrichedOsecInfo({
+            cluster: Cluster.Devnet,
+            osecInfo: makeOsecInfo(),
+            pdaData: PDA,
+            programId: PROGRAM_ID,
+        });
+        expect(info.verify_command).toBe(
+            'solana-verify verify-from-repo -ud --program-id BUYuxRfhCMWavaUWxhGtPP3ksKEDZxCD5gzknk3JfAya https://github.com/Woody4618/bar --commit-hash 07e3f708df2b9483426515bf3bcd8065c57f7a79 --library-name let_me_buy',
+        );
+    });
+
+    it('should report a missing PDA on devnet the same way as mainnet', () => {
         const info = buildEnrichedOsecInfo({
             cluster: Cluster.Devnet,
             osecInfo: makeOsecInfo(),
             pdaData: null,
             programId: PROGRAM_ID,
         });
-        expect(info.verify_command).toBe('Verify command only available on mainnet.');
+        expect(info.verify_command).toBe('Program does not have a verify PDA uploaded.');
+    });
+
+    it('should note the verify command is unavailable on clusters without a registry', () => {
+        const info = buildEnrichedOsecInfo({
+            cluster: Cluster.Testnet,
+            osecInfo: makeOsecInfo(),
+            pdaData: null,
+            programId: PROGRAM_ID,
+        });
+        expect(info.verify_command).toBe('Verify command not available on this cluster.');
     });
 
     it('should label a frozen, non-trusted signer as the program deployer', () => {

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -13,7 +13,24 @@ import { Cluster } from './cluster';
 import { composeOnchainRepoUrl, normalizeRepoUrl, safeRepoUrl } from './verified-builds-url';
 
 const OSEC_REGISTRY_URL = 'https://verify.osec.io';
+const OSEC_DEVNET_REGISTRY_URL = 'https://verify-devnet.osec.io';
 const VERIFY_PROGRAM_ID = 'verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC';
+
+export function supportsVerifiedBuilds(cluster: Cluster): boolean {
+    return getOsecRegistryUrl(cluster) !== undefined;
+}
+
+// OSEC hosts a separate verified-builds registry per cluster; Testnet/Custom/SIMD-296 have none.
+export function getOsecRegistryUrl(cluster: Cluster): string | undefined {
+    switch (cluster) {
+        case Cluster.MainnetBeta:
+            return OSEC_REGISTRY_URL;
+        case Cluster.Devnet:
+            return OSEC_DEVNET_REGISTRY_URL;
+        default:
+            return undefined;
+    }
+}
 
 export enum VerificationStatus {
     Verified = 'Verified Build',
@@ -79,14 +96,17 @@ export function useVerifiedProgramRegistry({
     options?: { suspense: boolean };
     programData?: ProgramDataAccountInfo;
 }) {
+    const { cluster } = useCluster();
+    const registryUrl = getOsecRegistryUrl(cluster);
     const {
         data: registryData,
         error: registryError,
         isLoading: isRegistryLoading,
     } = useSWRImmutable(
-        `${programId.toBase58()}`,
-        async (programId: string) => {
-            const response = await fetch(`${OSEC_REGISTRY_URL}/status-all/${programId}`);
+        // The full URL is the cache key so Mainnet and Devnet never share an entry.
+        registryUrl ? `${registryUrl}/status-all/${programId.toBase58()}` : null,
+        async (url: string) => {
+            const response = await fetch(url);
 
             return response.json() as Promise<OsecInfo[]>;
         },
@@ -152,14 +172,24 @@ export function useIsProgramVerified({
     programId: PublicKey;
     programData: ProgramDataAccountInfo;
 }) {
+    const { cluster } = useCluster();
+    const registryUrl = getOsecRegistryUrl(cluster);
     return useSWRImmutable(
-        ['is-program-verified', programId.toBase58(), hashProgramData(programData), programData.authority],
-        async ([_prefix, programId, hash]) => {
+        registryUrl
+            ? [
+                  'is-program-verified',
+                  registryUrl,
+                  programId.toBase58(),
+                  hashProgramData(programData),
+                  programData.authority,
+              ]
+            : null,
+        async ([_prefix, base, programId, hash]) => {
             if (!programId) {
                 return false;
             }
 
-            const response = await fetch(`${OSEC_REGISTRY_URL}/status/${programId}`);
+            const response = await fetch(`${base}/status/${programId}`);
             const osecInfo = (await response.json()) as OsecInfo;
 
             // Cross-check the on-chain hash to stay consistent with useVerifiedProgramRegistry
@@ -337,15 +367,17 @@ export function buildEnrichedOsecInfo({
               ? VerificationStatus.PdaUploaded
               : VerificationStatus.NotVerified,
         verify_command: pdaData
-            ? coalesceCommandFromPda(programId, pdaData)
-            : isMainnet(cluster)
+            ? coalesceCommandFromPda(programId, pdaData, cluster)
+            : supportsVerifiedBuilds(cluster)
               ? 'Program does not have a verify PDA uploaded.'
-              : 'Verify command only available on mainnet.',
+              : 'Verify command not available on this cluster.',
     };
 }
 
-function coalesceCommandFromPda(programId: PublicKey, pdaData: OtterVerifyBuildParams) {
-    let verify_command = `solana-verify verify-from-repo -um --program-id ${programId.toBase58()} ${pdaData.gitUrl}`;
+function coalesceCommandFromPda(programId: PublicKey, pdaData: OtterVerifyBuildParams, cluster: Cluster) {
+    // solana-verify targets a cluster with the URL moniker: -ud for Devnet, -um for Mainnet.
+    const clusterFlag = cluster === Cluster.Devnet ? '-ud' : '-um';
+    let verify_command = `solana-verify verify-from-repo ${clusterFlag} --program-id ${programId.toBase58()} ${pdaData.gitUrl}`;
 
     if (pdaData.commit) {
         verify_command += ` --commit-hash ${pdaData.commit}`;
@@ -357,10 +389,6 @@ function coalesceCommandFromPda(programId: PublicKey, pdaData: OtterVerifyBuildP
         verify_command += ` ${argsString}`;
     }
     return verify_command;
-}
-
-function isMainnet(currentCluster: Cluster): boolean {
-    return currentCluster == Cluster.MainnetBeta;
 }
 
 // Helper function to hash program data

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -103,10 +103,10 @@ export function useVerifiedProgramRegistry({
         error: registryError,
         isLoading: isRegistryLoading,
     } = useSWRImmutable(
-        // The full URL is the cache key so Mainnet and Devnet never share an entry.
-        registryUrl ? `${registryUrl}/status-all/${programId.toBase58()}` : null,
-        async (url: string) => {
-            const response = await fetch(url);
+        // The registry URL is part of the key so Mainnet and Devnet never share an entry.
+        registryUrl ? ['status-all', registryUrl, programId.toBase58()] : null,
+        async ([_prefix, base, id]) => {
+            const response = await fetch(`${base}/status-all/${id}`);
 
             return response.json() as Promise<OsecInfo[]>;
         },

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -269,8 +269,11 @@ function useEnrichedOsecInfo({
         error: pdaError,
         isLoading: isPdaLoading,
     } = useSWRImmutable(
+        // Scope the key by RPC endpoint: the PDA is an on-chain account that differs per cluster, and
+        // useSWRImmutable never revalidates — without this, switching Mainnet<->Devnet would reuse the
+        // other cluster's PDA and pair it with the wrong -um/-ud verify command.
         accountAnchorProgram && osecInfo && signerAuthorities.length > 0
-            ? `pda-${programId.toBase58()}-${signerAuthorities.map(x => x.toBase58()).join(',')}`
+            ? `pda-${clusterUrl}-${programId.toBase58()}-${signerAuthorities.map(x => x.toBase58()).join(',')}`
             : null,
         async () => {
             if (!osecInfo || !accountAnchorProgram) {

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -27,7 +27,7 @@
 | Dynamic | `/address/[address]/subscriptions` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/token-extensions` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/tokens` | 380 kB | 1.40 MB |
-| Dynamic | `/address/[address]/transfers` | 370 kB | 1.40 MB |
+| Dynamic | `/address/[address]/transfers` | 380 kB | 1.40 MB |
 | Dynamic | `/address/[address]/verified-build` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/vote-history` | 370 kB | 1.39 MB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |


### PR DESCRIPTION
## Description

OSEC now hosts a verified-builds registry for devnet (`https://verify-devnet.osec.io`). This wires the explorer's verified-build UI to query the correct registry per cluster, so verified builds now work on **Devnet** as well as **Mainnet**.

- Added `getOsecRegistryUrl(cluster)` — returns the mainnet registry for Mainnet, the devnet registry for Devnet, and `undefined` for clusters with no registry (Testnet/Custom/SIMD-296) — plus a `supportsVerifiedBuilds(cluster)` predicate.
- `useVerifiedProgramRegistry` and `useIsProgramVerified` now select the registry URL by cluster. The full URL is the SWR cache key, so Mainnet and Devnet never share a cached entry; on unsupported clusters no request is made.
- The generated `solana-verify` command uses the correct cluster moniker: `-ud` on Devnet, `-um` on Mainnet.
- `VerifiedProgramBadge` now renders on Mainnet and Devnet; the fallback notice reads "only available on Mainnet and Devnet".

The verified-programs **search autocomplete** stays Mainnet-only: it reads a pre-built snapshot (`public/verified-programs.json`) generated by a daily GitHub Action against Mainnet. Extending it to Devnet needs a separate snapshot + CI job + a `DEVNET_RPC_URL` secret — tracked as follow-up, not in this PR.

## Type of change

-   [x] New feature

## Testing

Manual testing on the preview deployment:

- [Devnet program page — badge queries `verify-devnet.osec.io` (previously the "only available on Mainnet" block)](https://explorer-git-fork-hoodieshq-feat-add-v-9f882a-solana-foundation.vercel.app/address/HnbLDGALwWtMHYFYrcCwz5vHAtWXcnZKT6iKBibZvyiP?cluster=devnet)
- [Devnet verified-build tab — resolved against the devnet registry](https://explorer-git-fork-hoodieshq-feat-add-v-9f882a-solana-foundation.vercel.app/address/HnbLDGALwWtMHYFYrcCwz5vHAtWXcnZKT6iKBibZvyiP/verified-build?cluster=devnet)
- [Testnet — "only available on Mainnet and Devnet" guard](https://explorer-git-fork-hoodieshq-feat-add-v-9f882a-solana-foundation.vercel.app/address/HnbLDGALwWtMHYFYrcCwz5vHAtWXcnZKT6iKBibZvyiP?cluster=testnet)
- [Mainnet verified card (unchanged) — full card with the `-um` verify command](https://explorer-git-fork-hoodieshq-feat-add-v-9f882a-solana-foundation.vercel.app/address/BUYuxRfhCMWavaUWxhGtPP3ksKEDZxCD5gzknk3JfAya/verified-build)

## Related Issues

Closes [HOO-871](https://linear.app/solana-fndn/issue/HOO-871/add-verified-builds-for-devnet)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

The OSEC devnet registry is **live but currently reports zero verified programs**: 218 programs have uploaded Otter Verify PDAs on-chain (`solana-verify … -ud`), but the devnet backend returns `is_verified: false` (empty `on_chain_hash`) for all of them — its build-and-compare pipeline has not populated devnet results yet. This client change is correct and will surface verified cards the moment OSEC populates the registry, with no further code change. The preview links above therefore exercise the wiring and the not-verified path; a green verified card on devnet is not yet reproducible.

Per the template note: Verified Builds bugs should be reported to disclosures@solana.org.


