### PR TITLE
feat(verified-builds): resolve program buffer builds via OSEC resolve-hash

### DIFF
--- a/app/components/account/BufferBuildCard.tsx
+++ b/app/components/account/BufferBuildCard.tsx
@@ -20,7 +20,12 @@ import {
     supportsVerifiedBuilds,
     useResolveBuildsByHash,
 } from '@/app/utils/verified-builds';
-import { composeOnchainRepoUrl, repoLabel, trimTrailingSlashes } from '@/app/utils/verified-builds-url';
+import {
+    composeOnchainRepoUrl,
+    repoLabel,
+    trimTrailingSlashes,
+    VERIFIED_BUILDS_GUIDE_URL,
+} from '@/app/utils/verified-builds-url';
 import { ProgramBufferAccountInfo } from '@/app/validators/accounts/upgradeable-program';
 
 import { Address } from '../common/Address';
@@ -90,7 +95,7 @@ export function BaseBufferBuildCard({
             <Card ui="dashkit">
                 <CardBody ui="dashkit" className="text-center">
                     No verified builds found for this buffer&apos;s binary. For more information, see the{' '}
-                    <Link href="https://solana.com/developers/guides/advanced/verified-builds" target="_blank">
+                    <Link href={VERIFIED_BUILDS_GUIDE_URL} target="_blank">
                         Verified Build Guide
                     </Link>
                     .
@@ -110,11 +115,7 @@ export function BaseBufferBuildCard({
             <Alert className="mb-1.5 mt-1.5">
                 These are completed builds whose compiled output matches this buffer&apos;s binary. A match does not
                 imply that the program has been audited. For more details, refer to the{' '}
-                <a
-                    href="https://solana.com/developers/guides/advanced/verified-builds"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
+                <a href={VERIFIED_BUILDS_GUIDE_URL} target="_blank" rel="noopener noreferrer">
                     Verified Builds Guide <ExternalLink className="ml-[3px] align-text-top" size={13} />
                 </a>
                 .

--- a/app/components/account/BufferBuildCard.tsx
+++ b/app/components/account/BufferBuildCard.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { ErrorCard } from '@components/common/ErrorCard';
+import { TableCardBodyHeaded } from '@components/common/TableCardBody';
+import { PublicKey } from '@solana/web3.js';
+import Link from 'next/link';
+import React, { Fragment, useState } from 'react';
+import { ExternalLink } from 'react-feather';
+
+import { Badge } from '@/app/components/shared/ui/badge';
+import { Alert } from '@/app/shared/ui/Alert';
+import { Card, CardBody, CardHeader, CardTitle } from '@/app/shared/ui/Card';
+import { ExpandInfoButton } from '@/app/shared/ui/ExpandInfoButton';
+import { BaseTable } from '@/app/shared/ui/Table';
+import {
+    dedupeAndSortBuilds,
+    hashProgramBuffer,
+    type OsecBuild,
+    useResolveBuildsByHash,
+} from '@/app/utils/verified-builds';
+import { composeOnchainRepoUrl, repoLabel, trimTrailingSlashes } from '@/app/utils/verified-builds-url';
+import { ProgramBufferAccountInfo } from '@/app/validators/accounts/upgradeable-program';
+
+import { Address } from '../common/Address';
+import { Copyable } from '../common/Copyable';
+import { LoadingCard } from '../common/LoadingCard';
+
+// Total column count (incl. the mobile-only toggle) for the expanded detail row's colSpan.
+const COLUMN_COUNT = 7;
+
+// Container: resolves the builds that produced a program buffer's staged binary and renders them.
+// A buffer has no program id to look up in the OSEC registry, so we hash its bytes with the same
+// `hashProgramBuffer` used elsewhere and resolve that hash against `/resolve-hash`.
+export function BufferBuildCard({ buffer }: { buffer: ProgramBufferAccountInfo; pubkey: PublicKey }) {
+    const bufferHash = React.useMemo(() => hashProgramBuffer(buffer), [buffer]);
+    const { data, error, isLoading } = useResolveBuildsByHash(bufferHash);
+
+    return (
+        <BaseBufferBuildCard
+            builds={data?.builds}
+            bufferHash={bufferHash}
+            isLoading={isLoading}
+            error={Boolean(error)}
+        />
+    );
+}
+
+// Presentational split so stories/tests drive every state without the network.
+export function BaseBufferBuildCard({
+    builds,
+    bufferHash,
+    isLoading,
+    error,
+}: {
+    builds: OsecBuild[] | undefined;
+    bufferHash: string | undefined;
+    isLoading: boolean;
+    error: boolean;
+}) {
+    if (isLoading) {
+        return <LoadingCard message="Resolving buffer build hash" />;
+    }
+
+    if (error) {
+        return <ErrorCard text="Error loading buffer build information" />;
+    }
+
+    const orderedBuilds = builds ? dedupeAndSortBuilds(builds) : [];
+
+    if (!bufferHash || orderedBuilds.length === 0) {
+        return (
+            <Card ui="dashkit">
+                <CardBody ui="dashkit" className="text-center">
+                    No verified builds found for this buffer&apos;s binary. For more information, see the{' '}
+                    <Link href="https://solana.com/developers/guides/advanced/verified-builds" target="_blank">
+                        Verified Build Guide
+                    </Link>
+                    .
+                </CardBody>
+            </Card>
+        );
+    }
+
+    return (
+        <Card ui="dashkit">
+            <CardHeader ui="dashkit">
+                <CardTitle as="h3" ui="dashkit" className="flex items-center">
+                    Buffer Build
+                </CardTitle>
+                <small>Information provided by osec.io</small>
+            </CardHeader>
+            <Alert className="mb-1.5 mt-1.5">
+                These are completed builds whose compiled output matches this buffer&apos;s binary. A match does not
+                imply that the program has been audited. For more details, refer to the{' '}
+                <a
+                    href="https://solana.com/developers/guides/advanced/verified-builds"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Verified Builds Guide <ExternalLink className="ml-[3px] align-text-top" size={13} />
+                </a>
+                .
+            </Alert>
+            <TableCardBodyHeaded layout="expanded" headerComponent={<BufferBuildHeader />}>
+                {orderedBuilds.map(build => (
+                    <BufferBuildRow key={build.build_id} build={build} />
+                ))}
+            </TableCardBodyHeaded>
+        </Card>
+    );
+}
+
+// `hidden lg:table-cell` columns collapse on small screens; their content reappears inside the
+// expandable detail row below. The trailing toggle column is the inverse (`lg:hidden`) so it only
+// shows on the small-screen layout where expansion is needed.
+function BufferBuildHeader() {
+    return (
+        <BaseTable.Row>
+            <BaseTable.HeaderCell className="whitespace-nowrap">Program</BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="whitespace-nowrap">Repository</BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="hidden whitespace-nowrap lg:table-cell">Commit</BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="hidden whitespace-nowrap lg:table-cell">Trusted</BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="hidden whitespace-nowrap lg:table-cell">
+                Matches Deployed
+            </BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="hidden whitespace-nowrap text-right lg:table-cell">
+                Date
+            </BaseTable.HeaderCell>
+            <BaseTable.HeaderCell className="w-10 lg:hidden" aria-label="Toggle details" />
+        </BaseTable.Row>
+    );
+}
+
+function BufferBuildRow({ build }: { build: OsecBuild }) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const detailId = `buffer-build-detail-${build.build_id}`;
+
+    return (
+        <Fragment>
+            <BaseTable.Row>
+                <BaseTable.Cell className="whitespace-nowrap">
+                    <Address pubkey={new PublicKey(build.program_id)} link />
+                </BaseTable.Cell>
+                <BaseTable.Cell className="[overflow-wrap:anywhere]">
+                    <RepositoryContent build={build} />
+                </BaseTable.Cell>
+                <BaseTable.Cell className="hidden whitespace-nowrap lg:table-cell">
+                    <CommitContent commit={build.commit} />
+                </BaseTable.Cell>
+                <BaseTable.Cell className="hidden whitespace-nowrap lg:table-cell">
+                    <TrustedBadge value={build.trusted} />
+                </BaseTable.Cell>
+                <BaseTable.Cell className="hidden whitespace-nowrap lg:table-cell">
+                    <MatchesDeployedBadge value={build.matches_deployed} />
+                </BaseTable.Cell>
+                <BaseTable.Cell className="hidden whitespace-nowrap text-right font-mono lg:table-cell">
+                    {formatCompletedAt(build.completed_at)}
+                </BaseTable.Cell>
+                <BaseTable.Cell className="text-right lg:hidden">
+                    <ExpandInfoButton
+                        isExpanded={isExpanded}
+                        onToggle={() => setIsExpanded(prev => !prev)}
+                        controlsId={detailId}
+                    />
+                </BaseTable.Cell>
+            </BaseTable.Row>
+            {isExpanded && (
+                <BaseTable.Row className="lg:hidden">
+                    <BaseTable.Cell colSpan={COLUMN_COUNT} className="bg-dk-gray-900-dark/40">
+                        <div id={detailId} className="flex flex-col gap-2">
+                            <DetailItem label="Commit">
+                                <CommitContent commit={build.commit} />
+                            </DetailItem>
+                            <DetailItem label="Trusted">
+                                <TrustedBadge value={build.trusted} />
+                            </DetailItem>
+                            <DetailItem label="Matches Deployed">
+                                <MatchesDeployedBadge value={build.matches_deployed} />
+                            </DetailItem>
+                            <DetailItem label="Date">
+                                <span className="font-mono">{formatCompletedAt(build.completed_at)}</span>
+                            </DetailItem>
+                        </div>
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
+        </Fragment>
+    );
+}
+
+// A label/value pair for the small-screen expanded detail, mirroring the hidden desktop columns.
+function DetailItem({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="text-dark-muted-foreground">{label}</span>
+            <span className="text-right">{children}</span>
+        </div>
+    );
+}
+
+function RepositoryContent({ build }: { build: OsecBuild }) {
+    // Trim trailing slashes so the composed `<repo>/tree/<sha>` link has no double slash; repoLabel
+    // renders a compact display label (`.../v4` not `https://.../v4/`).
+    const repoUrl = composeOnchainRepoUrl(trimTrailingSlashes(build.repository), build.commit);
+    const label = repoLabel(build.repository);
+
+    if (repoUrl) {
+        return (
+            <a className="font-mono" href={repoUrl} target="_blank" rel="noopener noreferrer">
+                {label}
+                <ExternalLink className="ml-1.5 inline-block align-text-top" size={13} />
+            </a>
+        );
+    }
+    return <span className="font-mono">{label || '-'}</span>;
+}
+
+function CommitContent({ commit }: { commit: string }) {
+    if (!commit) return <>-</>;
+    return (
+        <Copyable text={commit}>
+            <span className="font-mono">{commit.slice(0, 7)}</span>
+        </Copyable>
+    );
+}
+
+function TrustedBadge({ value }: { value: boolean }) {
+    return (
+        <Badge ui="dashkit" variant={value ? 'success' : 'secondary'}>
+            {String(value)}
+        </Badge>
+    );
+}
+
+function MatchesDeployedBadge({ value }: { value: boolean }) {
+    return (
+        <Badge ui="dashkit" variant={value ? 'success' : 'warning'}>
+            {String(value)}
+        </Badge>
+    );
+}
+
+function formatCompletedAt(completedAt: string): string {
+    return new Date(completedAt).toUTCString();
+}

--- a/app/components/account/BufferBuildCard.tsx
+++ b/app/components/account/BufferBuildCard.tsx
@@ -8,6 +8,7 @@ import React, { Fragment, useState } from 'react';
 import { ExternalLink } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
+import { useCluster } from '@/app/providers/cluster';
 import { Alert } from '@/app/shared/ui/Alert';
 import { Card, CardBody, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { ExpandInfoButton } from '@/app/shared/ui/ExpandInfoButton';
@@ -16,6 +17,7 @@ import {
     dedupeAndSortBuilds,
     hashProgramBuffer,
     type OsecBuild,
+    supportsVerifiedBuilds,
     useResolveBuildsByHash,
 } from '@/app/utils/verified-builds';
 import { composeOnchainRepoUrl, repoLabel, trimTrailingSlashes } from '@/app/utils/verified-builds-url';
@@ -32,6 +34,7 @@ const COLUMN_COUNT = 7;
 // A buffer has no program id to look up in the OSEC registry, so we hash its bytes with the same
 // `hashProgramBuffer` used elsewhere and resolve that hash against `/resolve-hash`.
 export function BufferBuildCard({ buffer }: { buffer: ProgramBufferAccountInfo; pubkey: PublicKey }) {
+    const { cluster } = useCluster();
     const bufferHash = React.useMemo(() => hashProgramBuffer(buffer), [buffer]);
     const { data, error, isLoading } = useResolveBuildsByHash(bufferHash);
 
@@ -41,6 +44,7 @@ export function BufferBuildCard({ buffer }: { buffer: ProgramBufferAccountInfo; 
             bufferHash={bufferHash}
             isLoading={isLoading}
             error={Boolean(error)}
+            clusterSupported={supportsVerifiedBuilds(cluster)}
         />
     );
 }
@@ -51,12 +55,26 @@ export function BaseBufferBuildCard({
     bufferHash,
     isLoading,
     error,
+    // OSEC hosts no registry for Testnet/Custom, so no resolve-hash lookup happens there. Defaults
+    // to true so stories and tests that exercise the build states need not opt in.
+    clusterSupported = true,
 }: {
     builds: OsecBuild[] | undefined;
     bufferHash: string | undefined;
     isLoading: boolean;
     error: boolean;
+    clusterSupported?: boolean;
 }) {
+    if (!clusterSupported) {
+        return (
+            <Card ui="dashkit">
+                <CardBody ui="dashkit" className="text-center">
+                    Verified Builds only available on Mainnet and Devnet.
+                </CardBody>
+            </Card>
+        );
+    }
+
     if (isLoading) {
         return <LoadingCard message="Resolving buffer build hash" />;
     }

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -10,6 +10,7 @@ import { Alert } from '@/app/shared/ui/Alert';
 import { Card, CardBody, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
 import { OsecRegistryInfo, useVerifiedProgram, VerificationStatus } from '@/app/utils/verified-builds';
+import { VERIFIED_BUILDS_GUIDE_URL } from '@/app/utils/verified-builds-url';
 
 import { Address } from '../common/Address';
 import { Copyable } from '../common/Copyable';
@@ -61,7 +62,7 @@ export function BaseVerifiedBuildCard({
             <Card ui="dashkit">
                 <CardBody ui="dashkit" className="text-center">
                     Verified build information not yet uploaded by the program authority. For more information, see the{' '}
-                    <Link href="https://solana.com/developers/guides/advanced/verified-builds" target="_blank">
+                    <Link href={VERIFIED_BUILDS_GUIDE_URL} target="_blank">
                         Verified Build Guide
                     </Link>
                     .<br />
@@ -95,11 +96,7 @@ export function BaseVerifiedBuildCard({
             <Alert className="mb-1.5 mt-1.5">
                 A verified build badge indicates that this program was built from source code that is publicly
                 available, but does not imply that this program has been audited. For more details, refer to the{' '}
-                <a
-                    href="https://solana.com/developers/guides/advanced/verified-builds"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
+                <a href={VERIFIED_BUILDS_GUIDE_URL} target="_blank" rel="noopener noreferrer">
                     Verified Builds Guide <ExternalLink className="ml-[3px] align-text-top" size={13} />
                 </a>
                 .

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -14,8 +14,20 @@ import { OsecRegistryInfo, useVerifiedProgram, VerificationStatus } from '@/app/
 import { Address } from '../common/Address';
 import { Copyable } from '../common/Copyable';
 import { LoadingCard } from '../common/LoadingCard';
+import { BufferBuildCard } from './BufferBuildCard';
 
 export function VerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAccountData; pubkey: PublicKey }) {
+    // A program buffer stages a binary that is not yet deployed, so it has no program id to look up
+    // in the OSEC registry. Resolve its buffer hash to the source build(s) that produced it instead.
+    // Each branch renders a distinct component, so neither calls a hook conditionally.
+    if (data.parsed.type === 'buffer') {
+        return <BufferBuildCard buffer={data.parsed.info} pubkey={pubkey} />;
+    }
+
+    return <DeployedProgramVerifiedBuildCard data={data} pubkey={pubkey} />;
+}
+
+function DeployedProgramVerifiedBuildCard({ data, pubkey }: { data: UpgradeableLoaderAccountData; pubkey: PublicKey }) {
     // suspense:false -- the chain mixes with a non-suspense SWR (useProgramIdls via useAnchorProgram); the mixed path triggers hook-order warnings under HMR.
     const { data: registryInfo, isLoading } = useVerifiedProgram({
         options: { suspense: false },

--- a/app/components/account/__stories__/BufferBuildCard.stories.tsx
+++ b/app/components/account/__stories__/BufferBuildCard.stories.tsx
@@ -1,0 +1,96 @@
+import { nextjsParameters, withClusterAndAccounts, withTokenInfoBatch } from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+import type { OsecBuild } from '@/app/utils/verified-builds';
+
+import { BaseBufferBuildCard } from '../BufferBuildCard';
+
+// BaseBufferBuildCard is the presentational split: `BufferBuildCard` is the container that hashes
+// the buffer and calls `/resolve-hash`; Base takes the resolved builds as props so stories drive
+// every state without the network.
+
+const BUFFER_HASH = '70386b8957a11985ca67032d98bfa39c6d11c1c5e87b6a32b386611ea3b39b96';
+
+// Two real builds returned by `/resolve-hash` for BUFFER_HASH: same program/repo, distinct commits.
+const TRUSTED_BUILD: OsecBuild = {
+    build_id: 'ce8a84f7-aafa-43cd-a0e0-4599fe366675',
+    commit: '39de954ea527007cc9da9f50c47be2c1d28594bc',
+    completed_at: '2026-07-21T11:51:56.865386',
+    matches_deployed: true,
+    program_id: 'wocur7QRRMdzPZN52688gBa5iJD4mLkNWSxN5xGGRjY',
+    repository: 'https://github.com/Woody4618/workflow-tutorial',
+    signer: '5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r',
+    trusted: true,
+};
+
+const TRUSTED_BUILD_OLDER: OsecBuild = {
+    ...TRUSTED_BUILD,
+    build_id: '9bf4d264-3085-49a2-8098-c9bced6f640b',
+    commit: '0b6c86b069b3787b58db24412a890cb6d0d33303',
+    completed_at: '2026-07-20T20:46:48.892517',
+};
+
+// Synthetic entry so the untrusted (`secondary`) and not-deployed (`warning`) badges are covered.
+const UNTRUSTED_BUILD: OsecBuild = {
+    ...TRUSTED_BUILD,
+    build_id: 'untrusted-not-deployed',
+    matches_deployed: false,
+    signer: 'GWk2DoJez1mwMWStprqusThgbzW8RmvgznnnXXqWHJoo',
+    trusted: false,
+};
+
+const meta = {
+    component: BaseBufferBuildCard,
+    decorators: [withClusterAndAccounts, withTokenInfoBatch],
+    parameters: nextjsParameters,
+    tags: ['autodocs', 'test'],
+    title: 'Components/Account/BufferBuildCard',
+} satisfies Meta<typeof BaseBufferBuildCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MultipleBuilds: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: [TRUSTED_BUILD, TRUSTED_BUILD_OLDER, UNTRUSTED_BUILD],
+        error: false,
+        isLoading: false,
+    },
+};
+
+export const SingleBuild: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: [TRUSTED_BUILD],
+        error: false,
+        isLoading: false,
+    },
+};
+
+export const NoBuilds: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: [],
+        error: false,
+        isLoading: false,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: undefined,
+        error: false,
+        isLoading: true,
+    },
+};
+
+export const Error: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: undefined,
+        error: true,
+        isLoading: false,
+    },
+};

--- a/app/components/account/__stories__/BufferBuildCard.stories.tsx
+++ b/app/components/account/__stories__/BufferBuildCard.stories.tsx
@@ -94,3 +94,15 @@ export const Error: Story = {
         isLoading: false,
     },
 };
+
+// Testnet/Custom have no OSEC registry, so no resolve-hash lookup runs and the card says so
+// rather than claiming the lookup found no builds.
+export const ClusterUnsupported: Story = {
+    args: {
+        bufferHash: BUFFER_HASH,
+        builds: undefined,
+        clusterSupported: false,
+        error: false,
+        isLoading: false,
+    },
+};

--- a/app/utils/__tests__/verified-builds-url.spec.ts
+++ b/app/utils/__tests__/verified-builds-url.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { composeOnchainRepoUrl, normalizeRepoUrl, safeRepoUrl } from '../verified-builds-url';
+import {
+    composeOnchainRepoUrl,
+    normalizeRepoUrl,
+    repoLabel,
+    safeRepoUrl,
+    trimTrailingSlashes,
+} from '../verified-builds-url';
 import osecStatusFixtures from './__fixtures__/osec-status.json';
 
 describe('normalizeRepoUrl', () => {
@@ -124,6 +130,68 @@ describe('composeOnchainRepoUrl', () => {
         it(`should ${scenario}`, () => {
             expect(composeOnchainRepoUrl(gitUrl, commit)).toBeUndefined();
         });
+    });
+});
+
+describe('trimTrailingSlashes', () => {
+    const cases: Array<[{ scenario: string; value: string }, string]> = [
+        [
+            { scenario: 'strip a single trailing slash', value: 'https://github.com/foo/bar/' },
+            'https://github.com/foo/bar',
+        ],
+        [
+            { scenario: 'strip multiple trailing slashes', value: 'https://github.com/foo/bar///' },
+            'https://github.com/foo/bar',
+        ],
+        [
+            { scenario: 'return a slash-free value unchanged', value: 'https://github.com/foo/bar' },
+            'https://github.com/foo/bar',
+        ],
+        [
+            { scenario: 'not touch interior slashes', value: 'https://github.com/foo/bar/tree/abc' },
+            'https://github.com/foo/bar/tree/abc',
+        ],
+        [{ scenario: 'return an empty string for input of only slashes', value: '///' }, ''],
+        [{ scenario: 'return an empty string unchanged', value: '' }, ''],
+    ];
+    cases.forEach(([{ scenario, value }, expected]) => {
+        it(`should ${scenario}`, () => {
+            expect(trimTrailingSlashes(value)).toBe(expected);
+        });
+    });
+});
+
+describe('repoLabel', () => {
+    const cases: Array<[{ scenario: string; repository: string }, string]> = [
+        [{ repository: 'https://github.com/foo/bar', scenario: 'drop the https scheme' }, 'github.com/foo/bar'],
+        [{ repository: 'http://github.com/foo/bar', scenario: 'drop the http scheme' }, 'github.com/foo/bar'],
+        [
+            { repository: 'https://github.com/foo/bar.git', scenario: 'drop a trailing .git suffix' },
+            'github.com/foo/bar',
+        ],
+        [{ repository: 'https://github.com/foo/bar/', scenario: 'drop a trailing slash' }, 'github.com/foo/bar'],
+        [
+            {
+                repository: 'https://github.com/Squads-Protocol/v4/',
+                scenario: 'drop scheme and trailing slash together',
+            },
+            'github.com/Squads-Protocol/v4',
+        ],
+        [
+            { repository: 'https://github.com/foo/bar.git/', scenario: 'drop a trailing slash then .git' },
+            'github.com/foo/bar',
+        ],
+        [{ repository: 'github.com/foo/bar', scenario: 'return a scheme-less label unchanged' }, 'github.com/foo/bar'],
+        [{ repository: '', scenario: 'return an empty string unchanged' }, ''],
+    ];
+    cases.forEach(([{ scenario, repository }, expected]) => {
+        it(`should ${scenario}`, () => {
+            expect(repoLabel(repository)).toBe(expected);
+        });
+    });
+
+    it('should keep interior .git-like segments (only a trailing .git is stripped)', () => {
+        expect(repoLabel('https://github.com/foo/bar.github')).toBe('github.com/foo/bar.github');
     });
 });
 

--- a/app/utils/__tests__/verified-builds.spec.ts
+++ b/app/utils/__tests__/verified-builds.spec.ts
@@ -1,5 +1,6 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { PublicKey } from '@solana/web3.js';
+import { create } from 'superstruct';
 import { describe, expect, it } from 'vitest';
 
 import { Cluster } from '../cluster';
@@ -11,6 +12,7 @@ import {
     hashProgramData,
     type OsecBuild,
     type OsecInfo,
+    OsecResolveHashResponse,
     supportsVerifiedBuilds,
     VerificationStatus,
 } from '../verified-builds';
@@ -405,5 +407,64 @@ describe('dedupeAndSortBuilds', () => {
 
     it('should return an empty array unchanged', () => {
         expect(dedupeAndSortBuilds([])).toEqual([]);
+    });
+});
+
+describe('OsecResolveHashResponse', () => {
+    const HASH = '6122072454d9763f71b04106e79a9e670c695d500f104e31e4c2e4177f0cd736';
+
+    function makeRawBuild(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+        return {
+            build_id: 'build-0',
+            commit: 'aaaaaaa',
+            completed_at: '2026-01-01T00:00:00.000Z',
+            matches_deployed: true,
+            program_id: 'HfU7iK2hyesWG1abBD8nXDpsw2ijrA2vpdiNYNj3Hg3c',
+            repository: 'https://github.com/example/repo',
+            signer: null,
+            trusted: true,
+            ...overrides,
+        };
+    }
+
+    it('should accept a well-formed payload', () => {
+        const raw = { builds: [makeRawBuild()], executable_hash: HASH };
+        expect(create(raw, OsecResolveHashResponse).builds).toHaveLength(1);
+    });
+
+    it('should accept a null or string signer', () => {
+        const raw = {
+            builds: [makeRawBuild({ signer: null }), makeRawBuild({ build_id: 'b', signer: 'some-signer' })],
+            executable_hash: HASH,
+        };
+        expect(create(raw, OsecResolveHashResponse).builds.map(b => b.signer)).toEqual([null, 'some-signer']);
+    });
+
+    it('should accept an empty builds list', () => {
+        expect(create({ builds: [], executable_hash: HASH }, OsecResolveHashResponse).builds).toEqual([]);
+    });
+
+    it('should tolerate unknown fields added upstream', () => {
+        const raw = {
+            builds: [makeRawBuild({ future_field: 'ignored' })],
+            executable_hash: HASH,
+            unknown_top_level: 1,
+        };
+        expect(() => create(raw, OsecResolveHashResponse)).not.toThrow();
+    });
+
+    it('should reject a build missing a required field', () => {
+        const raw = { builds: [makeRawBuild()], executable_hash: HASH };
+        delete (raw.builds[0] as Record<string, unknown>).repository;
+        expect(() => create(raw, OsecResolveHashResponse)).toThrow();
+    });
+
+    it('should reject a field with the wrong type', () => {
+        const raw = { builds: [makeRawBuild({ trusted: 'yes' })], executable_hash: HASH };
+        expect(() => create(raw, OsecResolveHashResponse)).toThrow();
+    });
+
+    it('should reject a payload with no builds array', () => {
+        expect(() => create({ executable_hash: HASH }, OsecResolveHashResponse)).toThrow();
     });
 });

--- a/app/utils/__tests__/verified-builds.spec.ts
+++ b/app/utils/__tests__/verified-builds.spec.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from 'vitest';
 import { Cluster } from '../cluster';
 import {
     buildEnrichedOsecInfo,
+    dedupeAndSortBuilds,
     getOsecRegistryUrl,
     hashProgramBuffer,
     hashProgramData,
+    type OsecBuild,
     type OsecInfo,
     supportsVerifiedBuilds,
     VerificationStatus,
@@ -318,5 +320,85 @@ describe('buildEnrichedOsecInfo', () => {
         });
         expect(info.repo_url).toBe('');
         expect(info.onchain_repo_url).toBe('');
+    });
+});
+
+describe('dedupeAndSortBuilds', () => {
+    function makeBuild(overrides: Partial<OsecBuild> = {}): OsecBuild {
+        return {
+            build_id: 'build-0',
+            commit: 'aaaaaaa',
+            completed_at: '2026-01-01T00:00:00.000Z',
+            matches_deployed: true,
+            program_id: 'HfU7iK2hyesWG1abBD8nXDpsw2ijrA2vpdiNYNj3Hg3c',
+            repository: 'https://github.com/example/repo',
+            signer: null,
+            trusted: true,
+            ...overrides,
+        };
+    }
+
+    it('should collapse builds that share program/repo/commit/trusted/matches_deployed', () => {
+        const result = dedupeAndSortBuilds([
+            makeBuild({ build_id: 'a' }),
+            makeBuild({ build_id: 'b' }), // same identity, different build_id -> dropped
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0].build_id).toBe('a');
+    });
+
+    it('should keep distinct trusted and untrusted rows for the same build', () => {
+        const result = dedupeAndSortBuilds([
+            makeBuild({ build_id: 'untrusted', trusted: false }),
+            makeBuild({ build_id: 'trusted', trusted: true }),
+        ]);
+        expect(result).toHaveLength(2);
+        // trusted sorts first
+        expect(result[0].build_id).toBe('trusted');
+        expect(result[1].build_id).toBe('untrusted');
+    });
+
+    it('should order by trusted, then matches_deployed, then most recent completed_at', () => {
+        // Distinct commits so none of these collapse during dedupe (which ignores completed_at).
+        const result = dedupeAndSortBuilds([
+            makeBuild({
+                build_id: 'old-trusted',
+                commit: 'commit-old',
+                completed_at: '2026-01-01T00:00:00.000Z',
+                trusted: true,
+            }),
+            makeBuild({
+                build_id: 'new-trusted',
+                commit: 'commit-new',
+                completed_at: '2026-06-01T00:00:00.000Z',
+                trusted: true,
+            }),
+            makeBuild({ build_id: 'untrusted-deployed', commit: 'commit-x', matches_deployed: true, trusted: false }),
+            makeBuild({
+                build_id: 'untrusted-undeployed',
+                commit: 'commit-y',
+                matches_deployed: false,
+                trusted: false,
+            }),
+        ]);
+        expect(result.map(b => b.build_id)).toEqual([
+            'new-trusted',
+            'old-trusted',
+            'untrusted-deployed',
+            'untrusted-undeployed',
+        ]);
+    });
+
+    it('should collapse re-run duplicates that differ only by build_id and completed_at', () => {
+        const result = dedupeAndSortBuilds([
+            makeBuild({ build_id: 'first', completed_at: '2026-01-01T00:00:00.000Z' }),
+            makeBuild({ build_id: 'rerun', completed_at: '2026-02-01T00:00:00.000Z' }),
+        ]);
+        expect(result).toHaveLength(1);
+        expect(result[0].build_id).toBe('first');
+    });
+
+    it('should return an empty array unchanged', () => {
+        expect(dedupeAndSortBuilds([])).toEqual([]);
     });
 });

--- a/app/utils/__tests__/verified-builds.spec.ts
+++ b/app/utils/__tests__/verified-builds.spec.ts
@@ -389,13 +389,18 @@ describe('dedupeAndSortBuilds', () => {
         ]);
     });
 
-    it('should collapse re-run duplicates that differ only by build_id and completed_at', () => {
-        const result = dedupeAndSortBuilds([
-            makeBuild({ build_id: 'first', completed_at: '2026-01-01T00:00:00.000Z' }),
-            makeBuild({ build_id: 'rerun', completed_at: '2026-02-01T00:00:00.000Z' }),
-        ]);
-        expect(result).toHaveLength(1);
-        expect(result[0].build_id).toBe('first');
+    it('should keep the most recent run when collapsing duplicates, regardless of input order', () => {
+        const older = makeBuild({ build_id: 'older', completed_at: '2026-01-01T00:00:00.000Z' });
+        const newer = makeBuild({ build_id: 'newer', completed_at: '2026-02-01T00:00:00.000Z' });
+
+        // Newest survives whether the older or the newer run appears first in the response.
+        const olderFirst = dedupeAndSortBuilds([older, newer]);
+        expect(olderFirst).toHaveLength(1);
+        expect(olderFirst[0].build_id).toBe('newer');
+
+        const newerFirst = dedupeAndSortBuilds([newer, older]);
+        expect(newerFirst).toHaveLength(1);
+        expect(newerFirst[0].build_id).toBe('newer');
     });
 
     it('should return an empty array unchanged', () => {

--- a/app/utils/verified-builds-url.ts
+++ b/app/utils/verified-builds-url.ts
@@ -24,3 +24,20 @@ export function composeOnchainRepoUrl(gitUrl: string | undefined, commit: string
     const composed = commit.length ? `${base}/tree/${commit}` : base;
     return safeRepoUrl(composed);
 }
+
+// Trim trailing slashes so a composed `<repo>/tree/<sha>` link has no `//` and labels read cleanly.
+export function trimTrailingSlashes(value: string): string {
+    let result = value;
+    while (result.endsWith('/')) result = result.slice(0, -1);
+    return result;
+}
+
+// Compact, readable repository label: drop the scheme and any trailing slash or `.git`. Display only
+// — the clickable href is still built from the full URL via composeOnchainRepoUrl.
+export function repoLabel(repository: string): string {
+    let label = trimTrailingSlashes(repository);
+    if (label.startsWith('https://')) label = label.slice('https://'.length);
+    else if (label.startsWith('http://')) label = label.slice('http://'.length);
+    if (label.endsWith('.git')) label = label.slice(0, -'.git'.length);
+    return label;
+}

--- a/app/utils/verified-builds-url.ts
+++ b/app/utils/verified-builds-url.ts
@@ -1,3 +1,6 @@
+// Canonical docs link for verified builds, shared by every card that explains the feature.
+export const VERIFIED_BUILDS_GUIDE_URL = 'https://solana.com/developers/guides/advanced/verified-builds';
+
 // Strip `.git` from clone URLs so `<repo>/tree/<sha>` deep-links resolve on GitHub.
 export function normalizeRepoUrl(repoUrl: string | undefined): string | undefined {
     if (!repoUrl) return undefined;

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -240,12 +240,17 @@ export function useResolveBuildsByHash(hash: string | undefined) {
 // most-relevant first: trusted, then matching the deployed program, then most recently completed.
 export function dedupeAndSortBuilds(builds: OsecBuild[]): OsecBuild[] {
     const seen = new Set<string>();
-    const deduped = builds.filter(build => {
-        const key = `${build.program_id}|${build.repository}|${build.commit}|${build.trusted}|${build.matches_deployed}`;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-    });
+    // Sort newest-first before de-duping so the entry kept for each duplicate group is the most
+    // recent run — the filter keeps the first occurrence, so this is independent of the order
+    // `/resolve-hash` returned the builds in.
+    const deduped = [...builds]
+        .sort((a, b) => new Date(b.completed_at).getTime() - new Date(a.completed_at).getTime())
+        .filter(build => {
+            const key = `${build.program_id}|${build.repository}|${build.commit}|${build.trusted}|${build.matches_deployed}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
 
     return deduped.sort((a, b) => {
         if (a.trusted !== b.trusted) return a.trusted ? -1 : 1;

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -2,6 +2,7 @@ import { useAnchorProgram } from '@entities/idl';
 import { sha256 } from '@noble/hashes/sha256';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { useEffect, useMemo } from 'react';
+import { array, boolean, create, Infer, nullable, string, type } from 'superstruct';
 import useSWRImmutable from 'swr/immutable';
 
 import { fromBase64, fromUtf8, toHex } from '@/app/shared/lib/bytes';
@@ -64,24 +65,29 @@ export type OsecInfo = {
 
 // A single completed build returned by the OSEC `/resolve-hash/{executable_hash}` endpoint.
 // Each build is a source repo/commit whose compiled output hashes to the queried executable hash.
-export type OsecBuild = {
-    build_id: string;
-    program_id: string;
-    signer: string | null;
-    repository: string;
-    commit: string;
-    completed_at: string;
+// Validated at the fetch boundary, so a field the API drops or retypes surfaces as an error state
+// instead of rendering `undefined` in the table. `type` is lenient about unknown keys, so fields
+// added upstream do not break the card.
+export type OsecBuild = Infer<typeof OsecBuild>;
+export const OsecBuild = type({
+    build_id: string(),
+    commit: string(),
+    completed_at: string(),
     // Whether this build's hash is what is currently deployed on its `program_id`.
-    matches_deployed: boolean;
+    matches_deployed: boolean(),
+    program_id: string(),
+    repository: string(),
+    signer: nullable(string()),
     // Whether the build's signer is a trusted signer.
-    trusted: boolean;
-};
+    trusted: boolean(),
+});
 
 // Response shape of `GET /resolve-hash/{executable_hash}`.
-export type OsecResolveHashResponse = {
-    executable_hash: string;
-    builds: OsecBuild[];
-};
+export type OsecResolveHashResponse = Infer<typeof OsecResolveHashResponse>;
+export const OsecResolveHashResponse = type({
+    builds: array(OsecBuild),
+    executable_hash: string(),
+});
 
 // Decoded subset of the Otter Verify `BuildParams` account used to compose the verify command / repo URL.
 type OtterVerifyBuildParams = {
@@ -235,7 +241,8 @@ export function useResolveBuildsByHash(hash: string | undefined) {
             if (!response.ok) {
                 throw new Error(`resolve-hash request failed with status ${response.status}`);
             }
-            return (await response.json()) as OsecResolveHashResponse;
+            // `create` throws on a malformed payload; SWR surfaces it as the card's error state.
+            return create(await response.json(), OsecResolveHashResponse);
         },
     );
 }

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -62,6 +62,27 @@ export type OsecInfo = {
     is_frozen: boolean;
 };
 
+// A single completed build returned by the OSEC `/resolve-hash/{executable_hash}` endpoint.
+// Each build is a source repo/commit whose compiled output hashes to the queried executable hash.
+export type OsecBuild = {
+    build_id: string;
+    program_id: string;
+    signer: string | null;
+    repository: string;
+    commit: string;
+    completed_at: string;
+    // Whether this build's hash is what is currently deployed on its `program_id`.
+    matches_deployed: boolean;
+    // Whether the build's signer is a trusted signer.
+    trusted: boolean;
+};
+
+// Response shape of `GET /resolve-hash/{executable_hash}`.
+export type OsecResolveHashResponse = {
+    executable_hash: string;
+    builds: OsecBuild[];
+};
+
 // Decoded subset of the Otter Verify `BuildParams` account used to compose the verify command / repo URL.
 type OtterVerifyBuildParams = {
     gitUrl: string;
@@ -196,6 +217,41 @@ export function useIsProgramVerified({
             return osecInfo.is_verified && hash === osecInfo['on_chain_hash'];
         },
     );
+}
+
+// Resolve the completed builds whose compiled output matches a given executable hash.
+// Used for program buffer accounts: a buffer holds a staged binary with no program id to look
+// up in the OSEC registry, but its buffer hash can still be resolved to the source build(s)
+// that produced it. Returns the `/resolve-hash` response, or nothing while `hash` is undefined
+// (e.g. a buffer whose `data` is unavailable, so no hash could be computed).
+export function useResolveBuildsByHash(hash: string | undefined) {
+    return useSWRImmutable(hash ? ['resolve-hash', hash] : null, async ([, executableHash]) => {
+        const response = await fetch(`${OSEC_REGISTRY_URL}/resolve-hash/${executableHash}`);
+        if (!response.ok) {
+            throw new Error(`resolve-hash request failed with status ${response.status}`);
+        }
+        return (await response.json()) as OsecResolveHashResponse;
+    });
+}
+
+// Collapse exact-duplicate builds and order them for display. `/resolve-hash` can return the same
+// build several times (e.g. re-runs); it can also return genuinely distinct entries that share a
+// program/repo/commit but differ in trust or deploy match, which we keep as separate rows. Ordered
+// most-relevant first: trusted, then matching the deployed program, then most recently completed.
+export function dedupeAndSortBuilds(builds: OsecBuild[]): OsecBuild[] {
+    const seen = new Set<string>();
+    const deduped = builds.filter(build => {
+        const key = `${build.program_id}|${build.repository}|${build.commit}|${build.trusted}|${build.matches_deployed}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+
+    return deduped.sort((a, b) => {
+        if (a.trusted !== b.trusted) return a.trusted ? -1 : 1;
+        if (a.matches_deployed !== b.matches_deployed) return a.matches_deployed ? -1 : 1;
+        return new Date(b.completed_at).getTime() - new Date(a.completed_at).getTime();
+    });
 }
 
 // Method to fetch verified build information for a given program

--- a/app/utils/verified-builds.tsx
+++ b/app/utils/verified-builds.tsx
@@ -223,15 +223,21 @@ export function useIsProgramVerified({
 // Used for program buffer accounts: a buffer holds a staged binary with no program id to look
 // up in the OSEC registry, but its buffer hash can still be resolved to the source build(s)
 // that produced it. Returns the `/resolve-hash` response, or nothing while `hash` is undefined
-// (e.g. a buffer whose `data` is unavailable, so no hash could be computed).
+// (e.g. a buffer whose `data` is unavailable, so no hash could be computed) or the cluster has
+// no registry. The registry URL is part of the cache key, so clusters never share an entry.
 export function useResolveBuildsByHash(hash: string | undefined) {
-    return useSWRImmutable(hash ? ['resolve-hash', hash] : null, async ([, executableHash]) => {
-        const response = await fetch(`${OSEC_REGISTRY_URL}/resolve-hash/${executableHash}`);
-        if (!response.ok) {
-            throw new Error(`resolve-hash request failed with status ${response.status}`);
-        }
-        return (await response.json()) as OsecResolveHashResponse;
-    });
+    const { cluster } = useCluster();
+    const registryUrl = getOsecRegistryUrl(cluster);
+    return useSWRImmutable(
+        hash && registryUrl ? ['resolve-hash', registryUrl, hash] : null,
+        async ([, base, executableHash]) => {
+            const response = await fetch(`${base}/resolve-hash/${executableHash}`);
+            if (!response.ok) {
+                throw new Error(`resolve-hash request failed with status ${response.status}`);
+            }
+            return (await response.json()) as OsecResolveHashResponse;
+        },
+    );
 }
 
 // Collapse exact-duplicate builds and order them for display. `/resolve-hash` can return the same

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -48,7 +48,7 @@
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
 | Dynamic | `/block/[slot]` | 220 kB | 1.24 MB |
-| Dynamic | `/block/[slot]/accounts` | 220 kB | 1.24 MB |
+| Dynamic | `/block/[slot]/accounts` | 210 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/programs` | 210 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/rewards` | 210 kB | 1.24 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -3,7 +3,7 @@
 | Type | Route | Size | First Load JS |
 |------|-------|------|---------------|
 | Static | `/` | 130 kB | 1.16 MB |
-| Static | `/_not-found` | 0 B | 1.03 MB |
+| Static | `/_not-found` | 0 B | 1.04 MB |
 | Dynamic | `/address/[address]` | 400 kB | 1.42 MB |
 | Dynamic | `/address/[address]/anchor-account` | 370 kB | 1.39 MB |
 | Dynamic | `/address/[address]/anchor-program` | 370 kB | 1.39 MB |
@@ -47,12 +47,12 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 220 kB | 1.24 MB |
-| Dynamic | `/block/[slot]/accounts` | 210 kB | 1.24 MB |
+| Dynamic | `/block/[slot]` | 220 kB | 1.25 MB |
+| Dynamic | `/block/[slot]/accounts` | 220 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/programs` | 210 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/rewards` | 210 kB | 1.24 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |
-| Static | `/feature-gates` | 50 kB | 1.07 MB |
+| Static | `/feature-gates` | 50 kB | 1.08 MB |
 | Dynamic | `/mcp` | — | — |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |


### PR DESCRIPTION
## Description

Program **buffer** accounts stage a compiled program binary before deployment, so they have no program id to look up in the OSEC verified-builds registry (`/status-all/{programId}`). This PR uses OSEC's new `GET /resolve-hash/{executable_hash}` endpoint to resolve a buffer's binary hash to the completed source build(s) that produced it, and surfaces them on the buffer account's **Verified Build** tab — which previously rendered "Account has no data" for buffers.

The card reuses the existing verified-build page styling and lists each resolved build: program, repository (linked to `/tree/<commit>`), commit, trusted, matches-deployed, and completion date. The table is responsive — on small screens the secondary columns collapse into an expandable per-row detail, mirroring the Feature Gates table. Builds are de-duplicated (by program/repo/commit/trusted/matches-deployed) and ordered trusted → matches-deployed → most-recent.

Resolution follows the per-cluster registry introduced in #1166: `useResolveBuildsByHash` selects the registry with `getOsecRegistryUrl(cluster)` and includes that URL in its SWR key, so Mainnet and Devnet never share a cache entry for the same buffer hash. Testnet and Custom have no OSEC registry, so no request is made and the card says verified builds are unavailable on the cluster rather than reporting that no builds were found.

The `/resolve-hash` payload is validated with superstruct at the fetch boundary, matching how the repo validates RPC account data. A response that drops or retypes a field now surfaces as the card's error state instead of rendering `undefined` in the table.

Key pieces:
- `useResolveBuildsByHash` + `dedupeAndSortBuilds`, and the `OsecBuild` / `OsecResolveHashResponse` structs in `app/utils/verified-builds.tsx`.
- `BufferBuildCard` (`app/components/account/BufferBuildCard.tsx`), wired into `VerifiedBuildCard` via a `data.parsed.type === 'buffer'` branch.
- Pure repo/label helpers `repoLabel` and `trimTrailingSlashes`, plus the shared `VERIFIED_BUILDS_GUIDE_URL` const, in `app/utils/verified-builds-url.ts`.

## Type of change

-   [x] New feature

## Screenshots


Buffer account **Verified Build** tab, rendered against real live mainnet buffers.

| Desktop | Mobile |
| --- | --- |
| <img width="1554" height="434" alt="Screenshot 2026-07-28 at 15 12 15" src="https://github.com/user-attachments/assets/48f25a2d-cc68-415d-8dc4-355b69eef7a9" /> | <img width="559" height="564" alt="Screenshot 2026-07-28 at 15 12 28" src="https://github.com/user-attachments/assets/25097a9f-06c2-435b-b518-b80a9eb58ba8" /> |

- **Desktop** — full table: Program · Repository · Commit · Trusted · Matches Deployed · Date.
- **Mobile** — Program + Repository + an expand toggle; expanding reveals Commit / Trusted / Matches Deployed / Date as label–value pairs.

## Testing

Manual testing on the preview deployment (real, currently-live mainnet buffers whose hashes resolve):

- [Squads v4 buffer — trusted build, not-yet-deployed](https://explorer-git-fork-hoodieshq-feat-resol-472505-solana-foundation.vercel.app/address/bacNFZy6nE1TLg2XiVgWpzqXeo8VhjYcVMAYyRRtdHi/verified-build)
- [LayerZero devtools buffer — untrusted signer, matches-deployed](https://explorer-git-fork-hoodieshq-feat-resol-472505-solana-foundation.vercel.app/address/aUn5hWzP7Q5Xi7npU1LayxCW9iky4eie761ucXPnbxA/verified-build)
- [omnipair buffer — single trusted build](https://explorer-git-fork-hoodieshq-feat-resol-472505-solana-foundation.vercel.app/address/FFS7K76YiLyhGqbcssw3RJkyaGF7P8WTucaJFKz8p3K/verified-build)
- [Same buffer on Devnet — resolves against the devnet registry, not mainnet](https://explorer-git-fork-hoodieshq-feat-resol-472505-solana-foundation.vercel.app/address/bacNFZy6nE1TLg2XiVgWpzqXeo8VhjYcVMAYyRRtdHi/verified-build?cluster=devnet)
- [Same buffer on Testnet — no registry, so the unavailable notice instead of a lookup](https://explorer-git-fork-hoodieshq-feat-resol-472505-solana-foundation.vercel.app/address/bacNFZy6nE1TLg2XiVgWpzqXeo8VhjYcVMAYyRRtdHi/verified-build?cluster=testnet)

## Related Issues

Closes [HOO-869](https://linear.app/solana-fndn/issue/HOO-869/use-resolve-hash-endpoint-for-program-buffer-builds)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information





