### PR TITLE
fix: scheme-guard on-chain external links

### DIFF
--- a/app/api/metadata/proxy/route.ts
+++ b/app/api/metadata/proxy/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { Logger } from '@/app/shared/lib/logger';
+import { parseUrl, SAFE_EXTERNAL_PROTOCOLS } from '@/app/shared/lib/url';
 
 import { CACHE_HEADERS, ERROR_CACHE_HEADERS, MAX_SIZE, SECURITY_HEADERS, TIMEOUT, USER_AGENT } from './config';
-import {
-    fetchResource,
-    isHTTPProtocol,
-    matchJsonContent,
-    STATUS_MESSAGES,
-    type StatusCode,
-    StatusError,
-} from './feature';
+import { fetchResource, matchJsonContent, STATUS_MESSAGES, type StatusCode, StatusError } from './feature';
 
 export const dynamic = 'force-dynamic';
 // Platform backstop. The per-hop fetch timeout (NEXT_PUBLIC_METADATA_TIMEOUT,
@@ -29,12 +23,12 @@ export async function GET(request: Request) {
     // decodeURIComponent needed. The client encodes once via encodeURIComponent
     // in getProxiedUri, and this single decode reverses it symmetrically.
     const uri = new URL(request.url).searchParams.get('uri');
-    const parsedUri = parseUrl(uri);
+    const parsedUri = parseProxyUrl(uri);
     if (!parsedUri) {
         return respondWithError(400);
     }
 
-    if (!isHTTPProtocol(parsedUri)) {
+    if (!SAFE_EXTERNAL_PROTOCOLS.includes(parsedUri.protocol)) {
         Logger.error(new Error('[api:metadata-proxy] Unsupported protocol'), { protocol: parsedUri.protocol });
         return respondWithError(400);
     }
@@ -60,14 +54,15 @@ export async function GET(request: Request) {
     }
 }
 
-function parseUrl(maybeUrl: string | null): URL | undefined {
+/** Thin wrapper around shared `parseUrl` that logs invalid inputs for ops. */
+function parseProxyUrl(maybeUrl: string | null): URL | undefined {
     if (!maybeUrl) return undefined;
-    try {
-        return new URL(maybeUrl);
-    } catch (error) {
-        Logger.error(new Error('[api:metadata-proxy] Invalid URL', { cause: error }));
+    const url = parseUrl(maybeUrl);
+    if (!url) {
+        Logger.error(new Error('[api:metadata-proxy] Invalid URL'));
         return undefined;
     }
+    return url;
 }
 
 // Content-Length is intentionally omitted to avoid browser CORS issues:

--- a/app/components/account/CompressedNftCard.tsx
+++ b/app/components/account/CompressedNftCard.tsx
@@ -2,14 +2,16 @@ import { AccountCard } from '@features/account';
 import { Account } from '@providers/accounts';
 import { PublicKey } from '@solana/web3.js';
 import { Suspense } from 'react';
-import { ChevronDown, ExternalLink } from 'react-feather';
+import { ChevronDown, ExternalLink as ExternalLinkIcon } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
 import { Button } from '@/app/components/shared/ui/button';
 import { Dropdown, DropdownMenu, DropdownToggle } from '@/app/components/shared/ui/dropdown';
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
 import { getProxiedUri } from '@/app/features/metadata';
 import { useCluster } from '@/app/providers/cluster';
 import { CompressedNft, useCompressedNft, useMetadataJsonLink } from '@/app/providers/compressed-nft';
+import { getSafeExternalHref } from '@/app/shared/lib/url';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 import { Address } from '../common/Address';
@@ -60,10 +62,14 @@ export function CompressedNftCard({ account }: { account: Account }) {
             <BaseTable.Row>
                 <BaseTable.Cell>Website</BaseTable.Cell>
                 <BaseTable.Cell className="text-right">
-                    <a rel="noopener noreferrer" target="_blank" href={compressedNft.content.links.external_url}>
-                        {compressedNft.content.links.external_url}
-                        <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                    </a>
+                    {getSafeExternalHref(compressedNft.content.links.external_url) ? (
+                        <ExternalLink href={compressedNft.content.links.external_url}>
+                            {compressedNft.content.links.external_url}
+                            <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                        </ExternalLink>
+                    ) : (
+                        compressedNft.content.links.external_url
+                    )}
                 </BaseTable.Cell>
             </BaseTable.Row>
             <BaseTable.Row>

--- a/app/components/account/ConfigAccountSection.tsx
+++ b/app/components/account/ConfigAccountSection.tsx
@@ -7,6 +7,8 @@ import { PublicKey } from '@solana/web3.js';
 import { ConfigAccount, StakeConfigInfoAccount, ValidatorInfoAccount } from '@validators/accounts/config';
 import React from 'react';
 
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
+import { getSafeExternalHref } from '@/app/shared/lib/url';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 const MAX_SLASH_PENALTY = Math.pow(2, 8);
@@ -88,9 +90,13 @@ function ValidatorInfoCard({ account, configAccount }: { account: Account; confi
                 <BaseTable.Row>
                     <BaseTable.Cell>Website</BaseTable.Cell>
                     <BaseTable.Cell className="text-right">
-                        <a href={configAccount.info.configData.website} target="_blank" rel="noopener noreferrer">
-                            {configAccount.info.configData.website}
-                        </a>
+                        {getSafeExternalHref(configAccount.info.configData.website) ? (
+                            <ExternalLink href={configAccount.info.configData.website}>
+                                {configAccount.info.configData.website}
+                            </ExternalLink>
+                        ) : (
+                            configAccount.info.configData.website
+                        )}
                     </BaseTable.Cell>
                 </BaseTable.Row>
             )}

--- a/app/components/account/TokenAccountSection.tsx
+++ b/app/components/account/TokenAccountSection.tsx
@@ -45,13 +45,15 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { capitalCase } from 'change-case';
 import { useEffect, useMemo, useState } from 'react';
-import { ExternalLink } from 'react-feather';
+import { ExternalLink as ExternalLinkIcon } from 'react-feather';
 import { create } from 'superstruct';
 import useSWR from 'swr';
 
 import { Badge } from '@/app/components/shared/ui/badge';
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
 import { invariant } from '@/app/shared/lib/invariant';
 import { Logger } from '@/app/shared/lib/logger';
+import { getSafeExternalHref } from '@/app/shared/lib/url';
 import { BaseTable } from '@/app/shared/ui/Table';
 import { FullLegacyTokenInfo, getTokenInfo, getTokenInfoSwrKey } from '@/app/utils/token-info';
 
@@ -185,10 +187,14 @@ function FungibleTokenMintAccountCard({
                 <BaseTable.Row>
                     <BaseTable.Cell>Website</BaseTable.Cell>
                     <BaseTable.Cell className="md:text-right">
-                        <a rel="noopener noreferrer" target="_blank" href={tokenInfo.extensions.website}>
-                            {tokenInfo.extensions.website}
-                            <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                        </a>
+                        {getSafeExternalHref(tokenInfo.extensions.website) ? (
+                            <ExternalLink href={tokenInfo.extensions.website}>
+                                {tokenInfo.extensions.website}
+                                <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                            </ExternalLink>
+                        ) : (
+                            tokenInfo.extensions.website
+                        )}
                     </BaseTable.Cell>
                 </BaseTable.Row>
             )}
@@ -223,9 +229,13 @@ function FungibleTokenMintAccountCard({
                     <BaseTable.Cell>Bridge Contract</BaseTable.Cell>
                     <BaseTable.Cell className="md:text-right">
                         <Copyable text={bridgeContractAddress}>
-                            <a href={tokenInfo.extensions.bridgeContract} target="_blank" rel="noreferrer">
-                                {bridgeContractAddress}
-                            </a>
+                            {getSafeExternalHref(tokenInfo.extensions.bridgeContract) ? (
+                                <ExternalLink href={tokenInfo.extensions.bridgeContract}>
+                                    {bridgeContractAddress}
+                                </ExternalLink>
+                            ) : (
+                                bridgeContractAddress
+                            )}
                         </Copyable>
                     </BaseTable.Cell>
                 </BaseTable.Row>
@@ -235,9 +245,13 @@ function FungibleTokenMintAccountCard({
                     <BaseTable.Cell>Bridged Asset Contract</BaseTable.Cell>
                     <BaseTable.Cell className="md:text-right">
                         <Copyable text={assetContractAddress}>
-                            <a href={tokenInfo.extensions.bridgeContract} target="_blank" rel="noreferrer">
-                                {assetContractAddress}
-                            </a>
+                            {getSafeExternalHref(tokenInfo.extensions.bridgeContract) ? (
+                                <ExternalLink href={tokenInfo.extensions.bridgeContract}>
+                                    {assetContractAddress}
+                                </ExternalLink>
+                            ) : (
+                                assetContractAddress
+                            )}
                         </Copyable>
                     </BaseTable.Cell>
                 </BaseTable.Row>
@@ -336,10 +350,14 @@ function NonFungibleTokenMintAccountCard({
                 <BaseTable.Row>
                     <BaseTable.Cell>Website</BaseTable.Cell>
                     <BaseTable.Cell className="md:text-right">
-                        <a rel="noopener noreferrer" target="_blank" href={nftData.json.external_url}>
-                            {nftData.json.external_url}
-                            <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                        </a>
+                        {getSafeExternalHref(nftData.json.external_url) ? (
+                            <ExternalLink href={nftData.json.external_url}>
+                                {nftData.json.external_url}
+                                <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                            </ExternalLink>
+                        ) : (
+                            nftData.json.external_url
+                        )}
                     </BaseTable.Cell>
                 </BaseTable.Row>
             )}
@@ -1026,11 +1044,11 @@ export function TokenExtensionRow(
                     <BaseTable.Row>
                         <BaseTable.Cell>URI</BaseTable.Cell>
                         <BaseTable.Cell className="md:text-right">
-                            {extension.uri.startsWith('http') ? (
-                                <a rel="noopener noreferrer" target="_blank" href={extension.uri}>
+                            {getSafeExternalHref(extension.uri) ? (
+                                <ExternalLink href={extension.uri}>
                                     {extension.uri}
-                                    <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                                </a>
+                                    <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                                </ExternalLink>
                             ) : (
                                 extension.uri
                             )}

--- a/app/components/account/TokenExtensionsSection.tsx
+++ b/app/components/account/TokenExtensionsSection.tsx
@@ -1,10 +1,11 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@components/shared/ui/accordion';
 import { useCallback, useMemo, useState } from 'react';
-import { Code, ExternalLink } from 'react-feather';
+import { Code, ExternalLink as ExternalLinkIcon } from 'react-feather';
 
 import { SolarizedJsonViewer as ReactJson } from '@/app/components/common/JsonViewer';
 import { TableCardBodyHeaded } from '@/app/components/common/TableCardBody';
 import { Badge } from '@/app/components/shared/ui/badge';
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
 import {
     getAnchorId,
     useTokenExtensionNavigation,
@@ -126,12 +127,12 @@ function TokenExtensionAccordionItem({
                         </Badge>
                     </button>
                     {parsedExtension.externalLinks.map((link, index) => (
-                        <a key={index} href={link.url} target="_blank" rel="noopener noreferrer">
+                        <ExternalLink key={index} href={link.url}>
                             <Badge variant="transparent" size="sm" as="link" className="font-normal text-white">
-                                <ExternalLink size={16} />
+                                <ExternalLinkIcon size={16} />
                                 {link.label}
                             </Badge>
-                        </a>
+                        </ExternalLink>
                     ))}
                 </div>
             </div>

--- a/app/components/account/VerifiedBuildCard.tsx
+++ b/app/components/account/VerifiedBuildCard.tsx
@@ -3,9 +3,11 @@ import { TableCardBody } from '@components/common/TableCardBody';
 import { UpgradeableLoaderAccountData } from '@providers/accounts';
 import { PublicKey } from '@solana/web3.js';
 import Link from 'next/link';
-import { ExternalLink } from 'react-feather';
+import { ExternalLink as ExternalLinkIcon } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
+import { getSafeExternalHref } from '@/app/shared/lib/url';
 import { Alert } from '@/app/shared/ui/Alert';
 import { Card, CardBody, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -97,7 +99,7 @@ export function BaseVerifiedBuildCard({
                 A verified build badge indicates that this program was built from source code that is publicly
                 available, but does not imply that this program has been audited. For more details, refer to the{' '}
                 <a href={VERIFIED_BUILDS_GUIDE_URL} target="_blank" rel="noopener noreferrer">
-                    Verified Builds Guide <ExternalLink className="ml-[3px] align-text-top" size={13} />
+                    Verified Builds Guide <ExternalLinkIcon className="ml-[3px] align-text-top" size={13} />
                 </a>
                 .
             </Alert>
@@ -219,24 +221,26 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
                     )}
                 </BaseTable.Cell>
             );
-        case DisplayType.URL:
-            if (isValidLink(value as string)) {
+        case DisplayType.URL: {
+            const href = value as string;
+            if (getSafeExternalHref(href)) {
                 return (
                     <BaseTable.Cell className="text-right">
                         <span className="whitespace-nowrap font-mono">
-                            <a rel="noopener noreferrer" target="_blank" href={value as string}>
-                                {value}
-                                <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                            </a>
+                            <ExternalLink href={href}>
+                                {href}
+                                <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                            </ExternalLink>
                         </span>
                     </BaseTable.Cell>
                 );
             }
             return (
                 <BaseTable.Cell className="text-right font-mono">
-                    {value && (value as string).length > 1 ? (value as string).trim() : '-'}
+                    {href && href.length > 1 ? href.trim() : '-'}
                 </BaseTable.Cell>
             );
+        }
         case DisplayType.Date:
             return (
                 <BaseTable.Cell className="text-right font-mono">
@@ -253,13 +257,4 @@ function RenderEntry({ value, type }: { value: OsecRegistryInfo[keyof OsecRegist
             break;
     }
     return <></>;
-}
-
-function isValidLink(value: string) {
-    try {
-        const url = new URL(value);
-        return ['http:', 'https:'].includes(url.protocol);
-    } catch (_err) {
-        return false;
-    }
 }

--- a/app/features/security-txt/ui/__tests__/common.spec.tsx
+++ b/app/features/security-txt/ui/__tests__/common.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ContactInfo, RenderExternalLink } from '../common';
+
+describe('ContactInfo link', () => {
+    it('should render a guarded external anchor for http(s) contact links', () => {
+        render(<ContactInfo type="link" information="https://example.com/security" />);
+
+        const link = screen.getByRole('link', { name: /https:\/\/example.com\/security/i });
+        expect(link).toHaveAttribute('href', 'https://example.com/security');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it.each(['javascript:alert(1)', 'data:text/html,x', 'vbscript:msgbox(1)'])(
+        'should render plain text and no anchor for unsafe contact link: %s',
+        href => {
+            render(<ContactInfo type="link" information={href} />);
+
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+            expect(screen.getByText(href)).toBeInTheDocument();
+        },
+    );
+});
+
+describe('RenderExternalLink', () => {
+    it('should render a guarded external anchor for http(s) URLs', () => {
+        render(<RenderExternalLink url="https://example.com/policy" />);
+
+        const link = screen.getByRole('link', { name: /https:\/\/example.com\/policy/i });
+        expect(link).toHaveAttribute('href', 'https://example.com/policy');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it.each(['javascript:alert(1)', 'data:text/html,x'])(
+        'should render plain text and no anchor for unsafe URL: %s',
+        href => {
+            render(<RenderExternalLink url={href} />);
+
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+            expect(screen.getByText(href)).toBeInTheDocument();
+        },
+    );
+});

--- a/app/features/security-txt/ui/common.tsx
+++ b/app/features/security-txt/ui/common.tsx
@@ -1,11 +1,13 @@
 import classNames from 'classnames';
-import { ExternalLink } from 'react-feather';
+import { ExternalLink as ExternalLinkIcon } from 'react-feather';
 
 import { Badge } from '@/app/components/shared/ui/badge';
+import { ExternalLink } from '@/app/components/shared/ui/external-link';
+import { getSafeExternalHref } from '@/app/shared/lib/url';
 import { BaseTable } from '@/app/shared/ui/Table';
 
 import type { SecurityTxtVersion } from './types';
-import { isValidLink, parseCodeValue } from './utils';
+import { parseCodeValue } from './utils';
 
 export function CodeCell({ value, alignRight = true }: { value: string; alignRight: boolean }) {
     return (
@@ -45,30 +47,31 @@ export function ContactInfo({ type, information }: { type: string; information: 
             return (
                 <a rel="noopener noreferrer" target="_blank" href={`mailto:${information}`}>
                     {information}
-                    <ExternalLink className="ml-1.5 align-text-top" size={13} />
+                    <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
                 </a>
             );
         case 'telegram':
             return (
                 <a rel="noopener noreferrer" target="_blank" href={`https://t.me/${information}`}>
                     Telegram: {information}
-                    <ExternalLink className="ml-1.5 align-text-top" size={13} />
+                    <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
                 </a>
             );
         case 'twitter':
             return (
                 <a rel="noopener noreferrer" target="_blank" href={`https://twitter.com/${information}`}>
                     Twitter {information}
-                    <ExternalLink className="ml-1.5 align-text-top" size={13} />
+                    <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
                 </a>
             );
         case 'link':
-            if (isValidLink(information)) {
+            // On-chain contact URLs are untrusted — ExternalLink scheme-guards; fall back to plain text.
+            if (getSafeExternalHref(information)) {
                 return (
-                    <a rel="noopener noreferrer" target="_blank" href={`${information}`}>
+                    <ExternalLink href={information}>
                         {information}
-                        <ExternalLink className="ml-1.5 align-text-top" size={13} />
-                    </a>
+                        <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                    </ExternalLink>
                 );
             }
             return <>{information}</>;
@@ -85,10 +88,14 @@ export function ContactInfo({ type, information }: { type: string; information: 
 export function RenderExternalLink({ url }: { url: string }) {
     return (
         <span className="font-mono">
-            <a rel="noopener noreferrer" target="_blank" href={url}>
-                {url}
-                <ExternalLink className="ml-1.5 align-text-top" size={13} />
-            </a>
+            {getSafeExternalHref(url) ? (
+                <ExternalLink href={url}>
+                    {url}
+                    <ExternalLinkIcon className="ml-1.5 align-text-top" size={13} />
+                </ExternalLink>
+            ) : (
+                url
+            )}
         </span>
     );
 }

--- a/openspec/changes/harden-external-link-schemes/tasks.md
+++ b/openspec/changes/harden-external-link-schemes/tasks.md
@@ -12,26 +12,28 @@
 
 > **Naming collision:** `CompressedNftCard`, `TokenAccountSection`, `TokenExtensionsSection`, `VerifiedBuildCard`, and `security-txt/ui/common.tsx` already `import { ExternalLink } from 'react-feather'` (the trailing icon next to each link). Alias one side on import when migrating — e.g. `import { ExternalLink as ExternalLinkIcon } from 'react-feather'`, or import the shared component as `ExternalLink as SafeExternalLink` — otherwise the first edit hits a duplicate-identifier `SyntaxError`.
 
-- [ ] `app/components/account/CompressedNftCard.tsx` — `content.links.external_url`
-- [ ] `app/components/account/TokenAccountSection.tsx` — `extensions.website`
-- [ ] `app/components/account/TokenAccountSection.tsx` — `extensions.bridgeContract` (×2; the missing `noopener` comes for free)
-- [ ] `app/components/account/TokenAccountSection.tsx` — `nftData.json.external_url`
-- [ ] `app/components/account/TokenAccountSection.tsx` — `extension.uri`
-- [ ] `app/components/account/ConfigAccountSection.tsx` — `configData.website`
-- [ ] `app/components/account/TokenExtensionsSection.tsx` — `link.url`
-- [ ] `app/features/security-txt/ui/common.tsx` — website field and `url` (leave the `mailto:`/`t.me/`/`twitter.com/` template links as-is)
-- [ ] `app/components/account/VerifiedBuildCard.tsx:211` — the `DisplayType.URL` metadata `value` anchor (currently gated by the file-local `isValidLink`, not the shared guard)
+- [x] `app/components/account/CompressedNftCard.tsx` — `content.links.external_url`
+- [x] `app/components/account/TokenAccountSection.tsx` — `extensions.website`
+- [x] `app/components/account/TokenAccountSection.tsx` — `extensions.bridgeContract` (×2; the missing `noopener` comes for free)
+- [x] `app/components/account/TokenAccountSection.tsx` — `nftData.json.external_url`
+- [x] `app/components/account/TokenAccountSection.tsx` — `extension.uri`
+- [x] `app/components/account/ConfigAccountSection.tsx` — `configData.website`
+- [x] `app/components/account/TokenExtensionsSection.tsx` — `link.url`
+- [x] `app/features/security-txt/ui/common.tsx` — website field and `url` (leave the `mailto:`/`t.me/`/`twitter.com/` template links as-is)
+- [x] `app/components/account/VerifiedBuildCard.tsx:211` — the `DisplayType.URL` metadata `value` anchor (currently gated by the file-local `isValidLink`, not the shared guard)
 
 ## 2. Provenance audit (migrate only if untrusted)
 
-- [ ] `app/features/token-verification-badge/ui/TokenVerificationContent.tsx` — `source.url`, `source.applyUrl`
-- [ ] `app/features/feature-gate/ui/*` and `app/components/account/FeatureAccountSection.tsx` — `simd_link`
-- [ ] `app/components/DeveloperResources.tsx` and `app/entities/cluster/ui/ExplorerLink.tsx` — `link`
+- [x] `app/features/token-verification-badge/ui/TokenVerificationContent.tsx` — `source.url`, `source.applyUrl` — **leave as-is**: URLs are built from hardcoded `https://` templates with only a base58 address interpolated (`use-verification-sources.ts`), so the scheme cannot be attacker-controlled.
+- [x] `app/features/feature-gate/ui/*` and `app/components/account/FeatureAccountSection.tsx` — `simd_link` — **leave as-is**: links come from the Foundation-curated feature-gates pipeline (wiki / SIMD GitHub scrape → committed JSON), not from arbitrary on-chain authors.
+- [x] `app/components/DeveloperResources.tsx` and `app/entities/cluster/ui/ExplorerLink.tsx` — `link` — **leave as-is**: `DeveloperResources` uses hardcoded constants; `ExplorerLink` builds same-origin explorer paths via `useExplorerLink`.
 
 ## 3. De-duplicate the server-side copy
 
-- [ ] `app/api/metadata/proxy/route.ts` — replace the local `parseUrl` + `isHTTPProtocol` with the shared `parseUrl` / `SAFE_EXTERNAL_PROTOCOLS`, keeping a thin wrapper for the invalid-URL `Logger.error`. No behaviour change (the route already rejects non-http(s)).
+- [x] `app/api/metadata/proxy/route.ts` — replace the local `parseUrl` + `isHTTPProtocol` with the shared `parseUrl` / `SAFE_EXTERNAL_PROTOCOLS`, keeping a thin wrapper for the invalid-URL `Logger.error`. No behaviour change (the route already rejects non-http(s)).
 
 ## 4. Verify
 
-- [ ] `pnpm typecheck`, targeted tests asserting unsafe schemes render no anchor, and `pnpm openspec:validate` pass.
+- [x] Targeted tests asserting unsafe schemes render no anchor at the migrated sinks (`security-txt/ui/__tests__/common.spec.tsx`; shared `ExternalLink` coverage remains in `app/components/shared/ui/__tests__/external-link.spec.tsx`).
+- [x] `pnpm openspec:validate` passes.
+- [x] Targeted unit tests pass.


### PR DESCRIPTION
## Description

Migrate remaining on-chain / third-party URL sinks to the shared `ExternalLink` + `getSafeExternalHref` guard so `javascript:` / `data:` / other non-http(s) schemes never reach the DOM. Also dedupe the metadata proxy route onto shared `parseUrl` / `SAFE_EXTERNAL_PROTOCOLS`.

Implements `openspec/changes/harden-external-link-schemes`.

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [ ] Other (please describe):

## Screenshots

N/A — security hardening; unsafe URLs now render as plain text (no anchor). Valid `https://` links are unchanged.

## Testing

- Targeted unit tests: `app/features/security-txt/ui/__tests__/common.spec.tsx` (unsafe schemes → no link; http(s) → guarded anchor)
- Existing `ExternalLink` / `getSafeExternalHref` specs still pass
- `pnpm openspec:validate`

## Related Issues

Implements OpenSpec change `harden-external-link-schemes` (follow-up to metadata-proxy / #1050).

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [x] For security-related features, I have included links to related information

## Additional Notes

Provenance audit left verification-badge URLs, SIMD links, DeveloperResources, and ExplorerLink unchanged (hardcoded / Foundation-curated / same-origin).