### PR TITLE
feat(idl): link to Orquestra MCP & API page from the Program IDL card

### DIFF
--- a/app/features/idl/ui/IdlCard.tsx
+++ b/app/features/idl/ui/IdlCard.tsx
@@ -3,6 +3,15 @@ import { LoadingCard } from '@components/common/LoadingCard';
 import { AddressLink } from '@components/shared/address';
 import { Badge } from '@components/shared/ui/badge';
 import { Button, buttonVariants } from '@components/shared/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@components/shared/ui/dialog';
 import { ExternalLink } from '@components/shared/ui/external-link';
 import {
     buildProgramName,
@@ -36,6 +45,7 @@ export function IdlCard({ programId }: { programId: string }) {
         cluster,
     );
     const [searchStr, setSearchStr] = useState<string>('');
+    const [isOrquestraDialogOpen, setIsOrquestraDialogOpen] = useState(false);
 
     // Link to the standalone IDL explorer (idl.solana.com) — the full history view across every IDL
     // source for this program; this card surfaces only the single latest IDL.
@@ -54,6 +64,63 @@ export function IdlCard({ programId }: { programId: string }) {
         </ExternalLink>
     );
 
+    // Orquestra exposes this program's IDL as MCP tooling and an API; its project page is
+    // cluster-agnostic, so the link is offered regardless of the selected cluster. Like the Castaway
+    // "Generate SDK" flow, it goes through a leaving-the-Explorer interstitial that shows the
+    // destination URL before opening it.
+    const orquestraUrl = `https://orquestra.dev/project/${programId}`;
+    const orquestraLink = (
+        <Button
+            ui="dashkit"
+            variant="white"
+            size="sm"
+            className="whitespace-nowrap"
+            onClick={() => setIsOrquestraDialogOpen(true)}
+        >
+            MCP &amp; API
+            <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+        </Button>
+    );
+
+    const headerLinks = (
+        <div className="flex flex-wrap items-center gap-2">
+            {idlHistoryLink}
+            {orquestraLink}
+            <Dialog open={isOrquestraDialogOpen} onOpenChange={setIsOrquestraDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                            <AlertCircle className="text-destructive" size={16} />
+                            Leaving Solana Explorer
+                        </DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 pl-6">
+                        <DialogDescription>You are now leaving Explorer and going to Orquestra.</DialogDescription>
+                        <DialogDescription className="break-all font-mono text-xs">{orquestraUrl}</DialogDescription>
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button variant="outline" size="sm">
+                                Cancel
+                            </Button>
+                        </DialogClose>
+                        <Button
+                            variant="default"
+                            size="sm"
+                            onClick={() => {
+                                window.open(orquestraUrl, '_blank', 'noopener,noreferrer');
+                                setIsOrquestraDialogOpen(false);
+                            }}
+                        >
+                            Continue
+                            <ExternalLinkIcon size={12} />
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+
     // Single IDL view: show the program-metadata (PMP) IDL, falling back to the Anchor source only
     // when no PMP IDL exists.
     const idl: SupportedIdl | undefined = programMetadataIdl ?? anchorIdl;
@@ -69,7 +136,7 @@ export function IdlCard({ programId }: { programId: string }) {
                     <CardTitle as="h4" ui="dashkit">
                         Program IDL
                     </CardTitle>
-                    {idlHistoryLink}
+                    {headerLinks}
                 </CardHeader>
                 <CardBody ui="dashkit">
                     <div className="mb-6 flex items-center gap-2 text-destructive">
@@ -184,7 +251,7 @@ export function IdlCard({ programId }: { programId: string }) {
                 <CardTitle as="h4" ui="dashkit">
                     Program IDL
                 </CardTitle>
-                {idlHistoryLink}
+                {headerLinks}
             </CardHeader>
             <CardBody ui="dashkit">
                 {isMismatch ? (

--- a/app/features/idl/ui/__tests__/IdlCard.spec.tsx
+++ b/app/features/idl/ui/__tests__/IdlCard.spec.tsx
@@ -321,6 +321,7 @@ describe('IdlCard', () => {
         expect(screen.queryByRole('tab')).not.toBeInTheDocument();
         // The IDL history link lives in the header, so it's offered even when the card has no IDL.
         expect(screen.getByRole('link', { name: /IDL history/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /MCP & API/i })).toBeInTheDocument();
     });
 
     test('should link to the idl.solana.com history view for the program', async () => {
@@ -338,5 +339,52 @@ describe('IdlCard', () => {
         expect(url.searchParams.get('programId')).toBe(programId);
         expect(url.searchParams.get('mode')).toBe('history');
         expect(url.searchParams.get('cluster')).toBe('mainnet-beta');
+    });
+
+    test('should open the Orquestra project page behind the leaving-Explorer interstitial', async () => {
+        mockProgramIdls({ programMetadataIdl: createMockProgramMetadataIdl() });
+
+        render(
+            <ClusterProvider>
+                <IdlCard programId={programId} />
+            </ClusterProvider>,
+        );
+
+        const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+        fireEvent.click(await screen.findByRole('button', { name: /MCP & API/i }));
+
+        // The interstitial names the destination and shows the full URL before anything opens.
+        expect(screen.getByText('Leaving Solana Explorer')).toBeInTheDocument();
+        expect(screen.getByText(/going to Orquestra/)).toBeInTheDocument();
+        expect(windowOpenSpy).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+        expect(windowOpenSpy).toHaveBeenCalledWith(
+            `https://orquestra.dev/project/${programId}`,
+            '_blank',
+            'noopener,noreferrer',
+        );
+        windowOpenSpy.mockRestore();
+    });
+
+    test('should not open Orquestra when the interstitial is cancelled', async () => {
+        mockProgramIdls({ programMetadataIdl: createMockProgramMetadataIdl() });
+
+        render(
+            <ClusterProvider>
+                <IdlCard programId={programId} />
+            </ClusterProvider>,
+        );
+
+        const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+        fireEvent.click(await screen.findByRole('button', { name: /MCP & API/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('Leaving Solana Explorer')).not.toBeInTheDocument();
+        });
+        expect(windowOpenSpy).not.toHaveBeenCalled();
+        windowOpenSpy.mockRestore();
     });
 });


### PR DESCRIPTION
Adds a second outbound link to the **Program IDL** card header, next to the existing `IDL history` button: **MCP & API**, pointing at `https://orquestra.dev/project/{program address}`.

Orquestra hosts a per-program page that surfaces the program's IDL as MCP tooling and an API surface. Today a developer looking at a program's IDL in the Explorer has no path there. This follows the pattern the card already uses for third-party IDL tooling — `idl.solana.com` ("IDL history", same header) and `castaway.lol` ("Generate SDK", in the Download dropdown).

Implementation notes:

-   Orquestra is a third-party site, so the button goes through the same **"Leaving Solana Explorer"** interstitial the Castaway "Generate SDK" flow uses (`IdlSection.tsx`): the dialog names the destination, shows the full URL, and only opens it via `window.open(url, '_blank', 'noopener,noreferrer')` after the user hits `Continue`.
-   Styling reuses `ui="dashkit" variant="white" size="sm"` — the same look as the adjacent `IDL history` link — so the two buttons match. No conditional class logic, per `AGENTS.md`.
-   The two links are wrapped in a `flex flex-wrap` row shared by both card headers (the with-IDL state and the "no IDL yet" upload state), so the link is available in both and the pair wraps rather than overflowing on narrow viewports.
-   The Orquestra project page is cluster-agnostic (the URL carries no cluster parameter), so the link renders on every cluster.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

<img width="1822" height="1119" alt="Screenshot 2026-07-29 at 16 27 06" src="https://github.com/user-attachments/assets/8bbf5b61-c015-436f-8c5b-4fe36d9787d1" />
<img width="694" height="310" alt="Screenshot 2026-07-29 at 16 27 11" src="https://github.com/user-attachments/assets/214bce0b-f1bd-4df7-804f-96535730bbcb" />


## Testing

Tests added to `app/features/idl/ui/__tests__/IdlCard.spec.tsx`:

-   Clicking `MCP & API` shows the interstitial and opens nothing; `Continue` then calls `window.open` with `https://orquestra.dev/project/{programId}`, `_blank`, `noopener,noreferrer`.
-   `Cancel` closes the interstitial without opening anything.
-   Extended the existing empty-state test to assert the button still renders when the program has no IDL.

```
vitest --project specs run app/features/idl/ui/__tests__/IdlCard.spec.tsx
  Test Files  1 passed (1)
       Tests  11 passed (11)
  Type Errors  no errors
```

`pnpm format:ci` and `pnpm lint` both pass locally.

Manually verified with `pnpm dev`: the button sits beside `IDL history` in the card header, the interstitial shows the correct URL, `Continue` opens Orquestra in a new tab, the button renders in the no-IDL upload state, and the header wraps cleanly at narrow widths.

## Related Issues

<!-- none -->

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed — n/a
-   [ ] I have run `build:info` script to update build information — n/a, no build metadata change
-   [ ] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information — n/a

## Additional Notes

Scope is deliberately minimal: one button in one component plus its tests. No new constants module — the sibling third-party URLs (`idl.solana.com`, `castaway.lol`) are inlined in these same files, and this matches them.