### PR TITLE
fix: use legacy account history RPC for custom clusters

### DIFF
--- a/app/providers/accounts/__tests__/history.spec.tsx
+++ b/app/providers/accounts/__tests__/history.spec.tsx
@@ -322,6 +322,73 @@ describe('useResetAccountHistory', () => {
     });
 });
 
+describe('cluster changes', () => {
+    it('should clear cached history when the cluster changes without changing the RPC URL', async () => {
+        mockResult([sig('rpc-2', 10)], null);
+
+        const { result, rerender } = renderHook(
+            () => ({
+                fetch: useFetchAccountHistory(25, {}),
+                history: useAccountHistory(ADDRESS),
+            }),
+            { wrapper },
+        );
+
+        await act(async () => {
+            result.current.fetch(new PublicKey(ADDRESS));
+        });
+        await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('rpc-2'));
+
+        mockCluster = Cluster.Custom;
+        rerender();
+
+        expect(result.current.history).toBeUndefined();
+
+        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+        await act(async () => {
+            result.current.fetch(new PublicKey(ADDRESS));
+        });
+
+        await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('legacy'));
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should discard an in-flight response from the previous cluster at the same RPC URL', async () => {
+        const pending = deferred<ReturnType<typeof envelope>>();
+        fetchMock.mockReturnValueOnce(pending.promise);
+
+        const { result, rerender } = renderHook(
+            () => ({
+                fetch: useFetchAccountHistory(25, {}),
+                history: useAccountHistory(ADDRESS),
+            }),
+            { wrapper },
+        );
+
+        act(() => {
+            result.current.fetch(new PublicKey(ADDRESS));
+        });
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        mockCluster = Cluster.Custom;
+        rerender();
+
+        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+        await act(async () => {
+            result.current.fetch(new PublicKey(ADDRESS));
+        });
+        await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('legacy'));
+
+        await act(async () => {
+            pending.resolve(envelope([sig('stale', 1)], null));
+            await pending.promise;
+        });
+
+        expect(result.current.history?.data?.fetched).toHaveLength(1);
+        expect(result.current.history?.data?.fetched[0].signature).toBe('legacy');
+    });
+});
+
 describe('getSignaturesForAddress fallback', () => {
     it('should use getSignaturesForAddress directly on a custom cluster', async () => {
         mockCluster = Cluster.Custom;

--- a/app/providers/accounts/__tests__/history.spec.tsx
+++ b/app/providers/accounts/__tests__/history.spec.tsx
@@ -1,13 +1,15 @@
 import { Connection, PublicKey } from '@solana/web3.js';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { Cluster } from '@utils/cluster';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+let mockCluster = Cluster.MainnetBeta;
 vi.mock('@providers/cluster', () => ({
-    useCluster: vi.fn(() => ({
-        cluster: 0,
+    useCluster: () => ({
+        cluster: mockCluster,
         url: 'https://mock.rpc',
-    })),
+    }),
 }));
 
 vi.mock('@solana/web3.js', async () => {
@@ -83,6 +85,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    mockCluster = Cluster.MainnetBeta;
     vi.mocked(Connection).mockImplementation(function () {
         return mockConnection as unknown as Connection;
     });
@@ -320,6 +323,30 @@ describe('useResetAccountHistory', () => {
 });
 
 describe('getSignaturesForAddress fallback', () => {
+    it('should use getSignaturesForAddress directly on a custom cluster', async () => {
+        mockCluster = Cluster.Custom;
+        mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);
+
+        const { result } = renderHook(
+            () => ({
+                fetch: useFetchAccountHistory(25, { slot: { gte: 10 } }),
+                history: useAccountHistory(ADDRESS),
+                supported: useHistoryFiltersSupported(),
+            }),
+            { wrapper },
+        );
+
+        expect(result.current.supported).toBe(false);
+
+        await act(async () => {
+            result.current.fetch(new PublicKey(ADDRESS));
+        });
+
+        await waitFor(() => expect(result.current.history?.data?.fetched?.[0]?.signature).toBe('legacy'));
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(mockConnection.getSignaturesForAddress).toHaveBeenCalledWith(expect.any(PublicKey), { limit: 25 });
+    });
+
     it('should fall back when getTransactionsForAddress is not found, applying no filters', async () => {
         mockRpcError(-32601, 'Method not found');
         mockConnection.getSignaturesForAddress.mockResolvedValueOnce([sig('legacy', 5)]);

--- a/app/providers/accounts/history.tsx
+++ b/app/providers/accounts/history.tsx
@@ -154,7 +154,7 @@ export const MethodSupportContext: React.Context<MethodSupport | undefined> = Re
 
 type HistoryProviderProps = { children: React.ReactNode };
 export function HistoryProvider({ children }: HistoryProviderProps) {
-    const { url } = useCluster();
+    const { cluster, url } = useCluster();
     const [state, dispatch] = Cache.useCustomReducer(url, reconcile);
     const inFlightRef = React.useRef(new Set<string>());
     const generationRef = React.useRef(new Map<string, number>());
@@ -168,7 +168,10 @@ export function HistoryProvider({ children }: HistoryProviderProps) {
     }, [dispatch, url]);
 
     const markUnsupported = React.useCallback(() => setSupported(false), []);
-    const methodSupport = React.useMemo(() => ({ markUnsupported, supported }), [markUnsupported, supported]);
+    const methodSupport = React.useMemo(
+        () => ({ markUnsupported, supported: cluster !== Cluster.Custom && supported }),
+        [cluster, markUnsupported, supported],
+    );
 
     return (
         <StateContext.Provider value={state}>
@@ -378,21 +381,29 @@ async function fetchAccountHistory(
     let status;
     let history;
     try {
-        const result = await getTransactionsForAddress(url, pubkey.toBase58(), {
-            filters: options.filters,
-            limit: options.limit,
-            paginationToken: options.paginationToken,
-        });
-        history = {
-            fetched: result.data,
-            // A null/absent paginationToken is the canonical end-of-stream signal; a
-            // short page is not, since the server may still hand back a token for more.
-            foundOldest: !result.paginationToken,
-            paginationToken: result.paginationToken,
-        };
+        if (cluster === Cluster.Custom) {
+            // Custom RPCs are not guaranteed to support the Triton extension.
+            history = await fetchViaSignatures(url, pubkey, {
+                before: options.before,
+                limit: options.limit,
+            });
+        } else {
+            const result = await getTransactionsForAddress(url, pubkey.toBase58(), {
+                filters: options.filters,
+                limit: options.limit,
+                paginationToken: options.paginationToken,
+            });
+            history = {
+                fetched: result.data,
+                // A null/absent paginationToken is the canonical end-of-stream signal; a
+                // short page is not, since the server may still hand back a token for more.
+                foundOldest: !result.paginationToken,
+                paginationToken: result.paginationToken,
+            };
+        }
         status = FetchStatus.Fetched;
     } catch (error) {
-        if (isMethodNotFound(error)) {
+        if (cluster !== Cluster.Custom && isMethodNotFound(error)) {
             // Endpoint doesn't implement getTransactionsForAddress: disable filtering
             // and fall back to the standard getSignaturesForAddress path.
             onMethodNotFound?.();
@@ -403,9 +414,7 @@ async function fetchAccountHistory(
                 });
                 status = FetchStatus.Fetched;
             } catch (fallbackError) {
-                if (cluster !== Cluster.Custom) {
-                    Logger.error(fallbackError, { url });
-                }
+                Logger.error(fallbackError, { url });
                 status = FetchStatus.FetchFailed;
             }
         } else {

--- a/app/providers/accounts/history.tsx
+++ b/app/providers/accounts/history.tsx
@@ -155,17 +155,22 @@ export const MethodSupportContext: React.Context<MethodSupport | undefined> = Re
 type HistoryProviderProps = { children: React.ReactNode };
 export function HistoryProvider({ children }: HistoryProviderProps) {
     const { cluster, url } = useCluster();
+
+    // Two cluster identities can share an RPC URL while selecting different history
+    // methods. Remount the cache boundary so neither cached nor in-flight results cross over.
+    return (
+        <ClusterHistoryProvider key={`${cluster}:${url}`} cluster={cluster} url={url}>
+            {children}
+        </ClusterHistoryProvider>
+    );
+}
+
+type ClusterHistoryProviderProps = HistoryProviderProps & { cluster: Cluster; url: string };
+function ClusterHistoryProvider({ children, cluster, url }: ClusterHistoryProviderProps) {
     const [state, dispatch] = Cache.useCustomReducer(url, reconcile);
     const inFlightRef = React.useRef(new Set<string>());
     const generationRef = React.useRef(new Map<string, number>());
     const [supported, setSupported] = React.useState(true);
-
-    React.useEffect(() => {
-        dispatch({ type: ActionType.Clear, url });
-        inFlightRef.current.clear();
-        generationRef.current.clear();
-        setSupported(true);
-    }, [dispatch, url]);
 
     const markUnsupported = React.useCallback(() => setSupported(false), []);
     const methodSupport = React.useMemo(

--- a/app/providers/accounts/history.tsx
+++ b/app/providers/accounts/history.tsx
@@ -382,7 +382,7 @@ async function fetchAccountHistory(
     let history;
     try {
         if (cluster === Cluster.Custom) {
-            // Custom RPCs are not guaranteed to support the Triton extension.
+            // Custom RPCs are not guaranteed to support the RPC 2.0 method.
             history = await fetchViaSignatures(url, pubkey, {
                 before: options.before,
                 limit: options.limit,


### PR DESCRIPTION
## Description

Custom clusters now use the standard `getSignaturesForAddress` account-history path directly instead of first calling the RPC 2.0 method, `getTransactionsForAddress`.

The filter UI is marked unsupported immediately for custom clusters because the standard RPC method cannot apply the slot, block-time, or status filters. Known clusters keep the existing RPC 2.0 request and runtime method-not-found fallback unchanged.

History state is scoped to both the cluster identity and RPC URL. This prevents cached pagination state or an in-flight response from crossing between a known and custom cluster that happen to use the same endpoint.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

Not applicable: this changes RPC selection and cache invalidation without introducing a visual UI change.

## Testing

- Added provider regression coverage confirming that custom clusters:
  - call `getSignaturesForAddress` directly
  - never call `getTransactionsForAddress`
  - report transaction filters as unsupported
  - do not forward unsupported filters to the legacy RPC
- Added same-URL cluster-transition coverage confirming that:
  - cached history is cleared when the cluster identity changes
  - an in-flight response from the previous cluster cannot populate the new state
- `pnpm format:ci`
- `pnpm lint`
- `pnpm openspec:validate`
- `pnpm build`
- `pnpm typecheck`
- All package tests passed
- App suite: 304 files passed; 3,313 tests passed and 28 skipped
- `pnpm build:info`

## Related Issues

None.

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information

## Additional Notes

This is not a protocol integration or security-related change.
