### PR TITLE
refactor(token-info): drop @solflare-wallet/utl-sdk, resolve mints server-side

### DIFF
--- a/.storybook/__mocks__/MockTokenInfoBatchProvider.tsx
+++ b/.storybook/__mocks__/MockTokenInfoBatchProvider.tsx
@@ -1,14 +1,15 @@
-import { Token } from '@solflare-wallet/utl-sdk';
 import { getTokenInfoSwrKey } from '@utils/token-info';
 import React, { useCallback } from 'react';
 import { mutate } from 'swr';
+
+import type { TokenInfo } from '@/app/entities/token-info';
 
 import { TokenInfoBatchContext } from '../../app/entities/token-info/model/token-info-batch-provider';
 
 type MockTokenInfoBatchProviderProps = {
     children: React.ReactNode;
     /** Optional per-mint token info keyed by base58 address. When set, a requested mint's SWR entry is seeded. */
-    infos?: Record<string, Partial<Token>>;
+    infos?: Record<string, Partial<TokenInfo>>;
 };
 
 /**

--- a/app/api/token-info/__tests__/route.spec.ts
+++ b/app/api/token-info/__tests__/route.spec.ts
@@ -1,13 +1,17 @@
-import { PublicKey } from '@solana/web3.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { gen } from '@/app/__fixtures__/gen';
 import type { TokenInfo } from '@/app/entities/token-info/server';
 import { Logger } from '@/app/shared/lib/logger';
 import { Cluster } from '@/app/utils/cluster';
 
-const MINT_A = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
-const MINT_B = 'So11111111111111111111111111111111111111112';
-const MINT_C = 'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So';
+import { MAX_ADDRESSES } from '../config';
+
+// The route treats a mint as an opaque, well-formed address, so generated ones say more about
+// what is under test than real mints would.
+const MINT_A = gen.address(1);
+const MINT_B = gen.address(2);
+const MINT_C = gen.address(3);
 
 const mocks = vi.hoisted(() => ({
     getTokenInfos: vi.fn(),
@@ -79,9 +83,32 @@ describe('POST /api/token-info', () => {
         expect(mocks.getTokenInfos).not.toHaveBeenCalled();
     });
 
+    it('should return 400 when the cluster is not a number', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: '0' }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when the genesis hash is not a string', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: Cluster.Custom, genesisHash: 42 }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should ignore keys it does not know', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: Cluster.MainnetBeta, verbose: true }));
+
+        expect(res.status).toBe(200);
+    });
+
     it('should return 400 when more distinct addresses than the cap are requested', async () => {
         const { POST } = await importRoute();
-        const addresses = Array.from({ length: 129 }, (_, i) => addressAt(i));
+        const addresses = Array.from({ length: MAX_ADDRESSES + 1 }, (_, i) => gen.address(i));
         const res = await POST(createRequest({ addresses, cluster: Cluster.MainnetBeta }));
 
         expect(res.status).toBe(400);
@@ -222,14 +249,6 @@ describe('POST /api/token-info', () => {
         expect(mocks.getTokenInfos).not.toHaveBeenCalled();
     });
 });
-
-/** Builds a distinct, well-formed mint address for cap tests. */
-function addressAt(index: number): string {
-    const bytes = new Uint8Array(32);
-    bytes[0] = index + 1;
-    bytes[1] = Math.floor((index + 1) / 256);
-    return new PublicKey(bytes).toBase58();
-}
 
 function createRequest(body: Record<string, unknown>) {
     return new Request('http://localhost:3000/api/token-info', {

--- a/app/api/token-info/__tests__/route.spec.ts
+++ b/app/api/token-info/__tests__/route.spec.ts
@@ -170,10 +170,12 @@ describe('POST /api/token-info', () => {
             }),
         );
 
+        // The endpoint is resolved from server config, and nothing is derived from the incoming
+        // request — a caller-controlled Host must not be able to redirect the fallback's fetches.
         expect(mocks.getTokenInfosFromMetaplex).toHaveBeenCalledWith(
             [MINT_B, MINT_C],
             expect.any(String),
-            expect.objectContaining({ baseUrl: 'http://localhost:3000' }),
+            expect.not.objectContaining({ baseUrl: expect.anything() }),
         );
         expect(await res.json()).toEqual({ content: [token(MINT_A), token(MINT_C, { verified: false })] });
     });

--- a/app/api/token-info/__tests__/route.spec.ts
+++ b/app/api/token-info/__tests__/route.spec.ts
@@ -1,0 +1,242 @@
+import { PublicKey } from '@solana/web3.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TokenInfo } from '@/app/entities/token-info/server';
+import { Logger } from '@/app/shared/lib/logger';
+import { Cluster } from '@/app/utils/cluster';
+
+const MINT_A = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const MINT_B = 'So11111111111111111111111111111111111111112';
+const MINT_C = 'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So';
+
+const mocks = vi.hoisted(() => ({
+    getTokenInfos: vi.fn(),
+    getTokenInfosFromMetaplex: vi.fn(),
+}));
+
+// The UTL list lookup and the Metaplex fallback each have their own spec. The route is the transport
+// edge, so both are mocked here to exercise body parsing, the address cap, response shaping, and the
+// opt-in fallback policy. `isValidCluster` stays real so cluster handling is exercised end to end.
+vi.mock('@entities/token-info/server', async () => {
+    const actual = await vi.importActual<typeof import('@entities/token-info/server')>('@entities/token-info/server');
+    return {
+        ...actual,
+        getTokenInfos: mocks.getTokenInfos,
+        getTokenInfosFromMetaplex: mocks.getTokenInfosFromMetaplex,
+    };
+});
+
+function token(address: string, overrides: Partial<TokenInfo> = {}): TokenInfo {
+    return {
+        address,
+        decimals: 6,
+        logoURI: null,
+        name: `Token ${address.slice(0, 4)}`,
+        symbol: 'TKN',
+        verified: true,
+        ...overrides,
+    };
+}
+
+describe('POST /api/token-info', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(Logger, 'warn').mockImplementation(() => {});
+        mocks.getTokenInfos.mockResolvedValue([]);
+        mocks.getTokenInfosFromMetaplex.mockResolvedValue([]);
+    });
+
+    it('should return 400 when the body is not valid JSON', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(new Request('http://localhost:3000/api/token-info', { body: 'nope', method: 'POST' }));
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: 'Invalid request' });
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when neither address nor addresses is given', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for a malformed address', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A, 'not-a-pubkey'], cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for an unsupported cluster', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: 999 }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when more distinct addresses than the cap are requested', async () => {
+        const { POST } = await importRoute();
+        const addresses = Array.from({ length: 129 }, (_, i) => addressAt(i));
+        const res = await POST(createRequest({ addresses, cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(400);
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+
+    it('should accept a request whose repeats push it over the cap only before de-duplication', async () => {
+        const { POST } = await importRoute();
+        // A single transaction can move one mint through far more than `MAX_ADDRESSES` token
+        // accounts; that must not be rejected, because it is one distinct lookup.
+        const addresses = Array.from({ length: 400 }, () => MINT_A);
+        const res = await POST(createRequest({ addresses, cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(200);
+        expect(mocks.getTokenInfos).toHaveBeenCalledWith([MINT_A], Cluster.MainnetBeta, undefined, expect.anything());
+    });
+
+    it('should accept a single address and still answer with an array', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([token(MINT_A)]);
+
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ address: MINT_A, cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ content: [token(MINT_A)] });
+        expect(mocks.getTokenInfos).toHaveBeenCalledWith([MINT_A], Cluster.MainnetBeta, undefined, expect.anything());
+    });
+
+    it('should resolve several addresses in one request', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([token(MINT_A), token(MINT_B)]);
+
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A, MINT_B], cluster: Cluster.MainnetBeta }));
+
+        expect(await res.json()).toEqual({ content: [token(MINT_A), token(MINT_B)] });
+        expect(mocks.getTokenInfos).toHaveBeenCalledWith(
+            [MINT_A, MINT_B],
+            Cluster.MainnetBeta,
+            undefined,
+            expect.anything(),
+        );
+    });
+
+    it('should de-duplicate repeated addresses', async () => {
+        const { POST } = await importRoute();
+        await POST(createRequest({ addresses: [MINT_A, MINT_A, MINT_B], cluster: Cluster.MainnetBeta }));
+
+        expect(mocks.getTokenInfos).toHaveBeenCalledWith(
+            [MINT_A, MINT_B],
+            Cluster.MainnetBeta,
+            undefined,
+            expect.anything(),
+        );
+    });
+
+    it('should forward the genesis hash so a custom cluster can resolve a chain id', async () => {
+        const genesisHash = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: Cluster.Custom, genesisHash }));
+
+        expect(res.status).toBe(200);
+        expect(mocks.getTokenInfos).toHaveBeenCalledWith([MINT_A], Cluster.Custom, genesisHash, expect.anything());
+    });
+
+    it('should not read on-chain metadata unless the caller opts in', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([]);
+
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [MINT_A], cluster: Cluster.MainnetBeta }));
+
+        expect(await res.json()).toEqual({ content: [] });
+        expect(mocks.getTokenInfosFromMetaplex).not.toHaveBeenCalled();
+    });
+
+    it('should read on-chain metadata only for mints the list is missing', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([token(MINT_A)]);
+        mocks.getTokenInfosFromMetaplex.mockResolvedValueOnce([token(MINT_C, { verified: false })]);
+
+        const { POST } = await importRoute();
+        const res = await POST(
+            createRequest({
+                addresses: [MINT_A, MINT_B, MINT_C],
+                cluster: Cluster.MainnetBeta,
+                includeOnChainFallback: true,
+            }),
+        );
+
+        expect(mocks.getTokenInfosFromMetaplex).toHaveBeenCalledWith(
+            [MINT_B, MINT_C],
+            expect.any(String),
+            expect.objectContaining({ baseUrl: 'http://localhost:3000' }),
+        );
+        expect(await res.json()).toEqual({ content: [token(MINT_A), token(MINT_C, { verified: false })] });
+    });
+
+    it('should skip the on-chain lookup when the list already covers every mint', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([token(MINT_A), token(MINT_B)]);
+
+        const { POST } = await importRoute();
+        await POST(
+            createRequest({
+                addresses: [MINT_A, MINT_B],
+                cluster: Cluster.MainnetBeta,
+                includeOnChainFallback: true,
+            }),
+        );
+
+        expect(mocks.getTokenInfosFromMetaplex).not.toHaveBeenCalled();
+    });
+
+    it('should still return the listed tokens when the on-chain lookup throws', async () => {
+        mocks.getTokenInfos.mockResolvedValueOnce([token(MINT_A)]);
+        mocks.getTokenInfosFromMetaplex.mockRejectedValueOnce(new Error('rpc exploded'));
+
+        const { POST } = await importRoute();
+        const res = await POST(
+            createRequest({
+                addresses: [MINT_A, MINT_B],
+                cluster: Cluster.MainnetBeta,
+                includeOnChainFallback: true,
+            }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ content: [token(MINT_A)] });
+        expect(Logger.warn).toHaveBeenCalled();
+    });
+
+    it('should answer with an empty list for an empty addresses array', async () => {
+        const { POST } = await importRoute();
+        const res = await POST(createRequest({ addresses: [], cluster: Cluster.MainnetBeta }));
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ content: [] });
+        expect(mocks.getTokenInfos).not.toHaveBeenCalled();
+    });
+});
+
+/** Builds a distinct, well-formed mint address for cap tests. */
+function addressAt(index: number): string {
+    const bytes = new Uint8Array(32);
+    bytes[0] = index + 1;
+    bytes[1] = Math.floor((index + 1) / 256);
+    return new PublicKey(bytes).toBase58();
+}
+
+function createRequest(body: Record<string, unknown>) {
+    return new Request('http://localhost:3000/api/token-info', {
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    });
+}
+
+async function importRoute() {
+    return await import('../route');
+}

--- a/app/api/token-info/config.ts
+++ b/app/api/token-info/config.ts
@@ -1,0 +1,13 @@
+// Configuration for the token-info route. Note: the Next.js route segment config
+// (`maxDuration`) stays in route.ts — Next only reads those as literal exports of
+// the route module, not via re-export.
+
+/** How long a resolved token list stays fresh in the Next data cache. */
+export const CACHE_MAX_AGE = 3600; // 1 hour
+
+/**
+ * Caps how many distinct mints one request may resolve. `TokensProvider` sends
+ * up to 101 token accounts, so this leaves headroom without letting a caller
+ * fan out an unbounded number of RPC lookups.
+ */
+export const MAX_ADDRESSES = 128;

--- a/app/api/token-info/route.ts
+++ b/app/api/token-info/route.ts
@@ -2,40 +2,53 @@ import { getTokenInfos, getTokenInfosFromMetaplex, isValidCluster, type TokenInf
 import { isAddress } from '@solana/kit';
 import { Cluster, serverClusterUrl } from '@utils/cluster';
 import { NextResponse } from 'next/server';
+import { array, boolean, type Infer, is, number, optional, refine, string, type } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-const CACHE_MAX_AGE = 3600; // 1 hour
+import { CACHE_MAX_AGE, MAX_ADDRESSES } from './config';
+
+// Platform backstop, as in `app/api/metadata/proxy/route.ts`. One invocation is the UTL list
+// lookup, then at most four RPC calls (`MAX_ADDRESSES` keys, chunked 100 at a time), then the
+// off-chain logo reads — and those are already bounded as a group by `LOGO_BUDGET_MS` (10s).
+// That leaves headroom here rather than a limit the fallback can hit. Kept inline (not in
+// config.ts): Next reads route segment config only as literal route exports.
+export const maxDuration = 30;
+
+const AddressStruct = refine(string(), 'address', value => isAddress(value));
 
 /**
- * Caps how many distinct mints one request may resolve. `TokensProvider` sends
- * up to 101 token accounts, so this leaves headroom without letting a caller
- * fan out an unbounded number of RPC lookups.
+ * An accepted request body; unknown keys are ignored.
+ *
+ * Two rules stay outside the struct because they are not shape checks: `cluster` is validated
+ * here only as a number, since `isValidCluster` decides whether it resolves a chain id, and the
+ * address cap applies after de-duplication.
  */
-const MAX_ADDRESSES = 128;
+const RequestStruct = type({
+    address: optional(AddressStruct),
+    addresses: optional(array(AddressStruct)),
+    cluster: number(),
+    genesisHash: optional(string()),
+    includeOnChainFallback: optional(boolean()),
+});
 
-type RequestBody = {
-    address?: unknown;
-    addresses?: unknown;
-    cluster?: unknown;
-    genesisHash?: unknown;
-    includeOnChainFallback?: unknown;
-};
+type RequestBody = Infer<typeof RequestStruct>;
 
 export async function POST(request: Request) {
-    let body: RequestBody;
+    let payload: unknown;
     try {
-        body = await request.json();
+        payload = await request.json();
     } catch {
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+        return invalidRequest();
     }
 
-    const { cluster, genesisHash } = body;
-    const maybeGenesisHash = typeof genesisHash === 'string' ? genesisHash : undefined;
-    const addresses = parseAddresses(body);
+    if (!is(payload, RequestStruct)) return invalidRequest();
 
-    if (!addresses || !isValidCluster(cluster, maybeGenesisHash)) {
-        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    const { cluster, genesisHash, includeOnChainFallback } = payload;
+    const addresses = distinctAddresses(payload);
+
+    if (!addresses || !isValidCluster(cluster, genesisHash)) {
+        return invalidRequest();
     }
 
     if (addresses.length === 0) {
@@ -44,37 +57,36 @@ export async function POST(request: Request) {
 
     // Allow to resolve chainId with genesisHash as the request does not use Connection instance
     // For requests that use Connection, Custom cluster should be disabled
-    const listed = await getTokenInfos(addresses, cluster, maybeGenesisHash, {
+    const listed = await getTokenInfos(addresses, cluster, genesisHash, {
         next: { revalidate: CACHE_MAX_AGE },
     });
 
     // Opt-in: only the batch path used to get the SDK's on-chain fallback, so
     // single-mint callers keep paying for the list lookup alone.
-    const tokens =
-        body.includeOnChainFallback === true ? await withMetaplexFallback(listed, addresses, cluster) : listed;
+    const tokens = includeOnChainFallback === true ? await withMetaplexFallback(listed, addresses, cluster) : listed;
 
     // `content` is always an array; single-address callers read `content[0]`.
     return NextResponse.json({ content: tokens });
 }
 
+function invalidRequest() {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+}
+
 /**
  * Reads the requested mints. Accepts a single `address` or an `addresses`
  * array; `address` is kept for the callers that resolve one mint at a time.
+ * Answers `undefined` when neither is given, or when the request names more
+ * distinct mints than `MAX_ADDRESSES`.
  */
-function parseAddresses(body: RequestBody): string[] | undefined {
-    let raw: unknown[] | undefined;
-    if (Array.isArray(body.addresses)) raw = body.addresses;
-    else if (body.address !== undefined) raw = [body.address];
-
-    if (!raw) return undefined;
+function distinctAddresses({ address, addresses }: RequestBody): string[] | undefined {
+    const requested = addresses ?? (address === undefined ? undefined : [address]);
+    if (!requested) return undefined;
 
     // De-duplicate before the cap: one transaction often moves the same mint through several token
     // accounts, and a repeated mint costs one lookup rather than a slot against the limit.
-    const unique = Array.from(new Set(raw));
-    if (unique.length > MAX_ADDRESSES) return undefined;
-    if (!unique.every((value): value is string => typeof value === 'string' && isAddress(value))) return undefined;
-
-    return unique;
+    const unique = Array.from(new Set(requested));
+    return unique.length > MAX_ADDRESSES ? undefined : unique;
 }
 
 /**

--- a/app/api/token-info/route.ts
+++ b/app/api/token-info/route.ts
@@ -1,22 +1,112 @@
-import { getTokenInfos, isValidCluster } from '@entities/token-info';
-import { Cluster } from '@utils/cluster';
+import { getTokenInfos, getTokenInfosFromMetaplex, isValidCluster, type TokenInfo } from '@entities/token-info/server';
+import { isAddress } from '@solana/kit';
+import { Cluster, serverClusterUrl } from '@utils/cluster';
 import { NextResponse } from 'next/server';
+
+import { Logger } from '@/app/shared/lib/logger';
 
 const CACHE_MAX_AGE = 3600; // 1 hour
 
+/**
+ * Caps how many distinct mints one request may resolve. `TokensProvider` sends
+ * up to 101 token accounts, so this leaves headroom without letting a caller
+ * fan out an unbounded number of RPC lookups.
+ */
+const MAX_ADDRESSES = 128;
+
+type RequestBody = {
+    address?: unknown;
+    addresses?: unknown;
+    cluster?: unknown;
+    genesisHash?: unknown;
+    includeOnChainFallback?: unknown;
+};
+
 export async function POST(request: Request) {
-    const { address, cluster, genesisHash } = await request.json();
-
-    const maybeGenesisHash = typeof genesisHash === 'string' ? genesisHash : undefined;
-
-    if (typeof address !== 'string' || !isValidCluster(cluster, maybeGenesisHash)) {
+    let body: RequestBody;
+    try {
+        body = await request.json();
+    } catch {
         return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    }
+
+    const { cluster, genesisHash } = body;
+    const maybeGenesisHash = typeof genesisHash === 'string' ? genesisHash : undefined;
+    const addresses = parseAddresses(body);
+
+    if (!addresses || !isValidCluster(cluster, maybeGenesisHash)) {
+        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    }
+
+    if (addresses.length === 0) {
+        return NextResponse.json({ content: [] });
     }
 
     // Allow to resolve chainId with genesisHash as the request does not use Connection instance
     // For requests that use Connection, Custom cluster should be disabled
-    const tokens = await getTokenInfos([address], cluster as Cluster, maybeGenesisHash, {
+    const listed = await getTokenInfos(addresses, cluster, maybeGenesisHash, {
         next: { revalidate: CACHE_MAX_AGE },
     });
-    return NextResponse.json({ content: tokens[0] });
+
+    // Opt-in: only the batch path used to get the SDK's on-chain fallback, so
+    // single-mint callers keep paying for the list lookup alone.
+    const tokens =
+        body.includeOnChainFallback === true
+            ? await withMetaplexFallback(listed, addresses, cluster, request.url)
+            : listed;
+
+    // `content` is always an array; single-address callers read `content[0]`.
+    return NextResponse.json({ content: tokens });
+}
+
+/**
+ * Reads the requested mints. Accepts a single `address` or an `addresses`
+ * array; `address` is kept for the callers that resolve one mint at a time.
+ */
+function parseAddresses(body: RequestBody): string[] | undefined {
+    let raw: unknown[] | undefined;
+    if (Array.isArray(body.addresses)) raw = body.addresses;
+    else if (body.address !== undefined) raw = [body.address];
+
+    if (!raw) return undefined;
+
+    // De-duplicate before the cap: one transaction often moves the same mint through several token
+    // accounts, and a repeated mint costs one lookup rather than a slot against the limit.
+    const unique = Array.from(new Set(raw));
+    if (unique.length > MAX_ADDRESSES) return undefined;
+    if (!unique.every((value): value is string => typeof value === 'string' && isAddress(value))) return undefined;
+
+    return unique;
+}
+
+/**
+ * Fills in mints the UTL list does not carry by reading their on-chain Metaplex
+ * metadata. The fallback is best-effort: a failure here still returns the
+ * listed tokens.
+ */
+async function withMetaplexFallback(
+    listed: TokenInfo[],
+    addresses: string[],
+    cluster: Cluster,
+    requestUrl: string,
+): Promise<TokenInfo[]> {
+    const found = new Set(listed.map(token => token.address));
+    const missing = addresses.filter(address => !found.has(address));
+    if (missing.length === 0) return listed;
+
+    // Resolved server-side on purpose: a client-supplied RPC URL would let a
+    // caller point this route at an arbitrary host.
+    const rpcEndpoint = serverClusterUrl(cluster, '');
+    if (!rpcEndpoint) return listed;
+
+    try {
+        const onChain = await getTokenInfosFromMetaplex(missing, rpcEndpoint, {
+            baseUrl: new URL(requestUrl).origin,
+            onError: error => Logger.warn('[api:token-info] Metaplex lookup failed', { error }),
+        });
+        return [...listed, ...onChain];
+    } catch (error) {
+        Logger.warn('[api:token-info] Metaplex fallback failed', { error });
+        return listed;
+    }
 }

--- a/app/api/token-info/route.ts
+++ b/app/api/token-info/route.ts
@@ -94,8 +94,14 @@ async function withMetaplexFallback(
     const missing = addresses.filter(address => !found.has(address));
     if (missing.length === 0) return listed;
 
-    // Resolved server-side on purpose: a client-supplied RPC URL would let a
-    // caller point this route at an arbitrary host.
+    // Resolved server-side on purpose: forwarding the browser's RPC URL would let any caller
+    // point this route at an arbitrary host.
+    //
+    // The cost is `Cluster.Custom`, whose endpoint only the browser knows, so it returns ''
+    // and the on-chain fallback is skipped. No regression: a custom cluster has no chain id
+    // unless the caller supplies a matching `genesisHash`, and neither `TokenBalancesCard` nor
+    // `TokensProvider` does, so `getTokenInfos` already returned nothing there. Where a chain
+    // id does resolve, the UTL list is still served — only the on-chain fallback is dropped.
     const rpcEndpoint = serverClusterUrl(cluster, '');
     if (!rpcEndpoint) return listed;
 

--- a/app/api/token-info/route.ts
+++ b/app/api/token-info/route.ts
@@ -51,9 +51,7 @@ export async function POST(request: Request) {
     // Opt-in: only the batch path used to get the SDK's on-chain fallback, so
     // single-mint callers keep paying for the list lookup alone.
     const tokens =
-        body.includeOnChainFallback === true
-            ? await withMetaplexFallback(listed, addresses, cluster, request.url)
-            : listed;
+        body.includeOnChainFallback === true ? await withMetaplexFallback(listed, addresses, cluster) : listed;
 
     // `content` is always an array; single-address callers read `content[0]`.
     return NextResponse.json({ content: tokens });
@@ -84,12 +82,7 @@ function parseAddresses(body: RequestBody): string[] | undefined {
  * metadata. The fallback is best-effort: a failure here still returns the
  * listed tokens.
  */
-async function withMetaplexFallback(
-    listed: TokenInfo[],
-    addresses: string[],
-    cluster: Cluster,
-    requestUrl: string,
-): Promise<TokenInfo[]> {
+async function withMetaplexFallback(listed: TokenInfo[], addresses: string[], cluster: Cluster): Promise<TokenInfo[]> {
     const found = new Set(listed.map(token => token.address));
     const missing = addresses.filter(address => !found.has(address));
     if (missing.length === 0) return listed;
@@ -107,7 +100,6 @@ async function withMetaplexFallback(
 
     try {
         const onChain = await getTokenInfosFromMetaplex(missing, rpcEndpoint, {
-            baseUrl: new URL(requestUrl).origin,
             onError: error => Logger.warn('[api:token-info] Metaplex lookup failed', { error }),
         });
         return [...listed, ...onChain];

--- a/app/entities/chain-id/@x/token-info/index.ts
+++ b/app/entities/chain-id/@x/token-info/index.ts
@@ -1,0 +1,4 @@
+// Cross-entity public API (FSD `@x` notation): the slice of the `chain-id` entity that the
+// `token-info` entity is allowed to consume. Every unified token list (UTL) lookup is scoped to a
+// chain id, so resolving one from the active cluster is a precondition for all of them.
+export { getChainId } from '../../lib/get-chain-id';

--- a/app/entities/chain-id/index.ts
+++ b/app/entities/chain-id/index.ts
@@ -1,2 +1,3 @@
+export { ChainId } from './lib/chain-id';
 export { GENESIS_HASHES } from './lib/const';
 export { getChainId } from './lib/get-chain-id';

--- a/app/entities/chain-id/lib/__tests__/get-chain-id.spec.ts
+++ b/app/entities/chain-id/lib/__tests__/get-chain-id.spec.ts
@@ -1,7 +1,7 @@
-import { ChainId } from '@solflare-wallet/utl-sdk';
 import { Cluster } from '@utils/cluster';
 import { describe, expect, it } from 'vitest';
 
+import { ChainId } from '../chain-id';
 import { GENESIS_HASHES } from '../const';
 import { getChainId } from '../get-chain-id';
 

--- a/app/entities/chain-id/lib/chain-id.ts
+++ b/app/entities/chain-id/lib/chain-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Solana chain ids used by the unified token list (UTL) REST API.
+ *
+ * These values replace the `ChainId` enum that came from
+ * `@solflare-wallet/utl-sdk`. They are part of the UTL request contract, so do
+ * not change them.
+ */
+export enum ChainId {
+    MAINNET = 101,
+    TESTNET = 102,
+    DEVNET = 103,
+}

--- a/app/entities/chain-id/lib/get-chain-id.ts
+++ b/app/entities/chain-id/lib/get-chain-id.ts
@@ -1,6 +1,6 @@
-import { ChainId } from '@solflare-wallet/utl-sdk';
 import { Cluster } from '@utils/cluster';
 
+import { ChainId } from './chain-id';
 import { GENESIS_HASHES } from './const';
 
 function getChainIdFromGenesisHash(genesisHash: string): ChainId | undefined {

--- a/app/entities/nft/@x/token-info/index.ts
+++ b/app/entities/nft/@x/token-info/index.ts
@@ -1,7 +1,7 @@
 // Cross-entity public API (FSD `@x` notation): the slice of the `nft` entity that the
 // `token-info` entity is allowed to consume. Resolving an unlisted mint means reading the same
-// Metaplex metadata account an NFT does, so both paths share one Umi client and one off-chain
-// JSON reader rather than growing a second copy.
-export { getMetadataJson } from '../../lib/get-metadata-json';
-export type { GetMetadataJsonDeps } from '../../lib/get-metadata-json';
+// Metaplex metadata account an NFT does, so both paths share one cached Umi client.
+//
+// `getMetadataJson` is deliberately not exported here: it is browser-only, and the server-side
+// token-info fallback reads off-chain JSON through the metadata proxy's hardened fetcher.
 export { getUmi } from '../../lib/umi';

--- a/app/entities/nft/@x/token-info/index.ts
+++ b/app/entities/nft/@x/token-info/index.ts
@@ -1,0 +1,7 @@
+// Cross-entity public API (FSD `@x` notation): the slice of the `nft` entity that the
+// `token-info` entity is allowed to consume. Resolving an unlisted mint means reading the same
+// Metaplex metadata account an NFT does, so both paths share one Umi client and one off-chain
+// JSON reader rather than growing a second copy.
+export { getMetadataJson } from '../../lib/get-metadata-json';
+export type { GetMetadataJsonDeps } from '../../lib/get-metadata-json';
+export { getUmi } from '../../lib/umi';

--- a/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
+++ b/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
@@ -1,0 +1,124 @@
+import type { Metadata } from '@metaplex-foundation/mpl-token-metadata';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ getProxiedUri: vi.fn() }));
+
+vi.mock('@/app/features/metadata/utils', () => ({ getProxiedUri: mocks.getProxiedUri }));
+
+const PROXY_PATH = '/api/metadata/proxy?uri=https%3A%2F%2Fexample.com%2Fmeta.json';
+
+function metadata(uri: string) {
+    return { uri } as Metadata;
+}
+
+function jsonResponse(body: unknown) {
+    return { json: () => Promise.resolve(body) } as Response;
+}
+
+describe('getMetadataJson', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        global.fetch = vi.fn().mockResolvedValue(jsonResponse({ image: 'https://example.com/logo.png' }));
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('should resolve a root-relative proxy path against the given origin', async () => {
+        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('https://example.com/meta.json'), { baseUrl: 'http://localhost:3000' });
+
+        expect(global.fetch).toHaveBeenCalledWith(`http://localhost:3000${PROXY_PATH}`, expect.anything());
+    });
+
+    it('should leave a root-relative proxy path alone in the browser, where no origin is given', async () => {
+        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('https://example.com/meta.json'));
+
+        expect(global.fetch).toHaveBeenCalledWith(PROXY_PATH, expect.anything());
+    });
+
+    it('should leave an absolute URI unchanged even when an origin is given', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://ipfs.io/ipfs/abc');
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('ipfs://abc'), { baseUrl: 'http://localhost:3000' });
+
+        expect(global.fetch).toHaveBeenCalledWith('https://ipfs.io/ipfs/abc', expect.anything());
+    });
+
+    it('should forward the abort signal so callers can bound the wait', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
+        const controller = new AbortController();
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('https://example.com/meta.json'), { signal: controller.signal });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://example.com/meta.json',
+            expect.objectContaining({ signal: controller.signal }),
+        );
+    });
+
+    it('should resolve undefined when the request fails', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
+        vi.mocked(global.fetch).mockRejectedValueOnce(new Error('aborted'));
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(getMetadataJson(metadata('https://example.com/meta.json'))).resolves.toBeUndefined();
+    });
+
+    // The NFT page maps `onError` to `Logger.error`. Dead and slow third-party metadata links are
+    // routine, so only bad input may be reported — otherwise the ordinary case escalates.
+    it('should not report a failed request, which is routine for third-party metadata', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
+        vi.mocked(global.fetch).mockRejectedValueOnce(new Error('socket hang up'));
+        const onError = vi.fn();
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('https://example.com/meta.json'), { onError });
+
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('should not report an unparseable body', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+        } as unknown as Response);
+        const onError = vi.fn();
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(getMetadataJson(metadata('https://example.com/meta.json'), { onError })).resolves.toBeUndefined();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('should report a malformed origin, which is bad input rather than a dead link', async () => {
+        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
+        const onError = vi.fn();
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(
+            getMetadataJson(metadata('https://example.com/meta.json'), { baseUrl: 'not-an-origin', onError }),
+        ).resolves.toBeUndefined();
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should resolve undefined when the metadata carries no URI', async () => {
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(getMetadataJson(metadata(''))).resolves.toBeUndefined();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
+++ b/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
@@ -45,11 +45,40 @@ describe('getMetadataJson', () => {
         expect(global.fetch).toHaveBeenCalledWith(PROXY_PATH, expect.anything());
     });
 
-    it('should leave an absolute URI unchanged even when an origin is given', async () => {
+    // A mint's `uri` is attacker-controlled on-chain data. The browser fetching it directly is
+    // the user's own network, but the server must only go through `/api/metadata/proxy`, which
+    // pins DNS and rejects private hosts. `getProxiedUri` returns the raw URI when
+    // `NEXT_PUBLIC_METADATA_ENABLED` is off, so the server has to refuse it.
+    it('should refuse a server fetch of an unproxied URI rather than reach it directly', async () => {
+        mocks.getProxiedUri.mockReturnValue('http://169.254.169.254/latest/meta-data/');
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(
+            getMetadataJson(metadata('http://169.254.169.254/latest/meta-data/'), {
+                baseUrl: 'http://localhost:3000',
+            }),
+        ).resolves.toBeUndefined();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a server fetch of an unproxied public URI too', async () => {
+        // Not only private hosts: without the proxy there is no redirect or size guard either.
         mocks.getProxiedUri.mockReturnValue('https://ipfs.io/ipfs/abc');
 
         const { getMetadataJson } = await import('../get-metadata-json');
-        await getMetadataJson(metadata('ipfs://abc'), { baseUrl: 'http://localhost:3000' });
+
+        await expect(
+            getMetadataJson(metadata('ipfs://abc'), { baseUrl: 'http://localhost:3000' }),
+        ).resolves.toBeUndefined();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should still fetch an unproxied URI in the browser, where no origin is given', async () => {
+        mocks.getProxiedUri.mockReturnValue('https://ipfs.io/ipfs/abc');
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+        await getMetadataJson(metadata('ipfs://abc'));
 
         expect(global.fetch).toHaveBeenCalledWith('https://ipfs.io/ipfs/abc', expect.anything());
     });

--- a/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
+++ b/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
@@ -11,8 +11,8 @@ function metadata(uri: string) {
     return { uri } as Metadata;
 }
 
-function jsonResponse(body: unknown) {
-    return { json: () => Promise.resolve(body) } as Response;
+function jsonResponse(body: unknown, ok = true) {
+    return { json: () => Promise.resolve(body), ok } as Response;
 }
 
 describe('getMetadataJson', () => {
@@ -68,10 +68,22 @@ describe('getMetadataJson', () => {
         expect(onError).not.toHaveBeenCalled();
     });
 
+    // The proxy answers a blocked or dead URI with `{ error: … }`. That body names no artwork, so
+    // `processJson` would hand it back as metadata if the status were not checked first.
+    it('should resolve undefined for an error response rather than read its body as metadata', async () => {
+        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
+        vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ error: 'Forbidden' }, false));
+
+        const { getMetadataJson } = await import('../get-metadata-json');
+
+        await expect(getMetadataJson(metadata('https://example.com/meta.json'))).resolves.toBeUndefined();
+    });
+
     it('should not report an unparseable body', async () => {
         mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
         vi.mocked(global.fetch).mockResolvedValueOnce({
             json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+            ok: true,
         } as unknown as Response);
         const onError = vi.fn();
 

--- a/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
+++ b/app/entities/nft/lib/__tests__/get-metadata-json.spec.ts
@@ -27,73 +27,23 @@ describe('getMetadataJson', () => {
         global.fetch = originalFetch;
     });
 
-    it('should resolve a root-relative proxy path against the given origin', async () => {
-        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
-
-        const { getMetadataJson } = await import('../get-metadata-json');
-        await getMetadataJson(metadata('https://example.com/meta.json'), { baseUrl: 'http://localhost:3000' });
-
-        expect(global.fetch).toHaveBeenCalledWith(`http://localhost:3000${PROXY_PATH}`, expect.anything());
-    });
-
-    it('should leave a root-relative proxy path alone in the browser, where no origin is given', async () => {
+    // The browser resolves a root-relative proxy path against the current page.
+    it('should fetch the proxy path as given', async () => {
         mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
 
         const { getMetadataJson } = await import('../get-metadata-json');
         await getMetadataJson(metadata('https://example.com/meta.json'));
 
-        expect(global.fetch).toHaveBeenCalledWith(PROXY_PATH, expect.anything());
+        expect(global.fetch).toHaveBeenCalledWith(PROXY_PATH);
     });
 
-    // A mint's `uri` is attacker-controlled on-chain data. The browser fetching it directly is
-    // the user's own network, but the server must only go through `/api/metadata/proxy`, which
-    // pins DNS and rejects private hosts. `getProxiedUri` returns the raw URI when
-    // `NEXT_PUBLIC_METADATA_ENABLED` is off, so the server has to refuse it.
-    it('should refuse a server fetch of an unproxied URI rather than reach it directly', async () => {
-        mocks.getProxiedUri.mockReturnValue('http://169.254.169.254/latest/meta-data/');
-
-        const { getMetadataJson } = await import('../get-metadata-json');
-
-        await expect(
-            getMetadataJson(metadata('http://169.254.169.254/latest/meta-data/'), {
-                baseUrl: 'http://localhost:3000',
-            }),
-        ).resolves.toBeUndefined();
-        expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it('should refuse a server fetch of an unproxied public URI too', async () => {
-        // Not only private hosts: without the proxy there is no redirect or size guard either.
-        mocks.getProxiedUri.mockReturnValue('https://ipfs.io/ipfs/abc');
-
-        const { getMetadataJson } = await import('../get-metadata-json');
-
-        await expect(
-            getMetadataJson(metadata('ipfs://abc'), { baseUrl: 'http://localhost:3000' }),
-        ).resolves.toBeUndefined();
-        expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it('should still fetch an unproxied URI in the browser, where no origin is given', async () => {
+    it('should fetch an unproxied URI as given, since the browser uses its own network', async () => {
         mocks.getProxiedUri.mockReturnValue('https://ipfs.io/ipfs/abc');
 
         const { getMetadataJson } = await import('../get-metadata-json');
         await getMetadataJson(metadata('ipfs://abc'));
 
-        expect(global.fetch).toHaveBeenCalledWith('https://ipfs.io/ipfs/abc', expect.anything());
-    });
-
-    it('should forward the abort signal so callers can bound the wait', async () => {
-        mocks.getProxiedUri.mockReturnValue('https://example.com/meta.json');
-        const controller = new AbortController();
-
-        const { getMetadataJson } = await import('../get-metadata-json');
-        await getMetadataJson(metadata('https://example.com/meta.json'), { signal: controller.signal });
-
-        expect(global.fetch).toHaveBeenCalledWith(
-            'https://example.com/meta.json',
-            expect.objectContaining({ signal: controller.signal }),
-        );
+        expect(global.fetch).toHaveBeenCalledWith('https://ipfs.io/ipfs/abc');
     });
 
     it('should resolve undefined when the request fails', async () => {
@@ -129,19 +79,6 @@ describe('getMetadataJson', () => {
 
         await expect(getMetadataJson(metadata('https://example.com/meta.json'), { onError })).resolves.toBeUndefined();
         expect(onError).not.toHaveBeenCalled();
-    });
-
-    it('should report a malformed origin, which is bad input rather than a dead link', async () => {
-        mocks.getProxiedUri.mockReturnValue(PROXY_PATH);
-        const onError = vi.fn();
-
-        const { getMetadataJson } = await import('../get-metadata-json');
-
-        await expect(
-            getMetadataJson(metadata('https://example.com/meta.json'), { baseUrl: 'not-an-origin', onError }),
-        ).resolves.toBeUndefined();
-        expect(onError).toHaveBeenCalledWith(expect.any(Error));
-        expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('should resolve undefined when the metadata carries no URI', async () => {

--- a/app/entities/nft/lib/get-metadata-json.ts
+++ b/app/entities/nft/lib/get-metadata-json.ts
@@ -57,6 +57,10 @@ export async function getMetadataJson(metadata: Metadata, deps?: GetMetadataJson
     // would escalate the ordinary case.
     try {
         const response = await fetch(requestUri);
+        // The proxy answers a blocked, dead or oversize URI with a JSON error body, and an
+        // upstream can serve its own JSON error page. Neither is metadata, and `processJson`
+        // would pass such a body through: it only rejects a payload that names no artwork.
+        if (!response.ok) return undefined;
         return processJson(await response.json(), uri);
     } catch {
         return undefined;

--- a/app/entities/nft/lib/get-metadata-json.ts
+++ b/app/entities/nft/lib/get-metadata-json.ts
@@ -7,26 +7,32 @@ import type { NftJson } from './types';
 export type GetMetadataJsonDeps = {
     onError?: (error: unknown) => void;
     /**
-     * Absolute origin used to resolve a root-relative proxy path.
-     * `getProxiedUri` returns `/api/metadata/proxy?uri=...` when the proxy is
-     * enabled, and `fetch` only accepts a relative path in the browser. Server
-     * callers must pass their own request origin.
+     * Absolute origin of the caller's own request. Passing it marks this as a
+     * server-side call, which both resolves the root-relative proxy path and
+     * restricts the fetch to the metadata proxy — see `resolveServerRequestUri`.
      */
     baseUrl?: string;
     /** Aborts the off-chain JSON request. Server callers use it to bound the wait. */
     signal?: AbortSignal;
 };
 
+const PROXY_PATH = '/api/metadata/proxy';
+
 // eslint-disable-next-line no-restricted-syntax -- match image data URI mime types
 const IMAGE_MIME_TYPE_REGEX = /data:image\/(svg\+xml|png|jpeg|gif)/;
 
 /**
- * Makes a proxied URI fetchable. The browser resolves a root-relative path
- * against the current page, so it is returned unchanged when no `baseUrl` is
- * given.
+ * Makes a proxied URI fetchable from the server, or refuses.
+ *
+ * A mint's `uri` is attacker-controlled on-chain data, so the server may only fetch it
+ * through `/api/metadata/proxy`, which pins DNS lookups and rejects private hosts. When
+ * `NEXT_PUBLIC_METADATA_ENABLED` is off, that route 404s and `getProxiedUri` returns the raw
+ * URI instead — harmless in the browser, which fetches from the user's own network, but from
+ * the server it would be an SSRF into ours. Refusing costs a logo; allowing it costs the
+ * cloud metadata endpoint.
  */
-function resolveRequestUri(proxiedUri: string, baseUrl?: string): string {
-    if (!baseUrl || !proxiedUri.startsWith('/')) return proxiedUri;
+function resolveServerRequestUri(proxiedUri: string, baseUrl: string): string | undefined {
+    if (!proxiedUri.startsWith(PROXY_PATH)) return undefined;
     return new URL(proxiedUri, baseUrl).toString();
 }
 
@@ -55,13 +61,19 @@ export async function getMetadataJson(metadata: Metadata, deps?: GetMetadataJson
 
     // Building the request URI is synchronous, and a failure means bad input (a malformed
     // `baseUrl`), so it is reported to the caller.
-    let requestUri: string;
+    let requestUri: string | undefined;
     try {
-        requestUri = resolveRequestUri(getProxiedUri(uri), deps?.baseUrl);
+        const proxiedUri = getProxiedUri(uri);
+        // The browser resolves a root-relative path against the current page, so it fetches
+        // whatever `getProxiedUri` produced. Only server calls are restricted.
+        requestUri = deps?.baseUrl ? resolveServerRequestUri(proxiedUri, deps.baseUrl) : proxiedUri;
     } catch (error) {
         deps?.onError?.(error);
         return undefined;
     }
+
+    // Server call for a URI the proxy will not carry.
+    if (!requestUri) return undefined;
 
     // A dead link, a timeout, or an unparseable body is an everyday outcome for third-party
     // metadata. Those stay quiet: the NFT page maps `onError` to `Logger.error`, so reporting them

--- a/app/entities/nft/lib/get-metadata-json.ts
+++ b/app/entities/nft/lib/get-metadata-json.ts
@@ -6,52 +6,70 @@ import type { NftJson } from './types';
 
 export type GetMetadataJsonDeps = {
     onError?: (error: unknown) => void;
+    /**
+     * Absolute origin used to resolve a root-relative proxy path.
+     * `getProxiedUri` returns `/api/metadata/proxy?uri=...` when the proxy is
+     * enabled, and `fetch` only accepts a relative path in the browser. Server
+     * callers must pass their own request origin.
+     */
+    baseUrl?: string;
+    /** Aborts the off-chain JSON request. Server callers use it to bound the wait. */
+    signal?: AbortSignal;
 };
 
 // eslint-disable-next-line no-restricted-syntax -- match image data URI mime types
 const IMAGE_MIME_TYPE_REGEX = /data:image\/(svg\+xml|png|jpeg|gif)/;
 
+/**
+ * Makes a proxied URI fetchable. The browser resolves a root-relative path
+ * against the current page, so it is returned unchanged when no `baseUrl` is
+ * given.
+ */
+function resolveRequestUri(proxiedUri: string, baseUrl?: string): string {
+    if (!baseUrl || !proxiedUri.startsWith('/')) return proxiedUri;
+    return new URL(proxiedUri, baseUrl).toString();
+}
+
+/**
+ * Resolves an image path against the metadata URI and drops payloads that carry
+ * no artwork at all.
+ */
+function processJson(extended: any, uri: string): NftJson | undefined {
+    if (!extended || (!extended.image && extended?.properties?.files?.length === 0)) {
+        return undefined;
+    }
+
+    if (extended?.image) {
+        extended.image =
+            extended.image.startsWith('http') || IMAGE_MIME_TYPE_REGEX.test(extended.image)
+                ? extended.image
+                : `${uri}/${extended.image}`;
+    }
+
+    return extended;
+}
+
 export async function getMetadataJson(metadata: Metadata, deps?: GetMetadataJsonDeps): Promise<NftJson | undefined> {
-    return new Promise(resolve => {
-        const uri = metadata.uri;
-        if (!uri) return resolve(undefined);
+    const uri = metadata.uri;
+    if (!uri) return undefined;
 
-        const processJson = (extended: any) => {
-            if (!extended || (!extended.image && extended?.properties?.files?.length === 0)) {
-                return;
-            }
+    // Building the request URI is synchronous, and a failure means bad input (a malformed
+    // `baseUrl`), so it is reported to the caller.
+    let requestUri: string;
+    try {
+        requestUri = resolveRequestUri(getProxiedUri(uri), deps?.baseUrl);
+    } catch (error) {
+        deps?.onError?.(error);
+        return undefined;
+    }
 
-            if (extended?.image) {
-                extended.image =
-                    extended.image.startsWith('http') || IMAGE_MIME_TYPE_REGEX.test(extended.image)
-                        ? extended.image
-                        : `${metadata.uri}/${extended.image}`;
-            }
-
-            return extended;
-        };
-
-        try {
-            fetch(getProxiedUri(uri))
-                .then(async _ => {
-                    try {
-                        const data = await _.json();
-                        try {
-                            localStorage.setItem(uri, JSON.stringify(data));
-                        } catch {
-                            // ignore
-                        }
-                        resolve(processJson(data));
-                    } catch {
-                        resolve(undefined);
-                    }
-                })
-                .catch(() => {
-                    resolve(undefined);
-                });
-        } catch (ex) {
-            deps?.onError?.(ex);
-            resolve(undefined);
-        }
-    });
+    // A dead link, a timeout, or an unparseable body is an everyday outcome for third-party
+    // metadata. Those stay quiet: the NFT page maps `onError` to `Logger.error`, so reporting them
+    // would escalate the ordinary case.
+    try {
+        const response = await fetch(requestUri, { signal: deps?.signal });
+        return processJson(await response.json(), uri);
+    } catch {
+        return undefined;
+    }
 }

--- a/app/entities/nft/lib/get-metadata-json.ts
+++ b/app/entities/nft/lib/get-metadata-json.ts
@@ -6,35 +6,10 @@ import type { NftJson } from './types';
 
 export type GetMetadataJsonDeps = {
     onError?: (error: unknown) => void;
-    /**
-     * Absolute origin of the caller's own request. Passing it marks this as a
-     * server-side call, which both resolves the root-relative proxy path and
-     * restricts the fetch to the metadata proxy — see `resolveServerRequestUri`.
-     */
-    baseUrl?: string;
-    /** Aborts the off-chain JSON request. Server callers use it to bound the wait. */
-    signal?: AbortSignal;
 };
-
-const PROXY_PATH = '/api/metadata/proxy';
 
 // eslint-disable-next-line no-restricted-syntax -- match image data URI mime types
 const IMAGE_MIME_TYPE_REGEX = /data:image\/(svg\+xml|png|jpeg|gif)/;
-
-/**
- * Makes a proxied URI fetchable from the server, or refuses.
- *
- * A mint's `uri` is attacker-controlled on-chain data, so the server may only fetch it
- * through `/api/metadata/proxy`, which pins DNS lookups and rejects private hosts. When
- * `NEXT_PUBLIC_METADATA_ENABLED` is off, that route 404s and `getProxiedUri` returns the raw
- * URI instead — harmless in the browser, which fetches from the user's own network, but from
- * the server it would be an SSRF into ours. Refusing costs a logo; allowing it costs the
- * cloud metadata endpoint.
- */
-function resolveServerRequestUri(proxiedUri: string, baseUrl: string): string | undefined {
-    if (!proxiedUri.startsWith(PROXY_PATH)) return undefined;
-    return new URL(proxiedUri, baseUrl).toString();
-}
 
 /**
  * Resolves an image path against the metadata URI and drops payloads that carry
@@ -55,31 +30,33 @@ function processJson(extended: any, uri: string): NftJson | undefined {
     return extended;
 }
 
+/**
+ * Reads an NFT's off-chain JSON in the browser.
+ *
+ * Browser-only by design. `getProxiedUri` returns a root-relative `/api/metadata/proxy` path
+ * that only the browser can resolve, and when proxying is disabled it returns the raw
+ * attacker-controlled on-chain URI — fine to fetch from the user's own network, not from ours.
+ * Server callers read off-chain metadata through the proxy's `fetchResource` in process
+ * instead; see `entities/token-info/api/fetch-token-metaplex.ts`.
+ */
 export async function getMetadataJson(metadata: Metadata, deps?: GetMetadataJsonDeps): Promise<NftJson | undefined> {
     const uri = metadata.uri;
     if (!uri) return undefined;
 
-    // Building the request URI is synchronous, and a failure means bad input (a malformed
-    // `baseUrl`), so it is reported to the caller.
-    let requestUri: string | undefined;
+    // Building the request URI is synchronous, and a failure means bad input, so it is reported.
+    let requestUri: string;
     try {
-        const proxiedUri = getProxiedUri(uri);
-        // The browser resolves a root-relative path against the current page, so it fetches
-        // whatever `getProxiedUri` produced. Only server calls are restricted.
-        requestUri = deps?.baseUrl ? resolveServerRequestUri(proxiedUri, deps.baseUrl) : proxiedUri;
+        requestUri = getProxiedUri(uri);
     } catch (error) {
         deps?.onError?.(error);
         return undefined;
     }
 
-    // Server call for a URI the proxy will not carry.
-    if (!requestUri) return undefined;
-
     // A dead link, a timeout, or an unparseable body is an everyday outcome for third-party
     // metadata. Those stay quiet: the NFT page maps `onError` to `Logger.error`, so reporting them
     // would escalate the ordinary case.
     try {
-        const response = await fetch(requestUri, { signal: deps?.signal });
+        const response = await fetch(requestUri);
         return processJson(await response.json(), uri);
     } catch {
         return undefined;

--- a/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
@@ -1,0 +1,278 @@
+import { TokenStandard } from '@metaplex-foundation/mpl-token-metadata';
+import { none, some } from '@metaplex-foundation/umi';
+import { PublicKey } from '@solana/web3.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MINT_A = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const MINT_B = 'So11111111111111111111111111111111111111112';
+const RPC = 'https://rpc.example.com';
+const NULL_CHAR = String.fromCharCode(0);
+
+const mocks = vi.hoisted(() => ({
+    getMetadataJson: vi.fn(),
+    getMultipleParsedAccounts: vi.fn(),
+    getUmi: vi.fn(() => ({})),
+    safeFetchAllMetadata: vi.fn(),
+}));
+
+vi.mock('@metaplex-foundation/mpl-token-metadata', async () => {
+    const actual = await vi.importActual<typeof import('@metaplex-foundation/mpl-token-metadata')>(
+        '@metaplex-foundation/mpl-token-metadata',
+    );
+    return {
+        ...actual,
+        // The PDA is derived by the real program elsewhere; here it only has to be a stable stand-in.
+        findMetadataPda: vi.fn((_umi, { mint }: { mint: string }) => [`${mint}-pda`, 255]),
+        safeFetchAllMetadata: mocks.safeFetchAllMetadata,
+    };
+});
+
+vi.mock('@solana/web3.js', async () => {
+    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
+    return {
+        ...actual,
+        // `Connection` is called with `new`, so the stand-in has to be constructible.
+        Connection: class {
+            getMultipleParsedAccounts = mocks.getMultipleParsedAccounts;
+        },
+    };
+});
+
+vi.mock('@/app/entities/nft/lib/umi', () => ({ getUmi: mocks.getUmi }));
+vi.mock('@/app/entities/nft/lib/get-metadata-json', () => ({ getMetadataJson: mocks.getMetadataJson }));
+
+type MetadataStub = { mint: string; name: string; symbol: string; tokenStandard: unknown; uri: string };
+
+function metadata(mint: string, overrides: Partial<MetadataStub> = {}): MetadataStub {
+    return {
+        mint,
+        name: 'USD Coin',
+        symbol: 'USDC',
+        tokenStandard: some(TokenStandard.Fungible),
+        uri: 'https://example.com/metadata.json',
+        ...overrides,
+    };
+}
+
+function parsedMint(decimals: number) {
+    return { data: { parsed: { info: { decimals } } } };
+}
+
+/** Builds a distinct, well-formed mint address; umi's `publicKey()` validates base58. */
+function addressAt(index: number): string {
+    const bytes = new Uint8Array(32);
+    bytes[0] = index % 256;
+    bytes[1] = Math.floor(index / 256) + 1;
+    return new PublicKey(bytes).toBase58();
+}
+
+async function importSubject() {
+    return await import('../fetch-token-metaplex');
+}
+
+describe('getTokenInfosFromMetaplex', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.getUmi.mockReturnValue({});
+        mocks.safeFetchAllMetadata.mockResolvedValue([]);
+        mocks.getMultipleParsedAccounts.mockResolvedValue({ value: [] });
+        mocks.getMetadataJson.mockResolvedValue(undefined);
+    });
+
+    it('should not touch the network without addresses', async () => {
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        await expect(getTokenInfosFromMetaplex([], RPC)).resolves.toEqual([]);
+        expect(mocks.safeFetchAllMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should return nothing when no RPC endpoint is configured', async () => {
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        await expect(getTokenInfosFromMetaplex([MINT_A], '')).resolves.toEqual([]);
+        expect(mocks.safeFetchAllMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should look up one metadata PDA per requested mint', async () => {
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        await getTokenInfosFromMetaplex([MINT_A, MINT_B], RPC);
+
+        expect(mocks.safeFetchAllMetadata).toHaveBeenCalledWith({}, [
+            [`${MINT_A}-pda`, 255],
+            [`${MINT_B}-pda`, 255],
+        ]);
+    });
+
+    it('should batch the metadata lookup so it stays under the getMultipleAccounts key limit', async () => {
+        // Umi sends every key in one request, and the RPC rejects more than 100 at a time.
+        const addresses = Array.from({ length: 230 }, (_, i) => addressAt(i));
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        await getTokenInfosFromMetaplex(addresses, RPC);
+
+        expect(mocks.safeFetchAllMetadata).toHaveBeenCalledTimes(3);
+        const batchSizes = mocks.safeFetchAllMetadata.mock.calls.map(([, pdas]) => pdas.length);
+        expect(batchSizes).toEqual([100, 100, 30]);
+    });
+
+    it('should keep the mints a surviving batch resolved when another batch fails', async () => {
+        const onError = vi.fn();
+        const addresses = Array.from({ length: 150 }, (_, i) => addressAt(i));
+        mocks.safeFetchAllMetadata
+            .mockRejectedValueOnce(new Error('rpc exploded'))
+            .mockResolvedValueOnce([metadata(MINT_B)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(9)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const result = await getTokenInfosFromMetaplex(addresses, RPC, { onError });
+
+        expect(result.map(t => t.address)).toEqual([MINT_B]);
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should map on-chain metadata into unverified token info', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMetadataJson.mockResolvedValueOnce({ image: 'https://example.com/logo.png' });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+
+        await expect(getTokenInfosFromMetaplex([MINT_A], RPC)).resolves.toEqual([
+            {
+                address: MINT_A,
+                decimals: 6,
+                logoURI: 'https://example.com/logo.png',
+                name: 'USD Coin',
+                symbol: 'USDC',
+                verified: false,
+            },
+        ]);
+    });
+
+    it('should keep only mints whose token standard is Fungible', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([
+            metadata(MINT_A),
+            metadata(MINT_B, { tokenStandard: some(TokenStandard.NonFungible) }),
+        ]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const result = await getTokenInfosFromMetaplex([MINT_A, MINT_B], RPC);
+
+        expect(result.map(t => t.address)).toEqual([MINT_A]);
+    });
+
+    it('should drop mints that declare no token standard', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { tokenStandard: none() })]);
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+
+        await expect(getTokenInfosFromMetaplex([MINT_A], RPC)).resolves.toEqual([]);
+        // Nothing survived the filter, so the mint accounts are never read.
+        expect(mocks.getMultipleParsedAccounts).not.toHaveBeenCalled();
+    });
+
+    it('should strip the null padding the metadata program adds', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([
+            metadata(MINT_A, { name: `USD Coin${NULL_CHAR.repeat(24)}`, symbol: `USDC${NULL_CHAR.repeat(6)}` }),
+        ]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.name).toBe('USD Coin');
+        expect(result.symbol).toBe('USDC');
+    });
+
+    it('should read decimals from the mint account, including zero', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(0)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.decimals).toBe(0);
+    });
+
+    it('should fall back to 6 decimals when the mint account is missing', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [null] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.decimals).toBe(6);
+    });
+
+    it('should report a null logo when the off-chain JSON has no image', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.getMetadataJson.mockResolvedValueOnce(undefined);
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.logoURI).toBeNull();
+    });
+
+    it('should pass the request origin and an abort signal when reading off-chain JSON', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        await getTokenInfosFromMetaplex([MINT_A], RPC, { baseUrl: 'http://localhost:3000' });
+
+        expect(mocks.getMetadataJson).toHaveBeenCalledWith(
+            expect.objectContaining({ mint: MINT_A }),
+            expect.objectContaining({ baseUrl: 'http://localhost:3000', signal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('should abort an off-chain JSON read that outlives the timeout', async () => {
+        vi.useFakeTimers();
+        try {
+            mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+            mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+            let captured: AbortSignal | undefined;
+            mocks.getMetadataJson.mockImplementationOnce((_metadata, deps) => {
+                captured = deps.signal;
+                return new Promise(resolve => {
+                    deps.signal.addEventListener('abort', () => resolve(undefined));
+                });
+            });
+
+            const { getTokenInfosFromMetaplex, METAPLEX_TIMEOUT_MS } = await importSubject();
+            const pending = getTokenInfosFromMetaplex([MINT_A], RPC);
+
+            await vi.advanceTimersByTimeAsync(METAPLEX_TIMEOUT_MS);
+            const [result] = await pending;
+
+            expect(captured?.aborted).toBe(true);
+            expect(result.logoURI).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('should report and return nothing when the metadata lookup throws', async () => {
+        const onError = vi.fn();
+        mocks.safeFetchAllMetadata.mockRejectedValueOnce(new Error('rpc exploded'));
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+
+        await expect(getTokenInfosFromMetaplex([MINT_A], RPC, { onError })).resolves.toEqual([]);
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should keep the token when reading its decimals fails', async () => {
+        const onError = vi.fn();
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockRejectedValueOnce(new Error('rpc exploded'));
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC, { onError });
+
+        expect(result).toMatchObject({ address: MINT_A, decimals: 6 });
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+});

--- a/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
@@ -9,7 +9,7 @@ const RPC = 'https://rpc.example.com';
 const NULL_CHAR = String.fromCharCode(0);
 
 const mocks = vi.hoisted(() => ({
-    getMetadataJson: vi.fn(),
+    fetchResource: vi.fn(),
     getMultipleParsedAccounts: vi.fn(),
     getUmi: vi.fn(() => ({})),
     safeFetchAllMetadata: vi.fn(),
@@ -39,7 +39,13 @@ vi.mock('@solana/web3.js', async () => {
 });
 
 vi.mock('@/app/entities/nft/lib/umi', () => ({ getUmi: mocks.getUmi }));
-vi.mock('@/app/entities/nft/lib/get-metadata-json', () => ({ getMetadataJson: mocks.getMetadataJson }));
+// The off-chain JSON is read through the metadata proxy's hardened fetcher, in process.
+vi.mock('@/app/api/metadata/proxy/feature', async () => {
+    const actual = await vi.importActual<typeof import('@/app/api/metadata/proxy/feature')>(
+        '@/app/api/metadata/proxy/feature',
+    );
+    return { ...actual, fetchResource: mocks.fetchResource };
+});
 
 type MetadataStub = { mint: string; name: string; symbol: string; tokenStandard: unknown; uri: string };
 
@@ -56,6 +62,11 @@ function metadata(mint: string, overrides: Partial<MetadataStub> = {}): Metadata
 
 function parsedMint(decimals: number) {
     return { data: { parsed: { info: { decimals } } } };
+}
+
+/** Shape `fetchResource` resolves to for a JSON body. */
+function jsonResource(data: unknown) {
+    return { data, headers: new Headers({ 'content-type': 'application/json' }) };
 }
 
 /** Builds a distinct, well-formed mint address; umi's `publicKey()` validates base58. */
@@ -76,7 +87,7 @@ describe('getTokenInfosFromMetaplex', () => {
         mocks.getUmi.mockReturnValue({});
         mocks.safeFetchAllMetadata.mockResolvedValue([]);
         mocks.getMultipleParsedAccounts.mockResolvedValue({ value: [] });
-        mocks.getMetadataJson.mockResolvedValue(undefined);
+        mocks.fetchResource.mockResolvedValue(jsonResource({}));
     });
 
     it('should not touch the network without addresses', async () => {
@@ -131,7 +142,7 @@ describe('getTokenInfosFromMetaplex', () => {
     it('should map on-chain metadata into unverified token info', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
         mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
-        mocks.getMetadataJson.mockResolvedValueOnce({ image: 'https://example.com/logo.png' });
+        mocks.fetchResource.mockResolvedValueOnce(jsonResource({ image: 'https://example.com/logo.png' }));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
 
@@ -206,7 +217,7 @@ describe('getTokenInfosFromMetaplex', () => {
     it('should report a null logo when the off-chain JSON has no image', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
         mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
-        mocks.getMetadataJson.mockResolvedValueOnce(undefined);
+        mocks.fetchResource.mockResolvedValueOnce(jsonResource({}));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
@@ -214,44 +225,58 @@ describe('getTokenInfosFromMetaplex', () => {
         expect(result.logoURI).toBeNull();
     });
 
-    it('should pass the request origin and an abort signal when reading off-chain JSON', async () => {
+    // Regression guard: this must never build a URL from the incoming request's host, and must
+    // never fetch the mint's URI outside the proxy's hardened fetcher.
+    it('should read the off-chain JSON through the proxy fetcher, bounded by the timeout', async () => {
         mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
         mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
 
-        const { getTokenInfosFromMetaplex } = await importSubject();
-        await getTokenInfosFromMetaplex([MINT_A], RPC, { baseUrl: 'http://localhost:3000' });
+        const { getTokenInfosFromMetaplex, METAPLEX_TIMEOUT_MS } = await importSubject();
+        await getTokenInfosFromMetaplex([MINT_A], RPC);
 
-        expect(mocks.getMetadataJson).toHaveBeenCalledWith(
-            expect.objectContaining({ mint: MINT_A }),
-            expect.objectContaining({ baseUrl: 'http://localhost:3000', signal: expect.any(AbortSignal) }),
+        expect(mocks.fetchResource).toHaveBeenCalledWith(
+            'https://example.com/metadata.json',
+            expect.objectContaining({ timeout: METAPLEX_TIMEOUT_MS }),
         );
     });
 
-    it('should abort an off-chain JSON read that outlives the timeout', async () => {
-        vi.useFakeTimers();
-        try {
-            mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
-            mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+    it('should report a null logo when the proxy fetcher rejects the address', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        // What `fetchResource` does for a private host or a redirect loop.
+        mocks.fetchResource.mockRejectedValueOnce(new Error('Hostname resolves to a private IP'));
+        const onError = vi.fn();
 
-            let captured: AbortSignal | undefined;
-            mocks.getMetadataJson.mockImplementationOnce((_metadata, deps) => {
-                captured = deps.signal;
-                return new Promise(resolve => {
-                    deps.signal.addEventListener('abort', () => resolve(undefined));
-                });
-            });
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC, { onError });
 
-            const { getTokenInfosFromMetaplex, METAPLEX_TIMEOUT_MS } = await importSubject();
-            const pending = getTokenInfosFromMetaplex([MINT_A], RPC);
+        expect(result).toMatchObject({ address: MINT_A, logoURI: null });
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
 
-            await vi.advanceTimersByTimeAsync(METAPLEX_TIMEOUT_MS);
-            const [result] = await pending;
+    it('should ignore a non-JSON body rather than treat it as metadata', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.fetchResource.mockResolvedValueOnce({
+            data: { image: 'https://example.com/logo.png' },
+            headers: new Headers({ 'content-type': 'text/html' }),
+        });
 
-            expect(captured?.aborted).toBe(true);
-            expect(result.logoURI).toBeNull();
-        } finally {
-            vi.useRealTimers();
-        }
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.logoURI).toBeNull();
+    });
+
+    it('should skip the off-chain read for a mint with no uri', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: '' })]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result.logoURI).toBeNull();
+        expect(mocks.fetchResource).not.toHaveBeenCalled();
     });
 
     it('should report and return nothing when the metadata lookup throws', async () => {

--- a/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
@@ -1,7 +1,8 @@
 import { TokenStandard } from '@metaplex-foundation/mpl-token-metadata';
 import { none, some } from '@metaplex-foundation/umi';
-import { PublicKey } from '@solana/web3.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { gen } from '@/app/__fixtures__/gen';
 
 const MINT_A = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const MINT_B = 'So11111111111111111111111111111111111111112';
@@ -69,14 +70,6 @@ function jsonResource(data: unknown) {
     return { data, headers: new Headers({ 'content-type': 'application/json' }) };
 }
 
-/** Builds a distinct, well-formed mint address; umi's `publicKey()` validates base58. */
-function addressAt(index: number): string {
-    const bytes = new Uint8Array(32);
-    bytes[0] = index % 256;
-    bytes[1] = Math.floor(index / 256) + 1;
-    return new PublicKey(bytes).toBase58();
-}
-
 async function importSubject() {
     return await import('../fetch-token-metaplex');
 }
@@ -114,7 +107,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should batch the metadata lookup so it stays under the getMultipleAccounts key limit', async () => {
         // Umi sends every key in one request, and the RPC rejects more than 100 at a time.
-        const addresses = Array.from({ length: 230 }, (_, i) => addressAt(i));
+        const addresses = Array.from({ length: 230 }, (_, i) => gen.address(i));
 
         const { getTokenInfosFromMetaplex } = await importSubject();
         await getTokenInfosFromMetaplex(addresses, RPC);
@@ -126,7 +119,7 @@ describe('getTokenInfosFromMetaplex', () => {
 
     it('should keep the mints a surviving batch resolved when another batch fails', async () => {
         const onError = vi.fn();
-        const addresses = Array.from({ length: 150 }, (_, i) => addressAt(i));
+        const addresses = Array.from({ length: 150 }, (_, i) => gen.address(i));
         mocks.safeFetchAllMetadata
             .mockRejectedValueOnce(new Error('rpc exploded'))
             .mockResolvedValueOnce([metadata(MINT_B)]);
@@ -238,6 +231,72 @@ describe('getTokenInfosFromMetaplex', () => {
             'https://example.com/metadata.json',
             expect.objectContaining({ timeout: METAPLEX_TIMEOUT_MS }),
         );
+    });
+
+    it('should keep the off-chain reads within the concurrency limit', async () => {
+        const addresses = Array.from({ length: 20 }, (_, i) => gen.address(i));
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce(addresses.map(address => metadata(address)));
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: addresses.map(() => parsedMint(6)) });
+
+        let inFlight = 0;
+        let peak = 0;
+        mocks.fetchResource.mockImplementation(async () => {
+            inFlight++;
+            peak = Math.max(peak, inFlight);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            inFlight--;
+            return jsonResource({});
+        });
+
+        const { getTokenInfosFromMetaplex, LOGO_CONCURRENCY } = await importSubject();
+        await getTokenInfosFromMetaplex(addresses, RPC);
+
+        expect(mocks.fetchResource).toHaveBeenCalledTimes(addresses.length);
+        expect(peak).toBeGreaterThan(1);
+        expect(peak).toBeLessThanOrEqual(LOGO_CONCURRENCY);
+    });
+
+    it('should keep every logo with its own mint when the reads settle out of order', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A), metadata(MINT_B)]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
+        mocks.fetchResource
+            .mockImplementationOnce(
+                () => new Promise(resolve => setTimeout(() => resolve(jsonResource({ image: 'logo-a' })), 10)),
+            )
+            .mockResolvedValueOnce(jsonResource({ image: 'logo-b' }));
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const result = await getTokenInfosFromMetaplex([MINT_A, MINT_B], RPC);
+
+        expect(result.map(t => [t.address, t.logoURI])).toEqual([
+            [MINT_A, 'logo-a'],
+            [MINT_B, 'logo-b'],
+        ]);
+    });
+
+    it('should give up the remaining logos once the batch spends its budget', async () => {
+        vi.useFakeTimers();
+        try {
+            mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A), metadata(MINT_B)]);
+            mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6), parsedMint(6)] });
+
+            const { getTokenInfosFromMetaplex, LOGO_BUDGET_MS } = await importSubject();
+            mocks.fetchResource.mockImplementationOnce(async () => {
+                vi.advanceTimersByTime(LOGO_BUDGET_MS);
+                return jsonResource({ image: 'logo-a' });
+            });
+
+            const result = await getTokenInfosFromMetaplex([MINT_A, MINT_B], RPC);
+
+            // The batch still answers with both mints — only the second one's logo is dropped.
+            expect(mocks.fetchResource).toHaveBeenCalledTimes(1);
+            expect(result.map(t => [t.address, t.logoURI])).toEqual([
+                [MINT_A, 'logo-a'],
+                [MINT_B, null],
+            ]);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('should report a null logo when the proxy fetcher rejects the address', async () => {

--- a/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-metaplex.spec.ts
@@ -8,6 +8,8 @@ const MINT_A = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const MINT_B = 'So11111111111111111111111111111111111111112';
 const RPC = 'https://rpc.example.com';
 const NULL_CHAR = String.fromCharCode(0);
+// A well-known valid CIDv0, as in app/features/metadata/__tests__/utils.spec.ts.
+const VALID_CID = 'QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u';
 
 const mocks = vi.hoisted(() => ({
     fetchResource: vi.fn(),
@@ -336,6 +338,49 @@ describe('getTokenInfosFromMetaplex', () => {
 
         expect(result.logoURI).toBeNull();
         expect(mocks.fetchResource).not.toHaveBeenCalled();
+    });
+
+    // `fetchResource` speaks only http(s), so an `ipfs://` uri handed to it straight would be
+    // rejected as a blocked protocol and every IPFS-hosted mint would lose its logo. The browser
+    // path already maps these through a gateway in `getProxiedUri`; this path must match it.
+    it('should read an ipfs uri through the http gateway', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: `ipfs://${VALID_CID}/meta.json` })]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+        mocks.fetchResource.mockResolvedValueOnce(jsonResource({ image: 'https://example.com/logo.png' }));
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(mocks.fetchResource).toHaveBeenCalledWith(
+            `https://ipfs.io/ipfs/${VALID_CID}/meta.json`,
+            expect.anything(),
+        );
+        expect(result.logoURI).toBe('https://example.com/logo.png');
+    });
+
+    it('should skip the off-chain read for an ipfs uri with a malformed CID', async () => {
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: 'ipfs://not-a-valid-cid' })]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC);
+
+        expect(result).toMatchObject({ address: MINT_A, decimals: 6, logoURI: null, symbol: 'USDC' });
+        expect(mocks.fetchResource).not.toHaveBeenCalled();
+    });
+
+    it('should skip the off-chain read for an unparseable uri', async () => {
+        const onError = vi.fn();
+        mocks.safeFetchAllMetadata.mockResolvedValueOnce([metadata(MINT_A, { uri: 'not-a-url' })]);
+        mocks.getMultipleParsedAccounts.mockResolvedValueOnce({ value: [parsedMint(6)] });
+
+        const { getTokenInfosFromMetaplex } = await importSubject();
+        const [result] = await getTokenInfosFromMetaplex([MINT_A], RPC, { onError });
+
+        expect(result.logoURI).toBeNull();
+        expect(mocks.fetchResource).not.toHaveBeenCalled();
+        // Junk on-chain data is not an app fault, and the NFT page maps `onError` to `Logger.error`.
+        expect(onError).not.toHaveBeenCalled();
     });
 
     it('should report and return nothing when the metadata lookup throws', async () => {

--- a/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
@@ -131,6 +131,51 @@ describe('getTokenInfos', () => {
         expect(result).toEqual([]);
     });
 
+    it('should call onError with TokenInfoInvalidResponseError when content is not an array', async () => {
+        const onError = vi.fn();
+
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.resolve({ content: { [mockToken.address]: mockToken } }),
+            ok: true,
+        } as Response);
+
+        const result = await getTokenInfos([mockToken.address], Cluster.MainnetBeta, undefined, { onError });
+
+        expect(onError.mock.calls[0][0]).toBeInstanceOf(TokenInfoInvalidResponseError);
+        expect(result).toEqual([]);
+    });
+
+    // A batch is worth more than its worst entry: dropping one malformed token keeps the symbols
+    // of every other mint in the transaction.
+    it('should drop a malformed token, keep the rest, and report the drop', async () => {
+        const onError = vi.fn();
+        const malformed = { ...mockToken, decimals: '9' };
+
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.resolve({ content: [malformed, mockToken] }),
+            ok: true,
+        } as Response);
+
+        const result = await getTokenInfos([mockToken.address], Cluster.MainnetBeta, undefined, { onError });
+
+        expect(result).toEqual([mockToken]);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError.mock.calls[0][0]).toBeInstanceOf(TokenInfoInvalidResponseError);
+    });
+
+    it('should keep a token that carries fields the app does not read', async () => {
+        const withExtras = { ...mockToken, chainId: 101, holders: null, tags: ['lp-token'] };
+
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.resolve({ content: [withExtras] }),
+            ok: true,
+        } as Response);
+
+        const result = await getTokenInfos([mockToken.address], Cluster.MainnetBeta, undefined);
+
+        expect(result).toEqual([withExtras]);
+    });
+
     it('should return tokens on successful response', async () => {
         const mockResponse = { content: [mockToken] };
 

--- a/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
@@ -163,6 +163,39 @@ describe('getTokenInfos', () => {
         expect(onError.mock.calls[0][0]).toBeInstanceOf(TokenInfoInvalidResponseError);
     });
 
+    // UTL omits these keys rather than sending null for some tokens. Requiring them would drop the
+    // token outright, losing the name and symbol over a missing logo — the failure this whole path
+    // exists to prevent. `discover-with-utl.ts` reads the same API and treats both as optional.
+    it('should keep a token that omits logoURI, reporting the logo as null', async () => {
+        const onError = vi.fn();
+        const withoutLogo = { address: mockToken.address, decimals: 9, name: 'Wrapped SOL', symbol: 'SOL' };
+
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.resolve({ content: [withoutLogo] }),
+            ok: true,
+        } as Response);
+
+        const result = await getTokenInfos([mockToken.address], Cluster.MainnetBeta, undefined, { onError });
+
+        expect(result).toEqual([{ ...withoutLogo, logoURI: null }]);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('should keep a token that omits decimals, reporting them as null', async () => {
+        const onError = vi.fn();
+        const withoutDecimals = { address: mockToken.address, logoURI: null, name: 'Wrapped SOL', symbol: 'SOL' };
+
+        vi.mocked(global.fetch).mockResolvedValueOnce({
+            json: () => Promise.resolve({ content: [withoutDecimals] }),
+            ok: true,
+        } as Response);
+
+        const result = await getTokenInfos([mockToken.address], Cluster.MainnetBeta, undefined, { onError });
+
+        expect(result).toEqual([{ ...withoutDecimals, decimals: null }]);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
     it('should keep a token that carries fields the app does not read', async () => {
         const withExtras = { ...mockToken, chainId: 101, holders: null, tags: ['lp-token'] };
 

--- a/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
+++ b/app/entities/token-info/api/__tests__/fetch-token-mints.spec.ts
@@ -2,9 +2,9 @@ import { PublicKey } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { TokenInfoHttpError, TokenInfoInvalidResponseError } from '../errors';
+import { TokenInfoHttpError, TokenInfoInvalidResponseError } from '../../lib/errors';
+import { type TokenInfo } from '../../lib/types';
 import { getTokenInfo, getTokenInfos } from '../fetch-token-mints';
-import { type TokenInfo } from '../types';
 
 const mockToken: TokenInfo = {
     address: PublicKey.default.toBase58(),

--- a/app/entities/token-info/api/fetch-token-metaplex.ts
+++ b/app/entities/token-info/api/fetch-token-metaplex.ts
@@ -1,4 +1,4 @@
-import { getMetadataJson, getUmi } from '@entities/nft/@x/token-info';
+import { getUmi } from '@entities/nft/@x/token-info';
 import {
     findMetadataPda,
     type Metadata,
@@ -7,6 +7,9 @@ import {
 } from '@metaplex-foundation/mpl-token-metadata';
 import { publicKey, unwrapOption } from '@metaplex-foundation/umi';
 import { Connection, PublicKey } from '@solana/web3.js';
+
+import { MAX_SIZE, USER_AGENT } from '@/app/api/metadata/proxy/config';
+import { fetchResource, matchJsonContent } from '@/app/api/metadata/proxy/feature';
 
 import type { TokenInfo } from '../lib/types';
 
@@ -23,11 +26,6 @@ const DEFAULT_DECIMALS = 6;
 const ACCOUNTS_CHUNK_SIZE = 100;
 
 export type FetchTokenInfosMetaplexOptions = {
-    /**
-     * Absolute origin of the incoming request. Needed because the off-chain
-     * JSON goes through the root-relative `/api/metadata/proxy` path.
-     */
-    baseUrl?: string;
     onError?: (error: unknown) => void;
 };
 
@@ -86,30 +84,36 @@ async function fetchDecimals(
 }
 
 /**
- * Reads one mint's off-chain JSON to find its logo, bounded by
- * `METAPLEX_TIMEOUT_MS`.
+ * Reads one mint's off-chain JSON to find its logo, bounded by `METAPLEX_TIMEOUT_MS`.
  *
- * Resolves to `null`, not `undefined`, because `TokenInfo.logoURI` is `string |
- * null` in the UTL REST contract and this value is serialised straight into it.
+ * A mint's `uri` is attacker-controlled on-chain data, so this calls the metadata proxy's
+ * `fetchResource` in process rather than requesting `/api/metadata/proxy` over HTTP. Same
+ * hardening — per-hop private-IP rejection, protocol and redirect validation, size cap — with
+ * no round trip, and nothing derived from the incoming request's host.
+ *
+ * Resolves to `null`, not `undefined`, because `TokenInfo.logoURI` is `string | null` in the
+ * UTL REST contract and this value is serialised straight into it.
  */
-
 async function fetchLogoUri(metadata: Metadata, options: FetchTokenInfosMetaplexOptions): Promise<string | null> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), METAPLEX_TIMEOUT_MS);
+    // eslint-disable-next-line unicorn/no-null -- `TokenInfo.logoURI` is `string | null` per the UTL contract
+    if (!metadata.uri) return null;
+
     try {
-        const json = await getMetadataJson(metadata, {
-            baseUrl: options.baseUrl,
-            onError: options.onError,
-            signal: controller.signal,
+        const { data, headers } = await fetchResource(metadata.uri, {
+            headers: new Headers({ 'User-Agent': USER_AGENT }),
+            size: MAX_SIZE,
+            timeout: METAPLEX_TIMEOUT_MS,
         });
         // eslint-disable-next-line unicorn/no-null -- same contract as above
-        return json?.image ?? null;
+        if (!matchJsonContent(headers.get('content-type'))) return null;
+        const image = (data as { image?: unknown } | undefined)?.image;
+        // eslint-disable-next-line unicorn/no-null -- same contract as above
+        return typeof image === 'string' ? image : null;
     } catch (error) {
+        // A dead link, a slow host, or a blocked address is routine for third-party metadata.
         options.onError?.(error);
         // eslint-disable-next-line unicorn/no-null -- same contract as above
         return null;
-    } finally {
-        clearTimeout(timeout);
     }
 }
 

--- a/app/entities/token-info/api/fetch-token-metaplex.ts
+++ b/app/entities/token-info/api/fetch-token-metaplex.ts
@@ -7,6 +7,7 @@ import {
 } from '@metaplex-foundation/mpl-token-metadata';
 import { publicKey, unwrapOption } from '@metaplex-foundation/umi';
 import { Connection, PublicKey } from '@solana/web3.js';
+import { fetchAll } from '@utils/fetch-all';
 
 import { MAX_SIZE, USER_AGENT } from '@/app/api/metadata/proxy/config';
 import { fetchResource, matchJsonContent } from '@/app/api/metadata/proxy/feature';
@@ -18,6 +19,22 @@ import type { TokenInfo } from '../lib/types';
  * `metaplexTimeout` default in `@solflare-wallet/utl-sdk`.
  */
 export const METAPLEX_TIMEOUT_MS = 5_000;
+
+/**
+ * How many off-chain JSON reads may be in flight at once. One batch names up to
+ * `MAX_ADDRESSES` mints, each pointing at a third-party host, so this bounds the
+ * sockets one request opens instead of fanning out over the whole batch.
+ */
+export const LOGO_CONCURRENCY = 8;
+
+/**
+ * Wall clock the off-chain reads may spend across one batch, in milliseconds.
+ * `METAPLEX_TIMEOUT_MS` bounds a single read, but a run of slow hosts would still
+ * add up past the route's `maxDuration` and lose the whole response. Past this
+ * point the remaining mints report `logoURI: null`, so names, symbols and
+ * decimals — which come from the metadata and mint accounts — still arrive.
+ */
+export const LOGO_BUDGET_MS = 10_000;
 
 /** Decimals reported when the mint account is missing or unparseable. */
 const DEFAULT_DECIMALS = 6;
@@ -84,7 +101,8 @@ async function fetchDecimals(
 }
 
 /**
- * Reads one mint's off-chain JSON to find its logo, bounded by `METAPLEX_TIMEOUT_MS`.
+ * Reads one mint's off-chain JSON to find its logo, bounded by `METAPLEX_TIMEOUT_MS` and by
+ * whatever is left of the batch's `deadline`.
  *
  * A mint's `uri` is attacker-controlled on-chain data, so this calls the metadata proxy's
  * `fetchResource` in process rather than requesting `/api/metadata/proxy` over HTTP. Same
@@ -94,15 +112,25 @@ async function fetchDecimals(
  * Resolves to `null`, not `undefined`, because `TokenInfo.logoURI` is `string | null` in the
  * UTL REST contract and this value is serialised straight into it.
  */
-async function fetchLogoUri(metadata: Metadata, options: FetchTokenInfosMetaplexOptions): Promise<string | null> {
+async function fetchLogoUri(
+    metadata: Metadata,
+    deadline: number,
+    options: FetchTokenInfosMetaplexOptions,
+): Promise<string | null> {
     // eslint-disable-next-line unicorn/no-null -- `TokenInfo.logoURI` is `string | null` per the UTL contract
     if (!metadata.uri) return null;
+
+    const timeout = Math.min(METAPLEX_TIMEOUT_MS, deadline - Date.now());
+    // The batch has spent its budget; the mints still queued give up their logo rather than the
+    // request giving up its response.
+    // eslint-disable-next-line unicorn/no-null -- same contract as above
+    if (timeout <= 0) return null;
 
     try {
         const { data, headers } = await fetchResource(metadata.uri, {
             headers: new Headers({ 'User-Agent': USER_AGENT }),
             size: MAX_SIZE,
-            timeout: METAPLEX_TIMEOUT_MS,
+            timeout,
         });
         // eslint-disable-next-line unicorn/no-null -- same contract as above
         if (!matchJsonContent(headers.get('content-type'))) return null;
@@ -158,13 +186,17 @@ export async function getTokenInfosFromMetaplex(
 
     if (fungible.length === 0) return [];
 
+    const deadline = Date.now() + LOGO_BUDGET_MS;
+
     const [decimals, logoUris] = await Promise.all([
         fetchDecimals(
             fungible.map(metadata => metadata.mint.toString()),
             rpcEndpoint,
             options.onError,
         ),
-        Promise.all(fungible.map(metadata => fetchLogoUri(metadata, options))),
+        // `fetchAll` runs at most `LOGO_CONCURRENCY` reads at a time and keeps the results in the
+        // order the mints were given, so `logoUris[index]` below still belongs to `fungible[index]`.
+        fetchAll(fungible, metadata => fetchLogoUri(metadata, deadline, options), LOGO_CONCURRENCY),
     ]);
 
     return fungible.map((metadata, index) => ({

--- a/app/entities/token-info/api/fetch-token-metaplex.ts
+++ b/app/entities/token-info/api/fetch-token-metaplex.ts
@@ -1,0 +1,174 @@
+import { getMetadataJson, getUmi } from '@entities/nft/@x/token-info';
+import {
+    findMetadataPda,
+    type Metadata,
+    safeFetchAllMetadata,
+    TokenStandard,
+} from '@metaplex-foundation/mpl-token-metadata';
+import { publicKey, unwrapOption } from '@metaplex-foundation/umi';
+import { Connection, PublicKey } from '@solana/web3.js';
+
+import type { TokenInfo } from '../lib/types';
+
+/**
+ * Milliseconds to wait for one mint's off-chain JSON. Carried over from the
+ * `metaplexTimeout` default in `@solflare-wallet/utl-sdk`.
+ */
+export const METAPLEX_TIMEOUT_MS = 5_000;
+
+/** Decimals reported when the mint account is missing or unparseable. */
+const DEFAULT_DECIMALS = 6;
+
+/** `getMultipleAccounts` accepts at most 100 keys per request. */
+const ACCOUNTS_CHUNK_SIZE = 100;
+
+export type FetchTokenInfosMetaplexOptions = {
+    /**
+     * Absolute origin of the incoming request. Needed because the off-chain
+     * JSON goes through the root-relative `/api/metadata/proxy` path.
+     */
+    baseUrl?: string;
+    onError?: (error: unknown) => void;
+};
+
+const NULL_CHAR = String.fromCharCode(0);
+
+/**
+ * Strips the null padding the token metadata program adds to fixed-width
+ * strings. Matches `removeEmptyChars` in `@metaplex-foundation/js`, which the
+ * SDK relied on to clean up on-chain names and symbols.
+ */
+function removeEmptyChars(value: string): string {
+    return value.split(NULL_CHAR).join('');
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) {
+        chunks.push(items.slice(i, i + size));
+    }
+    return chunks;
+}
+
+/**
+ * Reads `decimals` for each mint. Mirrors the SDK, which fetched the parsed
+ * mint accounts separately because the metadata account does not carry them.
+ */
+async function fetchDecimals(
+    mints: string[],
+    rpcEndpoint: string,
+    onError?: (error: unknown) => void,
+): Promise<Map<string, number>> {
+    const decimals = new Map<string, number>();
+    if (mints.length === 0) return decimals;
+
+    const connection = new Connection(rpcEndpoint);
+
+    await Promise.all(
+        chunk(mints, ACCOUNTS_CHUNK_SIZE).map(async batch => {
+            try {
+                const { value } = await connection.getMultipleParsedAccounts(batch.map(mint => new PublicKey(mint)));
+                value.forEach((account, index) => {
+                    const data = account?.data;
+                    if (!data || !('parsed' in data)) return;
+                    const parsedDecimals = data.parsed?.info?.decimals;
+                    if (typeof parsedDecimals === 'number') {
+                        decimals.set(batch[index], parsedDecimals);
+                    }
+                });
+            } catch (error) {
+                onError?.(error);
+            }
+        }),
+    );
+
+    return decimals;
+}
+
+/**
+ * Reads one mint's off-chain JSON to find its logo, bounded by
+ * `METAPLEX_TIMEOUT_MS`.
+ *
+ * Resolves to `null`, not `undefined`, because `TokenInfo.logoURI` is `string |
+ * null` in the UTL REST contract and this value is serialised straight into it.
+ */
+
+async function fetchLogoUri(metadata: Metadata, options: FetchTokenInfosMetaplexOptions): Promise<string | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), METAPLEX_TIMEOUT_MS);
+    try {
+        const json = await getMetadataJson(metadata, {
+            baseUrl: options.baseUrl,
+            onError: options.onError,
+            signal: controller.signal,
+        });
+        // eslint-disable-next-line unicorn/no-null -- same contract as above
+        return json?.image ?? null;
+    } catch (error) {
+        options.onError?.(error);
+        // eslint-disable-next-line unicorn/no-null -- same contract as above
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+/**
+ * Resolves token info from on-chain Metaplex metadata. Use this for mints the
+ * unified token list (UTL) API does not carry.
+ *
+ * This replaces the Metaplex fallback in `@solflare-wallet/utl-sdk`. Like the
+ * SDK it returns only mints whose token standard is `Fungible`, and it marks
+ * every result unverified because the data is not on a curated list.
+ */
+export async function getTokenInfosFromMetaplex(
+    addresses: string[],
+    rpcEndpoint: string,
+    options: FetchTokenInfosMetaplexOptions = {},
+): Promise<TokenInfo[]> {
+    if (addresses.length === 0 || !rpcEndpoint) return [];
+
+    let fungible: Metadata[];
+    try {
+        const umi = getUmi(rpcEndpoint);
+        const pdas = addresses.map(address => findMetadataPda(umi, { mint: publicKey(address) }));
+
+        // Umi sends every key in a single `getMultipleAccounts` call, so batch here to stay under
+        // the RPC limit. One failed batch must not lose the mints the others resolved.
+        const batches = await Promise.all(
+            chunk(pdas, ACCOUNTS_CHUNK_SIZE).map(async batch => {
+                try {
+                    return await safeFetchAllMetadata(umi, batch);
+                } catch (error) {
+                    options.onError?.(error);
+                    return [];
+                }
+            }),
+        );
+
+        fungible = batches.flat().filter(metadata => unwrapOption(metadata.tokenStandard) === TokenStandard.Fungible);
+    } catch (error) {
+        options.onError?.(error);
+        return [];
+    }
+
+    if (fungible.length === 0) return [];
+
+    const [decimals, logoUris] = await Promise.all([
+        fetchDecimals(
+            fungible.map(metadata => metadata.mint.toString()),
+            rpcEndpoint,
+            options.onError,
+        ),
+        Promise.all(fungible.map(metadata => fetchLogoUri(metadata, options))),
+    ]);
+
+    return fungible.map((metadata, index) => ({
+        address: metadata.mint.toString(),
+        decimals: decimals.get(metadata.mint.toString()) ?? DEFAULT_DECIMALS,
+        logoURI: logoUris[index],
+        name: removeEmptyChars(metadata.name),
+        symbol: removeEmptyChars(metadata.symbol),
+        verified: false,
+    }));
+}

--- a/app/entities/token-info/api/fetch-token-metaplex.ts
+++ b/app/entities/token-info/api/fetch-token-metaplex.ts
@@ -11,6 +11,8 @@ import { fetchAll } from '@utils/fetch-all';
 
 import { MAX_SIZE, USER_AGENT } from '@/app/api/metadata/proxy/config';
 import { fetchResource, matchJsonContent } from '@/app/api/metadata/proxy/feature';
+import { IPFS_PROTOCOL, resolveIpfsUri } from '@/app/shared/lib/ipfs';
+import { parseUrl } from '@/app/shared/lib/url';
 
 import type { TokenInfo } from '../lib/types';
 
@@ -101,6 +103,22 @@ async function fetchDecimals(
 }
 
 /**
+ * Resolves a mint's on-chain `uri` to something `fetchResource` can read.
+ *
+ * `ipfs://` is common in metadata and `fetchResource` speaks only http(s), so an ipfs URI is
+ * mapped to the same gateway the browser path uses via `getProxiedUri`. Without this every
+ * unlisted mint hosted on IPFS reports a blocked protocol instead of a logo.
+ *
+ * Returns '' when the URI names nothing readable — unparseable, or an ipfs address with a
+ * malformed CID. Other schemes pass through unchanged, for `fetchResource` to reject.
+ */
+function resolveMetadataUri(uri: string): string {
+    const url = parseUrl(uri);
+    if (!url) return '';
+    return url.protocol === IPFS_PROTOCOL ? resolveIpfsUri(url) : uri;
+}
+
+/**
  * Reads one mint's off-chain JSON to find its logo, bounded by `METAPLEX_TIMEOUT_MS` and by
  * whatever is left of the batch's `deadline`.
  *
@@ -117,8 +135,10 @@ async function fetchLogoUri(
     deadline: number,
     options: FetchTokenInfosMetaplexOptions,
 ): Promise<string | null> {
+    // Covers a mint with no `uri` at all, as well as one naming nothing readable.
+    const uri = resolveMetadataUri(metadata.uri);
     // eslint-disable-next-line unicorn/no-null -- `TokenInfo.logoURI` is `string | null` per the UTL contract
-    if (!metadata.uri) return null;
+    if (!uri) return null;
 
     const timeout = Math.min(METAPLEX_TIMEOUT_MS, deadline - Date.now());
     // The batch has spent its budget; the mints still queued give up their logo rather than the
@@ -127,7 +147,7 @@ async function fetchLogoUri(
     if (timeout <= 0) return null;
 
     try {
-        const { data, headers } = await fetchResource(metadata.uri, {
+        const { data, headers } = await fetchResource(uri, {
             headers: new Headers({ 'User-Agent': USER_AGENT }),
             size: MAX_SIZE,
             timeout,

--- a/app/entities/token-info/api/fetch-token-mints.ts
+++ b/app/entities/token-info/api/fetch-token-mints.ts
@@ -2,7 +2,7 @@
 
 import { getChainId } from '@entities/chain-id/@x/token-info';
 import { Cluster } from '@utils/cluster';
-import { array, boolean, is, nullable, number, optional, string, type } from 'superstruct';
+import { array, boolean, type Infer, is, nullable, number, optional, string, type } from 'superstruct';
 
 import { UTL_API_BASE_URL } from '../env';
 import { TokenInfoHttpError, TokenInfoInvalidResponseError } from '../lib/errors';
@@ -12,15 +12,33 @@ import { type FetchConfig, type TokenInfo } from '../lib/types';
  * The fields of a UTL `/v1/mints` token this app reads, with the types `TokenInfo`
  * declares. `type` ignores the rest (`chainId`, `tags`, `holders`, …), so an
  * upstream addition passes while a change to a rendered field does not.
+ *
+ * `decimals` and `logoURI` are optional as well as nullable: UTL omits the key
+ * outright for some tokens, and a missing logo must not cost the whole token its
+ * name and symbol. `normalizeToken` puts back the `null` `TokenInfo` declares.
+ * `app/features/search/api/discover-with-utl.ts` reads the same API and treats
+ * both fields the same way.
  */
 const TokenInfoStruct = type({
     address: string(),
-    decimals: nullable(number()),
-    logoURI: nullable(string()),
+    decimals: optional(nullable(number())),
+    logoURI: optional(nullable(string())),
     name: string(),
     symbol: string(),
     verified: optional(boolean()),
 });
+
+type UtlToken = Infer<typeof TokenInfoStruct>;
+
+/**
+ * Restores the keys UTL may omit to the `null` `TokenInfo` declares. Spreads the
+ * token so the fields this app does not read (`tags`, `holders`, …) survive for
+ * `getFullTokenInfo`, which merges them with the legacy CDN list.
+ */
+function normalizeToken(token: UtlToken): TokenInfo {
+    // eslint-disable-next-line unicorn/no-null -- `decimals` and `logoURI` are `… | null` per the UTL contract
+    return { ...token, decimals: token.decimals ?? null, logoURI: token.logoURI ?? null };
+}
 
 /** The response envelope. Entries stay `unknown` so one bad token can be dropped on its own. */
 const MintsResponseStruct = type({ content: array() });
@@ -60,7 +78,9 @@ export async function getTokenInfos(
 
         // Per token, not per batch: a single malformed entry must not blank every symbol in a
         // transaction. Drops are reported so upstream drift stays visible instead of silent.
-        const tokens = data.content.filter((token): token is TokenInfo => is(token, TokenInfoStruct));
+        const tokens = data.content
+            .filter((token): token is UtlToken => is(token, TokenInfoStruct))
+            .map(normalizeToken);
         if (tokens.length !== data.content.length) {
             config?.onError?.(
                 new TokenInfoInvalidResponseError(

--- a/app/entities/token-info/api/fetch-token-mints.ts
+++ b/app/entities/token-info/api/fetch-token-mints.ts
@@ -1,11 +1,11 @@
 'use server';
 
-import { getChainId } from '@entities/chain-id';
+import { getChainId } from '@entities/chain-id/@x/token-info';
 import { Cluster } from '@utils/cluster';
 
 import { UTL_API_BASE_URL } from '../env';
-import { TokenInfoHttpError, TokenInfoInvalidResponseError } from './errors';
-import { type FetchConfig, type TokenInfo } from './types';
+import { TokenInfoHttpError, TokenInfoInvalidResponseError } from '../lib/errors';
+import { type FetchConfig, type TokenInfo } from '../lib/types';
 
 export async function getTokenInfos(
     addresses: string[],

--- a/app/entities/token-info/api/fetch-token-mints.ts
+++ b/app/entities/token-info/api/fetch-token-mints.ts
@@ -2,10 +2,28 @@
 
 import { getChainId } from '@entities/chain-id/@x/token-info';
 import { Cluster } from '@utils/cluster';
+import { array, boolean, is, nullable, number, optional, string, type } from 'superstruct';
 
 import { UTL_API_BASE_URL } from '../env';
 import { TokenInfoHttpError, TokenInfoInvalidResponseError } from '../lib/errors';
 import { type FetchConfig, type TokenInfo } from '../lib/types';
+
+/**
+ * The fields of a UTL `/v1/mints` token this app reads, with the types `TokenInfo`
+ * declares. `type` ignores the rest (`chainId`, `tags`, `holders`, …), so an
+ * upstream addition passes while a change to a rendered field does not.
+ */
+const TokenInfoStruct = type({
+    address: string(),
+    decimals: nullable(number()),
+    logoURI: nullable(string()),
+    name: string(),
+    symbol: string(),
+    verified: optional(boolean()),
+});
+
+/** The response envelope. Entries stay `unknown` so one bad token can be dropped on its own. */
+const MintsResponseStruct = type({ content: array() });
 
 export async function getTokenInfos(
     addresses: string[],
@@ -33,14 +51,25 @@ export async function getTokenInfos(
             return [];
         }
 
-        const data = (await response.json()) as { content?: TokenInfo[] };
+        const data = await response.json();
 
-        if (!data.content) {
+        if (!is(data, MintsResponseStruct)) {
             config?.onError?.(new TokenInfoInvalidResponseError());
             return [];
         }
 
-        return data.content;
+        // Per token, not per batch: a single malformed entry must not blank every symbol in a
+        // transaction. Drops are reported so upstream drift stays visible instead of silent.
+        const tokens = data.content.filter((token): token is TokenInfo => is(token, TokenInfoStruct));
+        if (tokens.length !== data.content.length) {
+            config?.onError?.(
+                new TokenInfoInvalidResponseError(
+                    `Invalid response: dropped ${data.content.length - tokens.length} of ${data.content.length} tokens`,
+                ),
+            );
+        }
+
+        return tokens;
     } catch (error) {
         config?.onError?.(error);
         return [];

--- a/app/entities/token-info/index.ts
+++ b/app/entities/token-info/index.ts
@@ -1,9 +1,10 @@
+// Client-facing surface. Server-only pieces (the UTL list fetch, the on-chain
+// Metaplex fallback, cluster validation) live in `./server`.
 export { createAbortSignal } from './lib/create-abort-signal';
 export { deriveScaledUiAmountMultiplier } from './lib/derive-scaled-ui-multiplier';
 export { TokenInfoHttpError, TokenInfoInvalidResponseError } from './lib/errors';
-export { getTokenInfo, getTokenInfos } from './lib/fetch-token-mints';
-export { getChainId } from '@entities/chain-id';
-export { isValidCluster } from './lib/is-valid-cluster';
+export { getChainId } from '@entities/chain-id/@x/token-info';
+export { Tag } from './lib/types';
 export type { FetchConfig, TokenInfo } from './lib/types';
 export { TokenInfoBatchProvider, useTokenInfoBatch } from './model/token-info-batch-provider';
 export { useTokenInfo } from './model/use-token-info';

--- a/app/entities/token-info/lib/is-valid-cluster.ts
+++ b/app/entities/token-info/lib/is-valid-cluster.ts
@@ -1,4 +1,4 @@
-import { getChainId } from '@entities/chain-id';
+import { getChainId } from '@entities/chain-id/@x/token-info';
 import { Cluster } from '@utils/cluster';
 
 type SupportedCluster = Extract<

--- a/app/entities/token-info/lib/types.ts
+++ b/app/entities/token-info/lib/types.ts
@@ -1,10 +1,27 @@
-import type { Token as SdkToken } from '@solflare-wallet/utl-sdk';
+/**
+ * Tags the unified token list (UTL) API attaches to a token.
+ */
+export enum Tag {
+    LP_TOKEN = 'lp-token',
+}
 
 /**
- * Token information interface.
- * Extends the Solflare UTL SDK Token type to ensure compatibility.
+ * Token information returned by the unified token list (UTL) API and by the
+ * on-chain Metaplex fallback.
+ *
+ * This mirrors the `Token` type that came from `@solflare-wallet/utl-sdk`. The
+ * shape is the UTL REST response contract, so do not change it.
  */
-export interface TokenInfo extends SdkToken {}
+export interface TokenInfo {
+    name: string;
+    symbol: string;
+    logoURI: string | null;
+    verified?: boolean;
+    address: string;
+    tags?: Set<Tag>;
+    decimals: number | null;
+    holders?: number | null;
+}
 
 export type FetchConfig = {
     signal?: AbortSignal;

--- a/app/entities/token-info/model/__tests__/token-info-batch-provider.cache.spec.tsx
+++ b/app/entities/token-info/model/__tests__/token-info-batch-provider.cache.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { getTokenInfosMock } = vi.hoisted(() => ({ getTokenInfosMock: vi.fn().mockResolvedValue([]) }));
-vi.mock('@entities/token-info/lib/fetch-token-mints', () => ({ getTokenInfos: getTokenInfosMock }));
+vi.mock('@entities/token-info/api/fetch-token-mints', () => ({ getTokenInfos: getTokenInfosMock }));
 
 // The specs setup (test-setup.specs.ts) globally no-ops useTokenInfoBatch to prevent network. This suite
 // asserts real batch behavior, so restore the actual provider for this file only.

--- a/app/entities/token-info/model/token-info-batch-provider.tsx
+++ b/app/entities/token-info/model/token-info-batch-provider.tsx
@@ -7,7 +7,7 @@ import { mutate } from 'swr';
 
 import { Logger } from '@/app/shared/lib/logger';
 
-import { getTokenInfos } from '../lib/fetch-token-mints';
+import { getTokenInfos } from '../api/fetch-token-mints';
 
 type RequestTokenInfo = (address: string, cluster: Cluster, genesisHash?: string) => void;
 type BatchRequest = { address: string; cluster: Cluster; genesisHash?: string };

--- a/app/entities/token-info/model/use-token-info.ts
+++ b/app/entities/token-info/model/use-token-info.ts
@@ -1,11 +1,11 @@
 'use client';
 
-import { Token } from '@solflare-wallet/utl-sdk';
 import { Cluster } from '@utils/cluster';
 import { getTokenInfoSwrKey } from '@utils/token-info';
 import { useEffect } from 'react';
 import useSWR from 'swr';
 
+import type { TokenInfo } from '../lib/types';
 import { useTokenInfoBatch } from './token-info-batch-provider';
 
 export function useTokenInfo(
@@ -13,7 +13,7 @@ export function useTokenInfo(
     pubkey: string,
     cluster: Cluster,
     genesisHash?: string,
-): Token | undefined {
+): TokenInfo | undefined {
     const requestTokenInfo = useTokenInfoBatch();
 
     useEffect(() => {
@@ -22,7 +22,7 @@ export function useTokenInfo(
         }
     }, [fetchTokenLabelInfo, pubkey, cluster, genesisHash, requestTokenInfo]);
 
-    const { data } = useSWR<Token | undefined>(
+    const { data } = useSWR<TokenInfo | undefined>(
         fetchTokenLabelInfo ? getTokenInfoSwrKey(pubkey, cluster, genesisHash) : null,
         null,
     );

--- a/app/entities/token-info/server.ts
+++ b/app/entities/token-info/server.ts
@@ -1,1 +1,5 @@
 export { UTL_API_BASE_URL } from './env';
+export { getTokenInfosFromMetaplex } from './api/fetch-token-metaplex';
+export { getTokenInfo, getTokenInfos } from './api/fetch-token-mints';
+export { isValidCluster } from './lib/is-valid-cluster';
+export type { TokenInfo } from './lib/types';

--- a/app/features/metadata/utils.ts
+++ b/app/features/metadata/utils.ts
@@ -1,9 +1,5 @@
-import { CID } from 'multiformats/cid';
-
-import { Logger } from '@/app/shared/lib/logger';
+import { IPFS_PROTOCOL, resolveIpfsUri } from '@/app/shared/lib/ipfs';
 import { parseUrl, SAFE_EXTERNAL_PROTOCOLS } from '@/app/shared/lib/url';
-
-const IPFS_GATEWAY = 'https://ipfs.io/ipfs';
 
 export const getProxiedUri = (uri: string): string | '' => {
     if (!uri) return '';
@@ -18,7 +14,7 @@ export const getProxiedUri = (uri: string): string | '' => {
 
     const isProxyEnabled = process.env.NEXT_PUBLIC_METADATA_ENABLED === 'true';
 
-    if (url.protocol === 'ipfs:') {
+    if (url.protocol === IPFS_PROTOCOL) {
         const gatewayUri = resolveIpfsUri(url);
         if (gatewayUri === '') return '';
         return isProxyEnabled ? proxyUri(gatewayUri) : gatewayUri;
@@ -33,27 +29,4 @@ export const getProxiedUri = (uri: string): string | '' => {
     return proxyUri(uri);
 };
 
-const resolveIpfsUri = (url: URL): string => {
-    // eslint-disable-next-line no-restricted-syntax -- Strips redundant "ipfs/" prefix from the path for a clean gateway URL.
-    const fullPath = (url.host + url.pathname).replace(/^ipfs\//, '');
-    // Split the CID from any subpath (e.g. "QmXXX/image.png" → cid="QmXXX", subpath="/image.png")
-    const firstSlash = fullPath.indexOf('/');
-    const cid = firstSlash === -1 ? fullPath : fullPath.slice(0, firstSlash);
-    const subpath = firstSlash === -1 ? '' : fullPath.slice(firstSlash);
-    if (!verifyCID(cid)) {
-        Logger.warn(`[metadata] Cannot fetch a malformed CID: ${cid}`);
-        return '';
-    }
-    return `${IPFS_GATEWAY}/${cid}${subpath}${url.search}`;
-};
-
 const proxyUri = (uri: string): string => `/api/metadata/proxy?uri=${encodeURIComponent(uri)}`;
-
-const verifyCID = (cid: string): boolean => {
-    try {
-        CID.parse(cid);
-        return true;
-    } catch {
-        return false;
-    }
-};

--- a/app/features/transaction/ui/TokenBalancesCard.tsx
+++ b/app/features/transaction/ui/TokenBalancesCard.tsx
@@ -4,7 +4,6 @@ import ScaledUiAmountMultiplierTooltip from '@components/account/token-extension
 import { Address } from '@components/common/Address';
 import { BalanceDelta } from '@components/common/BalanceDelta';
 import { cn } from '@components/shared/utils';
-import { getTokenInfos } from '@entities/token-info';
 import { useTransactionDetails } from '@providers/transactions';
 import { ParsedMessageAccount, PublicKey, TokenBalance } from '@solana/web3.js';
 import { SignatureProps } from '@utils/index';
@@ -14,6 +13,7 @@ import useAsyncEffect from 'use-async-effect';
 
 import { useScaledUiAmountForMint } from '@/app/providers/accounts/tokens';
 import { useCluster } from '@/app/providers/cluster';
+import { getTokenInfos } from '@/app/utils/token-info';
 
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -65,11 +65,10 @@ export function TokenBalancesCardInner({ rows }: TokenBalancesCardInnerProps) {
     // genesisHash is required to derive a chainId on Custom/Simd296 clusters - without it getTokenInfos returns [].
     useAsyncEffect(
         async isMounted => {
-            const mints = rows.map(r => r.mint);
+            const mints = rows.map(r => new PublicKey(r.mint));
             const tokens = await getTokenInfos(mints, cluster, genesisHash);
-            if (isMounted()) {
-                setTokenSymbols(new Map(tokens.map(t => [t.address, t.symbol])));
-            }
+            if (!isMounted()) return;
+            setTokenSymbols(new Map(tokens?.map(t => [t.address, t.symbol])));
         },
         [mintKey, cluster, genesisHash],
     );

--- a/app/shared/lib/ipfs.ts
+++ b/app/shared/lib/ipfs.ts
@@ -1,0 +1,43 @@
+import { CID } from 'multiformats/cid';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+const IPFS_GATEWAY = 'https://ipfs.io/ipfs';
+
+/** The scheme an on-chain metadata URI uses to name IPFS content. */
+export const IPFS_PROTOCOL = 'ipfs:';
+
+/**
+ * Maps an `ipfs://` URL to its HTTP gateway URL, so callers that only speak
+ * http(s) can read it — an `<img src>`, or the metadata proxy's `fetchResource`,
+ * which rejects every other scheme.
+ *
+ * Returns '' for a malformed CID: that URI names nothing fetchable, and callers
+ * treat the empty string as "no resource" rather than passing it on.
+ *
+ * Only the `ipfs:` branch lives here. Each caller keeps its own decision about
+ * other schemes, and must keep passing the original URI string rather than
+ * `url.href`, which `new URL` may have normalised.
+ */
+export function resolveIpfsUri(url: URL): string {
+    // eslint-disable-next-line no-restricted-syntax -- Strips redundant "ipfs/" prefix from the path for a clean gateway URL.
+    const fullPath = (url.host + url.pathname).replace(/^ipfs\//, '');
+    // Split the CID from any subpath (e.g. "QmXXX/image.png" → cid="QmXXX", subpath="/image.png")
+    const firstSlash = fullPath.indexOf('/');
+    const cid = firstSlash === -1 ? fullPath : fullPath.slice(0, firstSlash);
+    const subpath = firstSlash === -1 ? '' : fullPath.slice(firstSlash);
+    if (!verifyCID(cid)) {
+        Logger.warn(`[ipfs] Cannot fetch a malformed CID: ${cid}`);
+        return '';
+    }
+    return `${IPFS_GATEWAY}/${cid}${subpath}${url.search}`;
+}
+
+function verifyCID(cid: string): boolean {
+    try {
+        CID.parse(cid);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/app/utils/get-readable-title-from-address.ts
+++ b/app/utils/get-readable-title-from-address.ts
@@ -1,6 +1,6 @@
 import { Cluster } from '@utils/cluster';
 
-import { getTokenInfo } from '@/app/entities/token-info';
+import { getTokenInfo } from '@/app/entities/token-info/server';
 
 export type AddressPageMetadataProps = Readonly<{
     params: Promise<{

--- a/app/utils/token-info.ts
+++ b/app/utils/token-info.ts
@@ -1,6 +1,6 @@
-import { getChainId } from '@entities/token-info';
+import { ChainId } from '@entities/chain-id';
+import { getChainId, type TokenInfo } from '@entities/token-info';
 import { PublicKey } from '@solana/web3.js';
-import { ChainId, Token } from '@solflare-wallet/utl-sdk';
 import { Cluster } from '@utils/cluster';
 import { TokenExtension } from '@validators/accounts/token-extension';
 
@@ -42,6 +42,40 @@ type FullLegacyTokenInfoList = {
     tokens: FullLegacyTokenInfo[];
 };
 
+/**
+ * Resolves mints through the `/api/token-info` route. The route owns the UTL
+ * list lookup and the RPC endpoint, so no RPC URL is sent from the browser.
+ *
+ * @param includeOnChainFallback Also read on-chain Metaplex metadata for mints
+ * the UTL list does not carry. Costs extra RPC calls, so it is opt-in.
+ */
+async function fetchTokenInfosFromApi(
+    addresses: string[],
+    cluster: Cluster,
+    genesisHash: string | undefined,
+    includeOnChainFallback: boolean,
+): Promise<TokenInfo[] | undefined> {
+    const chainId = getChainId(cluster, genesisHash);
+    if (!chainId) return undefined;
+    if (addresses.length === 0) return [];
+
+    try {
+        const response = await fetch('/api/token-info', {
+            body: JSON.stringify({ addresses, cluster, genesisHash, includeOnChainFallback }),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+        });
+
+        if (!response.ok) return undefined;
+
+        const data = (await response.json()) as { content?: TokenInfo[] };
+        return data.content;
+    } catch (error) {
+        Logger.warn('[utils:token-info] Failed to fetch token info', { addresses, error });
+        return undefined;
+    }
+}
+
 export function getTokenInfoSwrKey(address: string, cluster: Cluster, genesisHash?: string) {
     return ['get-token-info', address, cluster, genesisHash];
 }
@@ -50,7 +84,7 @@ export async function getTokenInfo(
     address: PublicKey,
     cluster: Cluster,
     genesisHash?: string,
-): Promise<Token | undefined> {
+): Promise<TokenInfo | undefined> {
     return getTokenInfoWithoutOnChainFallback(address, cluster, genesisHash);
 }
 
@@ -61,25 +95,9 @@ export async function getTokenInfoWithoutOnChainFallback(
     address: PublicKey,
     cluster: Cluster,
     genesisHash?: string,
-): Promise<Token | undefined> {
-    const chainId = getChainId(cluster, genesisHash);
-    if (!chainId) return undefined;
-
-    try {
-        const response = await fetch('/api/token-info', {
-            body: JSON.stringify({ address: address.toBase58(), cluster, genesisHash }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-
-        if (!response.ok) return undefined;
-
-        const data = (await response.json()) as { content?: Token };
-        return data.content;
-    } catch (error) {
-        Logger.warn('[utils:token-info] Failed to fetch token info', { address: address.toString(), error });
-        return undefined;
-    }
+): Promise<TokenInfo | undefined> {
+    const tokens = await fetchTokenInfosFromApi([address.toBase58()], cluster, genesisHash, false);
+    return tokens?.[0];
 }
 
 async function getFullLegacyTokenInfoUsingCdn(
@@ -168,6 +186,23 @@ export async function getFullTokenInfo(
         tags,
         verified: sdkTokenInfo.verified ?? false,
     };
+}
+
+/**
+ * Resolves several mints at once. Matches what the UTL SDK's `fetchMints` did:
+ * the UTL list first, then on-chain Metaplex metadata for whatever is missing.
+ */
+export async function getTokenInfos(
+    addresses: PublicKey[],
+    cluster: Cluster,
+    genesisHash?: string,
+): Promise<TokenInfo[] | undefined> {
+    return fetchTokenInfosFromApi(
+        addresses.map(address => address.toBase58()),
+        cluster,
+        genesisHash,
+        true,
+    );
 }
 
 export function getCurrentTokenScaledUiAmountMultiplier(extensions: Array<TokenExtension> | undefined): string {

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -2,34 +2,34 @@
 
 | Type | Route | Size | First Load JS |
 |------|-------|------|---------------|
-| Static | `/` | 130 kB | 1.16 MB |
-| Static | `/_not-found` | 0 B | 1.04 MB |
-| Dynamic | `/address/[address]` | 400 kB | 1.42 MB |
-| Dynamic | `/address/[address]/anchor-account` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/anchor-program` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/attestation` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/attributes` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/blockhashes` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/compression` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/concurrent-merkle-tree` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/domains` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/entries` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/feature-gate` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/idl` | 510 kB | 1.53 MB |
-| Dynamic | `/address/[address]/instructions` | 380 kB | 1.40 MB |
-| Dynamic | `/address/[address]/metadata` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/nftoken-collection-nfts` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/program-multisig` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/rewards` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/security` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/slot-hashes` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/stake-history` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/subscriptions` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/token-extensions` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/tokens` | 380 kB | 1.40 MB |
-| Dynamic | `/address/[address]/transfers` | 380 kB | 1.40 MB |
-| Dynamic | `/address/[address]/verified-build` | 370 kB | 1.39 MB |
-| Dynamic | `/address/[address]/vote-history` | 370 kB | 1.39 MB |
+| Static | `/` | 130 kB | 530 kB |
+| Static | `/_not-found` | 0 B | 400 kB |
+| Dynamic | `/address/[address]` | 520 kB | 910 kB |
+| Dynamic | `/address/[address]/anchor-account` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/anchor-program` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/attestation` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/attributes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/blockhashes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/compression` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/concurrent-merkle-tree` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/domains` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/entries` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/feature-gate` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/idl` | 620 kB | 0.99 MB |
+| Dynamic | `/address/[address]/instructions` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/metadata` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/nftoken-collection-nfts` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/program-multisig` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/rewards` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/security` | 490 kB | 880 kB |
+| Dynamic | `/address/[address]/slot-hashes` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/stake-history` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/subscriptions` | 480 kB | 880 kB |
+| Dynamic | `/address/[address]/token-extensions` | 490 kB | 880 kB |
+| Dynamic | `/address/[address]/tokens` | 500 kB | 890 kB |
+| Dynamic | `/address/[address]/transfers` | 490 kB | 890 kB |
+| Dynamic | `/address/[address]/verified-build` | 490 kB | 880 kB |
+| Dynamic | `/address/[address]/vote-history` | 480 kB | 880 kB |
 | Dynamic | `/api/ans-domains/[address]` | — | — |
 | Dynamic | `/api/domain-info/[domain]` | — | — |
 | Dynamic | `/api/geo-location` | — | — |
@@ -47,17 +47,17 @@
 | Dynamic | `/api/verification/coingecko/[address]` | — | — |
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
-| Dynamic | `/block/[slot]` | 220 kB | 1.24 MB |
-| Dynamic | `/block/[slot]/accounts` | 210 kB | 1.24 MB |
-| Dynamic | `/block/[slot]/programs` | 210 kB | 1.24 MB |
-| Dynamic | `/block/[slot]/rewards` | 210 kB | 1.24 MB |
-| Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |
-| Static | `/feature-gates` | 50 kB | 1.08 MB |
+| Dynamic | `/block/[slot]` | 300 kB | 690 kB |
+| Dynamic | `/block/[slot]/accounts` | 290 kB | 690 kB |
+| Dynamic | `/block/[slot]/programs` | 290 kB | 690 kB |
+| Dynamic | `/block/[slot]/rewards` | 290 kB | 690 kB |
+| Dynamic | `/epoch/[epoch]` | 10 kB | 410 kB |
+| Static | `/feature-gates` | 50 kB | 440 kB |
 | Dynamic | `/mcp` | — | — |
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 390 kB |
-| Dynamic | `/tx/[signature]` | 700 kB | 1.05 MB |
-| Dynamic | `/tx/[signature]/inspect` | 490 kB | 880 kB |
-| Static | `/tx/inspector` | 490 kB | 880 kB |
+| Static | `/tos` | 880 B | 400 kB |
+| Dynamic | `/tx/[signature]` | 690 kB | 1.06 MB |
+| Dynamic | `/tx/[signature]/inspect` | 480 kB | 880 kB |
+| Static | `/tx/inspector` | 480 kB | 880 kB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -58,6 +58,6 @@
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
 | Static | `/tos` | 880 B | 400 kB |
-| Dynamic | `/tx/[signature]` | 690 kB | 1.06 MB |
+| Dynamic | `/tx/[signature]` | 690 kB | 1.05 MB |
 | Dynamic | `/tx/[signature]/inspect` | 480 kB | 880 kB |
 | Static | `/tx/inspector` | 480 kB | 880 kB |

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -57,7 +57,7 @@
 | Dynamic | `/og/feature-gate/[address]` | — | — |
 | Dynamic | `/og/receipt/[signature]` | — | — |
 | Static | `/opengraph-image.png` | — | — |
-| Static | `/tos` | 880 B | 1.04 MB |
-| Dynamic | `/tx/[signature]` | 450 kB | 1.47 MB |
-| Dynamic | `/tx/[signature]/inspect` | 360 kB | 1.38 MB |
-| Static | `/tx/inspector` | 360 kB | 1.38 MB |
+| Static | `/tos` | 880 B | 390 kB |
+| Dynamic | `/tx/[signature]` | 700 kB | 1.05 MB |
+| Dynamic | `/tx/[signature]/inspect` | 490 kB | 880 kB |
+| Static | `/tx/inspector` | 490 kB | 880 kB |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -404,9 +404,6 @@ export default tseslint.config(
         files: [
             // app/entities cross-entity / wrong-direction imports
             'app/entities/nft/lib/get-metadata-json.ts',
-            'app/entities/token-info/index.ts',
-            'app/entities/token-info/lib/fetch-token-mints.ts',
-            'app/entities/token-info/lib/is-valid-cluster.ts',
 
             // app/features cross-feature imports
             'app/features/idl/interactive-idl/model/use-mainnet-confirmation.ts',

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
         "@solana/wallet-adapter-react": "0.15.39",
         "@solana/wallet-adapter-react-ui": "0.9.39",
         "@solana/web3.js": "1.98.4",
-        "@solflare-wallet/utl-sdk": "1.4.0",
         "@sqds/multisig": "2.1.3",
         "@types/bn.js": "5.1.0",
         "bignumber.js": "9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,9 +253,6 @@ importers:
       '@solana/web3.js':
         specifier: 1.98.4
         version: 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solflare-wallet/utl-sdk':
-        specifier: 1.4.0
-        version: 1.4.0(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@sqds/multisig':
         specifier: 2.1.3
         version: 2.1.3(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
@@ -883,171 +880,6 @@ packages:
   '@asamuzakjp/css-color@3.1.1':
     resolution: {integrity: sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==}
 
-  '@aws-crypto/crc32@3.0.0':
-    resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
-
-  '@aws-crypto/crc32c@3.0.0':
-    resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
-
-  '@aws-crypto/ie11-detection@3.0.0':
-    resolution: {integrity: sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==}
-
-  '@aws-crypto/sha1-browser@3.0.0':
-    resolution: {integrity: sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==}
-
-  '@aws-crypto/sha256-browser@3.0.0':
-    resolution: {integrity: sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==}
-
-  '@aws-crypto/sha256-js@3.0.0':
-    resolution: {integrity: sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==}
-
-  '@aws-crypto/supports-web-crypto@3.0.0':
-    resolution: {integrity: sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==}
-
-  '@aws-crypto/util@3.0.0':
-    resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
-
-  '@aws-sdk/client-s3@3.377.0':
-    resolution: {integrity: sha512-sbZ3iJKhwMRVAK/AFVzUFcmojRhGvDfUDF1ouB/zLOCeGY0UekP/HnUNHmowYpFQsvHiEo0rQjmbbrGrlFPijw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/client-sso-oidc@3.370.0':
-    resolution: {integrity: sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/client-sso@3.370.0':
-    resolution: {integrity: sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/client-sts@3.377.0':
-    resolution: {integrity: sha512-K/yTHxVtTIwU42qCxbv78eT74j+GZMCcQ5TUd2fwxEWeq8HcIWcTIhujv7F6UtdrQHrou20wZ/+jMQtVKfkXXQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.370.0':
-    resolution: {integrity: sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.370.0':
-    resolution: {integrity: sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.370.0':
-    resolution: {integrity: sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.370.0':
-    resolution: {integrity: sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.370.0':
-    resolution: {integrity: sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.370.0':
-    resolution: {integrity: sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/hash-stream-node@3.374.0':
-    resolution: {integrity: sha512-Ta7YEFcgc+d4Rt7foV/fbgnXP8IgMAb+JVzZVYcHTwQf836+PdjGfKbamYkh8cM2xE47hzZqPe+BacCjePqH7g==}
-    engines: {node: '>=14.0.0'}
-    deprecated: This package has moved to @smithy/hash-stream-node
-
-  '@aws-sdk/middleware-bucket-endpoint@3.370.0':
-    resolution: {integrity: sha512-B36+fOeJVO0D9cjR92Ob6Ki2FTzyTQ/uKk8w+xtur6W6zYVOPU4IQNpNZvN3Ykt4jitR2uUnVSlBb3sXHHhdFA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-expect-continue@3.370.0':
-    resolution: {integrity: sha512-OlFIpXa53obLryHyrqedE2Cp8lp2k+1Vjd++hlZFDFJncRlWZMxoXSyl6shQPqhIiGnNW4vt7tG5xE4jg4NAvw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.374.0':
-    resolution: {integrity: sha512-NVXqMiYrEvpbAK0jTOy791dkJAz+JQkIX8lgl/BgnNXvXFDP2wOW5JT830LX27bMhs/yzt1nJSLvgnSCuhOKtg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-host-header@3.370.0':
-    resolution: {integrity: sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-location-constraint@3.370.0':
-    resolution: {integrity: sha512-NlDZEbBOF1IN7svUTcjbLodkUctt9zsfDI8+DqNlklRs5lsPb91WYvahOfjFO/EvACixa+a5d3cCumMCaIq4Cw==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-logger@3.370.0':
-    resolution: {integrity: sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.370.0':
-    resolution: {integrity: sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.370.0':
-    resolution: {integrity: sha512-DPYXtveWBDS5MzSHWTThg2KkLaOzZkCgPejjEuw3yl4ljsHawDs/ZIVCtmWXlBIS2lLCaBMpCV+t9psuJ/6/zQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-sdk-sts@3.370.0':
-    resolution: {integrity: sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-signing@3.370.0':
-    resolution: {integrity: sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-ssec@3.370.0':
-    resolution: {integrity: sha512-NIosfLS7mxCNdGYnuy76W9qP3f3YWVTusUA+uv+s6rnwG+Z2UheXCf1wpnJKzxORA8pioSP7ylZ8w2A0reCgYQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.370.0':
-    resolution: {integrity: sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.370.0':
-    resolution: {integrity: sha512-Q3NQopPDnHbJXMhtYl0Mfy5U2o76K6tzhdnYRcrYImY0ze/zOkCQI7KPC4588PuyvAXCdQ02cmCPPjYD55UeNg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@aws-sdk/signature-v4-crt': ^3.118.0
-    peerDependenciesMeta:
-      '@aws-sdk/signature-v4-crt':
-        optional: true
-
-  '@aws-sdk/token-providers@3.370.0':
-    resolution: {integrity: sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/types@3.370.0':
-    resolution: {integrity: sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-arn-parser@3.310.0':
-    resolution: {integrity: sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-endpoints@3.370.0':
-    resolution: {integrity: sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-locate-window@3.310.0':
-    resolution: {integrity: sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==}
-    engines: {node: '>=14.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.370.0':
-    resolution: {integrity: sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==}
-
-  '@aws-sdk/util-user-agent-node@3.370.0':
-    resolution: {integrity: sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/util-utf8-browser@3.259.0':
-    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
-
-  '@aws-sdk/xml-builder@3.310.0':
-    resolution: {integrity: sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==}
-    engines: {node: '>=14.0.0'}
-
   '@babel/code-frame@7.21.4':
     resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
@@ -1354,11 +1186,6 @@ packages:
   '@boundaries/elements@2.0.1':
     resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
     engines: {node: '>=18.18'}
-
-  '@bundlr-network/client@0.7.17':
-    resolution: {integrity: sha512-1qTDrwgmgeh0pO24JbeGt2W8GlpWYkVnQ8AhEZ02Lm00J7RALSyma3C5pNlKuvAQBczL1r9KhLr9KHK1og3J0g==}
-    deprecated: Bundlr is now Irys - please switch to @irys/sdk - this package will remain compatible with Irys for the foreseeable future.
-    hasBin: true
 
   '@clack/core@0.3.5':
     resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
@@ -2140,12 +1967,6 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
-  '@hapi/hoek@9.3.0':
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-
-  '@hapi/topo@5.1.0':
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
-
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -2600,47 +2421,14 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@metaplex-foundation/beet-solana@0.1.1':
-    resolution: {integrity: sha512-QV2DbxjaJWLkMvn12OC09g+r7a6R0uNwf8msYuOUSw4cG7amXzvFb7s0bh4IxY3Rk8/0ma0PfKi/FEdC7Hi4Pg==}
-
-  '@metaplex-foundation/beet-solana@0.3.1':
-    resolution: {integrity: sha512-tgyEl6dvtLln8XX81JyBvWjIiEcjTkUwZbrM5dIobTmoqMuGewSyk9CClno8qsMsFdB5T3jC91Rjeqmu/6xk2g==}
-
   '@metaplex-foundation/beet-solana@0.4.0':
     resolution: {integrity: sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==}
-
-  '@metaplex-foundation/beet@0.2.0':
-    resolution: {integrity: sha512-H570hkJxmx/FxET1OggPPLkPL7psYQa71rNI9NJjYRM8WXdrEvmI/IRIEUW2KR6RqwWWN3FvlRHnKoQUV/lQtA==}
-
-  '@metaplex-foundation/beet@0.4.0':
-    resolution: {integrity: sha512-2OAKJnLatCc3mBXNL0QmWVQKAWK2C7XDfepgL0p/9+8oSx4bmRAFHFqptl1A/C0U5O3dxGwKfmKluW161OVGcA==}
-
-  '@metaplex-foundation/beet@0.6.1':
-    resolution: {integrity: sha512-OYgnijLFzw0cdUlRKH5POp0unQECPOW9muJ2X3QIVyak5G6I6l/rKo72sICgPLIFKdmsi2jmnkuLY7wp14iXdw==}
 
   '@metaplex-foundation/beet@0.7.1':
     resolution: {integrity: sha512-hNCEnS2WyCiYyko82rwuISsBY3KYpe828ubsd2ckeqZr7tl0WVLivGkoyA/qdiaaHEBGdGl71OpfWa2rqL3DiA==}
 
   '@metaplex-foundation/cusper@0.0.2':
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
-
-  '@metaplex-foundation/js@0.11.7':
-    resolution: {integrity: sha512-zL3Ac++8lUOoKjjhDArdNSimvVYcOqg4uhxfBVRKLV6H8q6E/sOepXuzYSLXxzYWdvapYWEPKFdEDFluYzk7DA==}
-    engines: {node: ^14.0 || >=16.0}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@metaplex-foundation/mpl-auction-house@2.5.1':
-    resolution: {integrity: sha512-O+IAdYVaoOvgACB8pm+1lF5BNEjl0COkqny2Ho8KQZwka6aC/vHbZ239yRwAMtJhf5992BPFdT4oifjyE0O+Mw==}
-
-  '@metaplex-foundation/mpl-candy-machine@4.7.1':
-    resolution: {integrity: sha512-tBNRAfBE/rYy9pe2aJD4gTFw+pgQ11o3AJjoYGB4+05ow0VjJMSt6kQGzHm2LRPgdLY4diKAq8qHvgsbV5ikNQ==}
-
-  '@metaplex-foundation/mpl-core@0.6.1':
-    resolution: {integrity: sha512-6R4HkfAqU2EUakNbVLcCmka0YuQTLGTbHJ62ig765+NRWuB2HNGUQ1HfHcRsGnyxhlCvwKK79JE01XUjFE+dzw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
-  '@metaplex-foundation/mpl-token-metadata@2.13.0':
-    resolution: {integrity: sha512-Fl/8I0L9rv4bKTV/RAl5YIbJe9SnQPInKvLz+xR1fEc4/VQkuCn3RPgypfUMEKWmCznzaw4sApDxy6CFS4qmJw==}
 
   '@metaplex-foundation/mpl-token-metadata@3.4.0':
     resolution: {integrity: sha512-AxBAYCK73JWxY3g9//z/C9krkR0t1orXZDknUPS4+GjwGH2vgPfsk04yfZ31Htka2AdS9YE/3wH7sMUBHKn9Rg==}
@@ -2822,9 +2610,6 @@ packages:
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@noble/ed25519@1.7.3':
-    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
   '@noble/hashes@1.5.0':
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
@@ -4099,12 +3884,6 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@randlabs/communication-bridge@1.0.1':
-    resolution: {integrity: sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg==}
-
-  '@randlabs/myalgo-connect@1.4.2':
-    resolution: {integrity: sha512-K9hEyUi7G8tqOp7kWIALJLVbGCByhilcy6123WfcorxWwiE1sbQupPyIU5f3YdQK6wMjBsyTWiLW52ZBMp7sXA==}
-
   '@react-hook/debounce@4.0.0':
     resolution: {integrity: sha512-706Xcg+KKWHk9BuZQUQ0ZQKp9zhv3/MbqFenWVfHcynYpSGRVwQTzJRGvPxvsdtXxJv+HfgKTY/O/hEejakwmA==}
     peerDependencies:
@@ -4505,15 +4284,6 @@ packages:
     peerDependencies:
       webpack: '>=4.40.0'
 
-  '@sideway/address@4.1.4':
-    resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
-
-  '@sideway/formula@3.0.1':
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-
-  '@sideway/pinpoint@2.0.0':
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
-
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
@@ -4531,189 +4301,6 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
-
-  '@smithy/abort-controller@1.1.0':
-    resolution: {integrity: sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/chunked-blob-reader-native@1.1.0':
-    resolution: {integrity: sha512-RCJRL4+T54deVRYxuQT4lRsVPO60mqbfm7Mc5cyo9KeKsVpHTjtSKsMDP7ancRnzh9WLb6zeUJ/KWZ7K9Pvozw==}
-
-  '@smithy/chunked-blob-reader@1.1.0':
-    resolution: {integrity: sha512-yU3BNPaWxWqV5z64vJ2sanu0j9BPzD1bxVm8Ab9MZ9AZc2lZQgoYOlPgKrrG2adRXpXddxFGuoJGgmNL8bIvgw==}
-
-  '@smithy/config-resolver@1.1.0':
-    resolution: {integrity: sha512-7WD9eZHp46BxAjNGHJLmxhhyeiNWkBdVStd7SUJPUZqQGeIO/REtIrcIfKUfdiHTQ9jyu2SYoqvzqqaFc6987w==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/credential-provider-imds@1.1.0':
-    resolution: {integrity: sha512-kUMOdEu3RP6ozH0Ga8OeMP8gSkBsK1UqZZKyPLFnpZHrtZuHSSt7M7gsHYB/bYQBZAo3o7qrGmRty3BubYtYxQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/eventstream-codec@1.1.0':
-    resolution: {integrity: sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==}
-
-  '@smithy/eventstream-serde-browser@1.1.0':
-    resolution: {integrity: sha512-qUov6SYlcCeubwTQgaSBuNO0J31UdwgGRSZvmHhc3CCYOywoVSsA5vahcNuhoZDzZkhWTpol3Pm7+6OUuHF0aA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@1.1.0':
-    resolution: {integrity: sha512-vtPnp8FJkrNibWZCXvJN6rijTAEAzrmEKNfCUJOHAeBScY25hc6NjYlEJfdSmhW1qaA179oXeqHobcUNzvFkmw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/eventstream-serde-node@1.1.0':
-    resolution: {integrity: sha512-r8kUOPsJMolBGi/eU2gKfw5spfAhQjJXLe4bjjTzkapsqL654JZ+8G9iS1TprYUcCoCHDbwnH1of3kjrYKk7CQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/eventstream-serde-universal@1.1.0':
-    resolution: {integrity: sha512-8nQttgdbefJbLfz7Mao0FtkdRUlc92fCiHV3vClAl1N/qetm/I6Lsu5mLt9CzG7TGFkFb5t3qzAV2FaeAqF+ag==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/fetch-http-handler@1.1.0':
-    resolution: {integrity: sha512-N22C9R44u5WGlcY+Wuv8EXmCAq62wWwriRAuoczMEwAIjPbvHSthyPSLqI4S7kAST1j6niWg8kwpeJ3ReAv3xg==}
-
-  '@smithy/hash-blob-browser@1.1.0':
-    resolution: {integrity: sha512-9dt+piziVY0rZQanHav5ud2VgVHL4+RMnsT9QZolgNFZcj9io5fkK+G946gxx1gCslG+40UO0vIvoaE1OGlmNw==}
-
-  '@smithy/hash-node@1.1.0':
-    resolution: {integrity: sha512-yiNKDGMzrQjnpnbLfkYKo+HwIxmBAsv0AI++QIJwvhfkLpUTBylelkv6oo78/YqZZS6h+bGfl0gILJsKE2wAKQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/hash-stream-node@1.1.0':
-    resolution: {integrity: sha512-+kpru9xjxnNUvDBmbiRULWD3dV+YQLb1GtSE7rfG1WntkWUxB4mZ4VLW1qM38uMOS+LEQxGN/JP+ewfB16K4dQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/invalid-dependency@1.1.0':
-    resolution: {integrity: sha512-h2rXn68ClTwzPXYzEUNkz+0B/A0Hz8YdFNTiEwlxkwzkETGKMxmsrQGFXwYm3jd736R5vkXcClXz1ddKrsaBEQ==}
-
-  '@smithy/is-array-buffer@1.1.0':
-    resolution: {integrity: sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/md5-js@1.1.0':
-    resolution: {integrity: sha512-ftB+GrB/AgF+NlaoVMc3wlXZxsAcenrq2inrc6FfwM2tXUmU2Oc1W3qVW7rIDNqR6GmvXkAIxlnp6P2QkwlkNw==}
-
-  '@smithy/middleware-content-length@1.1.0':
-    resolution: {integrity: sha512-iNxwhZ7Xc5+LjeDElEOi/Nh8fFsc9Dw9+5w7h7/GLFIU0RgAwBJuJtcP1vNTOwzW4B3hG+gRu8sQLqA9OEaTwA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/middleware-endpoint@1.1.0':
-    resolution: {integrity: sha512-PvpazNjVpxX2ICrzoFYCpFnjB39DKCpZds8lRpAB3p6HGrx6QHBaNvOzVhJGBf0jcAbfCdc5/W0n9z8VWaSSww==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/middleware-retry@1.1.0':
-    resolution: {integrity: sha512-lINKYxIvT+W20YFOtHBKeGm7npuJg0/YCoShttU7fVpsmU+a2rdb9zrJn1MHqWfUL6DhTAWGa0tH2O7l4XrDcw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/middleware-serde@1.1.0':
-    resolution: {integrity: sha512-RiBMxhxuO9VTjHsjJvhzViyceoLhU6gtrnJGpAXY43wE49IstXIGEQz8MT50/hOq5EumX16FCpup0r5DVyfqNQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/middleware-stack@1.1.0':
-    resolution: {integrity: sha512-XynYiIvXNea2BbLcppvpNK0zu8o2woJqgnmxqYTn4FWagH/Hr2QIk8LOsUz7BIJ4tooFhmx8urHKCdlPbbPDCA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/node-config-provider@1.1.0':
-    resolution: {integrity: sha512-2G4TlzUnmTrUY26VKTonQqydwb+gtM/mcl+TqDP8CnWtJKVL8ElPpKgLGScP04bPIRY9x2/10lDdoaRXDqPuCw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/node-http-handler@1.1.0':
-    resolution: {integrity: sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/property-provider@1.2.0':
-    resolution: {integrity: sha512-qlJd9gT751i4T0t/hJAyNGfESfi08Fek8QiLcysoKPgR05qHhG0OYhlaCJHhpXy4ECW0lHyjvFM1smrCLIXVfw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/protocol-http@1.2.0':
-    resolution: {integrity: sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/querystring-builder@1.1.0':
-    resolution: {integrity: sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/querystring-parser@1.1.0':
-    resolution: {integrity: sha512-Lm/FZu2qW3XX+kZ4WPwr+7aAeHf1Lm84UjNkKyBu16XbmEV7ukfhXni2aIwS2rcVf8Yv5E7wchGGpOFldj9V4Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/service-error-classification@1.1.0':
-    resolution: {integrity: sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/shared-ini-file-loader@1.1.0':
-    resolution: {integrity: sha512-S/v33zvCWzFyGZGlsEF0XsZtNNR281UhR7byk3nRfsgw5lGpg51rK/zjMgulM+h6NSuXaFILaYrw1I1v4kMcuA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/signature-v4@1.1.0':
-    resolution: {integrity: sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/smithy-client@1.1.0':
-    resolution: {integrity: sha512-j32SGgVhv2G9nBTmel9u3OXux8KG20ssxuFakJrEeDug3kqbl1qrGzVLCe+Eib402UDtA0Sp1a4NZ2SEXDBxag==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/types@1.2.0':
-    resolution: {integrity: sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/url-parser@1.1.0':
-    resolution: {integrity: sha512-tpvi761kzboiLNGEWczuybMPCJh6WHB3cz9gWAG95mSyaKXmmX8ZcMxoV+irZfxDqLwZVJ22XTumu32S7Ow8aQ==}
-
-  '@smithy/util-base64@1.1.0':
-    resolution: {integrity: sha512-FpYmDmVbOXAxqvoVCwqehUN0zXS+lN8V7VS9O7I8MKeVHdSTsZzlwiMEvGoyTNOXWn8luF4CTDYgNHnZViR30g==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-body-length-browser@1.1.0':
-    resolution: {integrity: sha512-cep3ioRxzRZ2Jbp3Kly7gy6iNVefYXiT6ETt8W01RQr3uwi1YMkrbU1p3lMR4KhX/91Nrk6UOgX1RH+oIt48RQ==}
-
-  '@smithy/util-body-length-node@1.1.0':
-    resolution: {integrity: sha512-fRHRjkUuT5em4HZoshySXmB1n3HAU7IS232s+qU4TicexhyGJpXMK/2+c56ePOIa1FOK2tV1Q3J/7Mae35QVSw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-buffer-from@1.1.0':
-    resolution: {integrity: sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-config-provider@1.1.0':
-    resolution: {integrity: sha512-rQ47YpNmF6Is4I9GiE3T3+0xQ+r7RKRKbmHYyGSbyep/0cSf9kteKcI0ssJTvveJ1K4QvwrxXj1tEFp/G2UqxQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-defaults-mode-browser@1.1.0':
-    resolution: {integrity: sha512-0bWhs1e412bfC5gwPCMe8Zbz0J8UoZ/meEQdo6MYj8Ne+c+QZ+KxVjx0a1dFYOclvM33SslL9dP0odn8kfblkg==}
-    engines: {node: '>= 10.0.0'}
-
-  '@smithy/util-defaults-mode-node@1.1.0':
-    resolution: {integrity: sha512-440e25TUH2b+TeK5CwsjYFrI9ShVOgA31CoxCKiv4ncSK4ZM68XW5opYxQmzMbRWARGEMu2XEUeBmOgMU2RLsw==}
-    engines: {node: '>= 10.0.0'}
-
-  '@smithy/util-hex-encoding@1.1.0':
-    resolution: {integrity: sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-middleware@1.1.0':
-    resolution: {integrity: sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-retry@1.1.0':
-    resolution: {integrity: sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@smithy/util-stream@1.1.0':
-    resolution: {integrity: sha512-w3lsdGsntaLQIrwDWJkIFKrFscgZXwU/oxsse09aSTNv5TckPhDeYea3LhsDrU5MGAG3vprhVZAKr33S45coVA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-uri-escape@1.1.0':
-    resolution: {integrity: sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@1.1.0':
-    resolution: {integrity: sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-waiter@1.1.0':
-    resolution: {integrity: sha512-S6FNIB3UJT+5Efd/0DeziO5Rs82QAMODHW4v2V3oNRrwaBigY/7Yx3SiLudZuF9WpVsV08Ih3BjIH34nzZiinQ==}
-    engines: {node: '>=14.0.0'}
 
   '@solana-developers/helpers@2.8.1':
     resolution: {integrity: sha512-xvoOj+ewL18+h6fMrXp1vTss0WBLnhQHnBb6mMPfEQE32w0THlxm8OPXNUY8g4tREX7ugU5cDEP7c2teye1Z7A==}
@@ -5947,10 +5534,6 @@ packages:
     resolution: {integrity: sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==}
     engines: {node: '>= 10'}
 
-  '@solana/spl-token@0.2.0':
-    resolution: {integrity: sha512-RWcn31OXtdqIxmkzQfB2R+WpsJOVS6rKuvpxJFjvik2LyODd+WN58ZP3Rpjpro03fscGAkzlFuP3r42doRJgyQ==}
-    engines: {node: '>= 14'}
-
   '@solana/spl-token@0.3.8':
     resolution: {integrity: sha512-ogwGDcunP9Lkj+9CODOWMiVJEdRtqHAtX2rWF62KxnnSWtMZtV9rDhTrZFshiyJmxDnRL/1nKE1yJHg4jjs3gg==}
     engines: {node: '>=16'}
@@ -6175,11 +5758,6 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
-  '@solflare-wallet/utl-sdk@1.4.0':
-    resolution: {integrity: sha512-0E3s+fXs5XMGBNrXGB4XSH4+sPgLanbBEVyz227KJyxSIgiRdQMcM2Yv/KdnMHNmhYoR/aPpH6TH115SIJqM0A==}
-    peerDependencies:
-      '@solana/web3.js': '*'
-
   '@sqds/multisig@2.1.3':
     resolution: {integrity: sha512-WOiL7La+RSiJsz7jVO85yhSiiSvNMUthiWuLPeWVOoD6IYa34BEAzanF1RdXRWGglSbRFYCTkyr+Ay1WmXmSRQ==}
     engines: {node: '>=14'}
@@ -6286,10 +5864,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@supercharge/promise-pool@2.4.0':
-    resolution: {integrity: sha512-O9CMipBlq5OObdt1uKJGIzm9cdjpPWfj+a+Zw9EgWKxaMNHKC7EU7X9taj3H0EGQNLOSq2jAcOa3EzxlfHsD6w==}
-    engines: {node: '>=8'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -6449,9 +6023,6 @@ packages:
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
-
-  '@types/node@11.11.6':
-    resolution: {integrity: sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -6929,20 +6500,8 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  algo-msgpack-with-bigint@2.1.1:
-    resolution: {integrity: sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==}
-    engines: {node: '>= 10'}
-
-  algosdk@1.24.1:
-    resolution: {integrity: sha512-9moZxdqeJ6GdE4N6fA/GlUP4LrbLZMYcYkt141J4Ss68OfEgH9qW0wBuZ3ZOKEx/xjc5bg7mLP2Gjg7nwrkmww==}
-    engines: {node: '>=14.0.0'}
-
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
-
-  ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -6973,12 +6532,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  arbundles@0.6.22:
-    resolution: {integrity: sha512-QlSavBHk59mNqgQ6ScxlqaBJlDbSmSrK/uTcF3HojLAZ/4aufTkVTBjl1hSfZ/ZN45oIPgJC05R8SmVARF+8VA==}
-
-  arconnect@0.4.2:
-    resolution: {integrity: sha512-Jkpd4QL3TVqnd3U683gzXmZUVqBUy17DdJDuL/3D9rkysLgX6ymJ2e+sR+xyZF5Rh42CBqDXWNMmCjBXeP7Gbw==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -7058,23 +6611,11 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
-  arweave-stream-tx@1.2.2:
-    resolution: {integrity: sha512-bNt9rj0hbAEzoUZEF2s6WJbIz8nasZlZpxIw03Xm8fzb9gRiiZlZGW3lxQLjfc9Z0VRUWDzwtqoYeEoB/JDToQ==}
-    peerDependencies:
-      arweave: ^1.10.0
-
-  arweave@1.14.0:
-    resolution: {integrity: sha512-P2g9FjbJZQfk0Q3a5R2aCyPP3jen3ZN6Oxh6p6BlwEGHn5M5O0KvZSaiNV4X/PENgnZA4+afOf9MR3ySGcR3JQ==}
-    engines: {node: '>=16.15.0'}
-
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
-
-  asn1.js@5.4.1:
-    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
@@ -7095,9 +6636,6 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
-
-  async-retry@1.3.3:
-    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -7122,11 +6660,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  avsc@https://codeload.github.com/Irys-xyz/avsc/tar.gz/a730cc8018b79e114b6a3381bbb57760a24c6cef:
-    resolution: {tarball: https://codeload.github.com/Irys-xyz/avsc/tar.gz/a730cc8018b79e114b6a3381bbb57760a24c6cef}
-    version: 5.4.7
-    engines: {node: '>=0.11'}
-
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
@@ -7134,9 +6667,6 @@ packages:
   axe-core@4.12.0:
     resolution: {integrity: sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==}
     engines: {node: '>=4'}
-
-  axios@0.30.2:
-    resolution: {integrity: sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7196,10 +6726,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
-
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -7222,20 +6748,8 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
-  bip39-light@1.0.7:
-    resolution: {integrity: sha512-WDTmLRQUsiioBdTs9BmSEmkJza+8xfJmptsNJjxnoq3EydSa/ZBXT6rm66KoT3PJIRYMnhSKNR7S9YL1l7R40Q==}
-
-  bip39@3.0.2:
-    resolution: {integrity: sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==}
-
-  bluebird@3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-
   bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
-
-  bn.js@5.2.0:
-    resolution: {integrity: sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==}
 
   bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
@@ -7263,9 +6777,6 @@ packages:
         optional: true
       react:
         optional: true
-
-  bowser@2.11.0:
-    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -7406,9 +6917,6 @@ packages:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
     engines: {node: '>=10.0.0'}
 
-  capability@0.2.5:
-    resolution: {integrity: sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg==}
-
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -7447,9 +6955,6 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
-  chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
-
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -7460,10 +6965,6 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
-
-  check-more-types@2.24.0:
-    resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
-    engines: {node: '>= 0.8.0'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -7509,10 +7010,6 @@ packages:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
 
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -7520,10 +7017,6 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
-
-  cli-width@3.0.0:
-    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
-    engines: {node: '>= 10'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -7613,10 +7106,6 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -7738,19 +7227,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  csv-generate@4.2.6:
-    resolution: {integrity: sha512-VtnYqhWLcsUocA346ewFOk+rrqcoT663j11vXzD2uelXq9WguQ3QzDeVD8ISso7hhVtkDSHcWl9psdemeiEHDA==}
-
-  csv-parse@5.4.0:
-    resolution: {integrity: sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==}
-
-  csv-stringify@6.4.0:
-    resolution: {integrity: sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA==}
-
-  csv@6.3.1:
-    resolution: {integrity: sha512-ZTcWLvr0Ux0IQDz/QzhCToBVIZtF5GDrStMt9I8mRSk0jPnfF9OeYKz0EZTspaAEOK6hf515ag97nKmwoyU8ZA==}
-    engines: {node: '>= 0.1.90'}
-
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -7799,15 +7275,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -7882,10 +7349,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  depd@1.1.2:
-    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
-    engines: {node: '>= 0.6'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -7977,9 +7440,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  duplexer@0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
-
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -8027,9 +7487,6 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-
-  error-polyfill@0.1.3:
-    resolution: {integrity: sha512-XHJk60ufE+TG/ydwp4lilOog549iiQF2OAPhkk9DdiYWMrltz5yhDz/xnKuenNwP7gy3dsibssO5QpVhkrSzzg==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -8319,9 +7776,6 @@ packages:
   ethers@5.7.2:
     resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
 
-  event-stream@3.3.4:
-    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
-
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -8347,10 +7801,6 @@ packages:
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
-  execa@5.1.1:
-    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
-    engines: {node: '>=10'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -8358,9 +7808,6 @@ packages:
   expect@29.5.0:
     resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  exponential-backoff@3.1.1:
-    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -8377,10 +7824,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
-    engines: {node: '>=4'}
 
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
@@ -8428,10 +7871,6 @@ packages:
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@4.5.4:
-    resolution: {integrity: sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==}
-    hasBin: true
-
   fast-xml-parser@5.7.0:
     resolution: {integrity: sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==}
     hasBin: true
@@ -8464,10 +7903,6 @@ packages:
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
-  figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -8513,15 +7948,6 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
-  follow-redirects@1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -8535,10 +7961,6 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -8562,9 +7984,6 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-
-  from@0.1.7:
-    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -8624,10 +8043,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@6.0.1:
-    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
-    engines: {node: '>=10'}
 
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -8799,9 +8214,6 @@ packages:
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
 
-  hi-base32@0.5.1:
-    resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
-
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
@@ -8827,10 +8239,6 @@ packages:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
     engines: {node: '>=8.0.0'}
 
-  http-errors@1.8.1:
-    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
-    engines: {node: '>= 0.6'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -8854,19 +8262,11 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  human-signals@2.1.0:
-    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
-    engines: {node: '>=10.17.0'}
-
   humanize-duration-ts@2.1.1:
     resolution: {integrity: sha512-TibNF2/fkypjAfHdGpWL/dmWUS0G6Qi+3mKyiB6LDCowbMy+PtzbgPTnFMNTOVAJXDau01jYrJ3tFoz5AJSqhA==}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -8928,10 +8328,6 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
-
-  inquirer@8.2.5:
-    resolution: {integrity: sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==}
-    engines: {node: '>=12.0.0'}
 
   internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -9155,10 +8551,6 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -9347,9 +8739,6 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  joi@17.9.2:
-    resolution: {integrity: sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==}
-
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -9379,9 +8768,6 @@ packages:
 
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-
-  js-sha512@0.8.0:
-    resolution: {integrity: sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -9426,9 +8812,6 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -9478,10 +8861,6 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
-  keccak@3.0.3:
-    resolution: {integrity: sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==}
-    engines: {node: '>=10.0.0'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -9499,10 +8878,6 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
-
-  lazy-ass@1.6.0:
-    resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
-    engines: {node: '> 0.8'}
 
   leb@1.0.0:
     resolution: {integrity: sha512-Y3c3QZfvKWHX60BVOQPhLCvVGmDYWyJEiINE3drOog6KCyN2AOwvuQQzlS3uJg1J85kzpILXIUwRXULWavir+w==}
@@ -9617,9 +8992,6 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
@@ -9688,9 +9060,6 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
-
-  map-stream@0.1.0:
-    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -9949,15 +9318,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-
-  mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
-
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -10022,9 +9382,6 @@ packages:
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
-  ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -10046,16 +9403,6 @@ packages:
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
-  multistream@4.1.0:
-    resolution: {integrity: sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==}
-
-  mustache@4.2.0:
-    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
-    hasBin: true
-
-  mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -10074,15 +9421,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  near-api-js@0.44.2:
-    resolution: {integrity: sha512-eMnc4V+geggapEUa3nU2p8HSHn/njtloI4P2mceHQWO8vDE1NGpnAw8FuTBrLmXSgIv9m6oocgFc9t3VNf5zwg==}
-
-  near-hd-key@1.2.1:
-    resolution: {integrity: sha512-SIrthcL5Wc0sps+2e1xGj3zceEa68TgNZDLuCx0daxmfTP7sFTB3/mtE2pYhlFsCxWoMn+JfID5E1NlzvvbRJg==}
-
-  near-seed-phrase@0.2.0:
-    resolution: {integrity: sha512-NpmrnejpY1AdlRpDZ0schJQJtfBaoUheRfiYtQpcq9TkwPgqKZCRULV5L3hHmLc0ep7KRtikbPQ9R2ztN/3cyQ==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -10114,12 +9452,6 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
-  node-addon-api@2.0.2:
-    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
-
-  node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -10155,10 +9487,6 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
-  npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
-
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
 
@@ -10167,9 +9495,6 @@ packages:
 
   nwsapi@2.2.4:
     resolution: {integrity: sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==}
-
-  o3@1.0.3:
-    resolution: {integrity: sha512-f+4n+vC6s4ysy7YO7O2gslWZBUu8Qj2i2OUJOvjRxQva7jVjYjB29jrr9NCjmxZQR0gzrOcv1RnqoYOeMs5VRQ==}
 
   ob1@0.83.7:
     resolution: {integrity: sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==}
@@ -10244,10 +9569,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -10413,9 +9734,6 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  pause-stream@0.0.11:
-    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
   pbkdf2@3.1.3:
     resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
@@ -10683,11 +10001,6 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  ps-tree@1.2.0:
-    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
 
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -11006,17 +10319,9 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
 
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
@@ -11063,10 +10368,6 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
-
-  run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -11127,10 +10428,6 @@ packages:
 
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-
-  secp256k1@4.0.4:
-    resolution: {integrity: sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==}
-    engines: {node: '>=18.0.0'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -11313,9 +10610,6 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  split@0.3.3:
-    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
-
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -11336,11 +10630,6 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
-
-  start-server-and-test@1.15.4:
-    resolution: {integrity: sha512-ucQtp5+UCr0m4aHlY+aEV2JSYNTiMZKdSKK/bsIr6AlmwAWDYDnV7uGlWWEtWa7T4XvRI5cPYcPcQgeLqpz+Tg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -11377,14 +10666,8 @@ packages:
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
-  stream-combiner@0.0.4:
-    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
-
   stream-http@3.2.0:
     resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
-
-  stream-transform@3.2.6:
-    resolution: {integrity: sha512-/pyOvaCQFqYTmrFhmMbnAEVo3SsTx1H39eUVPOtYeAgbEUc+rDo7GoP8LbHJgU83mKtzJe/7Nq/ipaAnUOHgJQ==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -11452,10 +10735,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
-
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -11467,9 +10746,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -11683,13 +10959,6 @@ packages:
     resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
     hasBin: true
 
-  tmp-promise@3.0.3:
-    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
-
-  tmp@0.2.4:
-    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
-    engines: {node: '>=14.14'}
-
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -11825,10 +11094,6 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
-  type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
-
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -11883,9 +11148,6 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  u3@0.1.1:
-    resolution: {integrity: sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -12161,9 +11423,6 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
-  vlq@2.0.4:
-    resolution: {integrity: sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA==}
-
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
@@ -12174,11 +11433,6 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
-
-  wait-on@7.0.1:
-    resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -12499,458 +11753,6 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
-
-  '@aws-crypto/crc32@3.0.0':
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      tslib: 1.14.1
-
-  '@aws-crypto/crc32c@3.0.0':
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      tslib: 1.14.1
-
-  '@aws-crypto/ie11-detection@3.0.0':
-    dependencies:
-      tslib: 1.14.1
-
-  '@aws-crypto/sha1-browser@3.0.0':
-    dependencies:
-      '@aws-crypto/ie11-detection': 3.0.0
-      '@aws-crypto/supports-web-crypto': 3.0.0
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-locate-window': 3.310.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-
-  '@aws-crypto/sha256-browser@3.0.0':
-    dependencies:
-      '@aws-crypto/ie11-detection': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-crypto/supports-web-crypto': 3.0.0
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-locate-window': 3.310.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-
-  '@aws-crypto/sha256-js@3.0.0':
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      tslib: 1.14.1
-
-  '@aws-crypto/supports-web-crypto@3.0.0':
-    dependencies:
-      tslib: 1.14.1
-
-  '@aws-crypto/util@3.0.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-
-  '@aws-sdk/client-s3@3.377.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 3.0.0
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.377.0
-      '@aws-sdk/credential-provider-node': 3.370.0
-      '@aws-sdk/hash-stream-node': 3.374.0
-      '@aws-sdk/middleware-bucket-endpoint': 3.370.0
-      '@aws-sdk/middleware-expect-continue': 3.370.0
-      '@aws-sdk/middleware-flexible-checksums': 3.374.0
-      '@aws-sdk/middleware-host-header': 3.370.0
-      '@aws-sdk/middleware-location-constraint': 3.370.0
-      '@aws-sdk/middleware-logger': 3.370.0
-      '@aws-sdk/middleware-recursion-detection': 3.370.0
-      '@aws-sdk/middleware-sdk-s3': 3.370.0
-      '@aws-sdk/middleware-signing': 3.370.0
-      '@aws-sdk/middleware-ssec': 3.370.0
-      '@aws-sdk/middleware-user-agent': 3.370.0
-      '@aws-sdk/signature-v4-multi-region': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-endpoints': 3.370.0
-      '@aws-sdk/util-user-agent-browser': 3.370.0
-      '@aws-sdk/util-user-agent-node': 3.370.0
-      '@aws-sdk/xml-builder': 3.310.0
-      '@smithy/config-resolver': 1.1.0
-      '@smithy/eventstream-serde-browser': 1.1.0
-      '@smithy/eventstream-serde-config-resolver': 1.1.0
-      '@smithy/eventstream-serde-node': 1.1.0
-      '@smithy/fetch-http-handler': 1.1.0
-      '@smithy/hash-blob-browser': 1.1.0
-      '@smithy/hash-node': 1.1.0
-      '@smithy/invalid-dependency': 1.1.0
-      '@smithy/md5-js': 1.1.0
-      '@smithy/middleware-content-length': 1.1.0
-      '@smithy/middleware-endpoint': 1.1.0
-      '@smithy/middleware-retry': 1.1.0
-      '@smithy/middleware-serde': 1.1.0
-      '@smithy/middleware-stack': 1.1.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/node-http-handler': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/smithy-client': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      '@smithy/util-base64': 1.1.0
-      '@smithy/util-body-length-browser': 1.1.0
-      '@smithy/util-body-length-node': 1.1.0
-      '@smithy/util-defaults-mode-browser': 1.1.0
-      '@smithy/util-defaults-mode-node': 1.1.0
-      '@smithy/util-retry': 1.1.0
-      '@smithy/util-stream': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      '@smithy/util-waiter': 1.1.0
-      fast-xml-parser: 4.5.4
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - aws-crt
-
-  '@aws-sdk/client-sso-oidc@3.370.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/middleware-host-header': 3.370.0
-      '@aws-sdk/middleware-logger': 3.370.0
-      '@aws-sdk/middleware-recursion-detection': 3.370.0
-      '@aws-sdk/middleware-user-agent': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-endpoints': 3.370.0
-      '@aws-sdk/util-user-agent-browser': 3.370.0
-      '@aws-sdk/util-user-agent-node': 3.370.0
-      '@smithy/config-resolver': 1.1.0
-      '@smithy/fetch-http-handler': 1.1.0
-      '@smithy/hash-node': 1.1.0
-      '@smithy/invalid-dependency': 1.1.0
-      '@smithy/middleware-content-length': 1.1.0
-      '@smithy/middleware-endpoint': 1.1.0
-      '@smithy/middleware-retry': 1.1.0
-      '@smithy/middleware-serde': 1.1.0
-      '@smithy/middleware-stack': 1.1.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/node-http-handler': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/smithy-client': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      '@smithy/util-base64': 1.1.0
-      '@smithy/util-body-length-browser': 1.1.0
-      '@smithy/util-body-length-node': 1.1.0
-      '@smithy/util-defaults-mode-browser': 1.1.0
-      '@smithy/util-defaults-mode-node': 1.1.0
-      '@smithy/util-retry': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sso@3.370.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/middleware-host-header': 3.370.0
-      '@aws-sdk/middleware-logger': 3.370.0
-      '@aws-sdk/middleware-recursion-detection': 3.370.0
-      '@aws-sdk/middleware-user-agent': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-endpoints': 3.370.0
-      '@aws-sdk/util-user-agent-browser': 3.370.0
-      '@aws-sdk/util-user-agent-node': 3.370.0
-      '@smithy/config-resolver': 1.1.0
-      '@smithy/fetch-http-handler': 1.1.0
-      '@smithy/hash-node': 1.1.0
-      '@smithy/invalid-dependency': 1.1.0
-      '@smithy/middleware-content-length': 1.1.0
-      '@smithy/middleware-endpoint': 1.1.0
-      '@smithy/middleware-retry': 1.1.0
-      '@smithy/middleware-serde': 1.1.0
-      '@smithy/middleware-stack': 1.1.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/node-http-handler': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/smithy-client': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      '@smithy/util-base64': 1.1.0
-      '@smithy/util-body-length-browser': 1.1.0
-      '@smithy/util-body-length-node': 1.1.0
-      '@smithy/util-defaults-mode-browser': 1.1.0
-      '@smithy/util-defaults-mode-node': 1.1.0
-      '@smithy/util-retry': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/client-sts@3.377.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/credential-provider-node': 3.370.0
-      '@aws-sdk/middleware-host-header': 3.370.0
-      '@aws-sdk/middleware-logger': 3.370.0
-      '@aws-sdk/middleware-recursion-detection': 3.370.0
-      '@aws-sdk/middleware-sdk-sts': 3.370.0
-      '@aws-sdk/middleware-signing': 3.370.0
-      '@aws-sdk/middleware-user-agent': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-endpoints': 3.370.0
-      '@aws-sdk/util-user-agent-browser': 3.370.0
-      '@aws-sdk/util-user-agent-node': 3.370.0
-      '@smithy/config-resolver': 1.1.0
-      '@smithy/fetch-http-handler': 1.1.0
-      '@smithy/hash-node': 1.1.0
-      '@smithy/invalid-dependency': 1.1.0
-      '@smithy/middleware-content-length': 1.1.0
-      '@smithy/middleware-endpoint': 1.1.0
-      '@smithy/middleware-retry': 1.1.0
-      '@smithy/middleware-serde': 1.1.0
-      '@smithy/middleware-stack': 1.1.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/node-http-handler': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/smithy-client': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      '@smithy/util-base64': 1.1.0
-      '@smithy/util-body-length-browser': 1.1.0
-      '@smithy/util-body-length-node': 1.1.0
-      '@smithy/util-defaults-mode-browser': 1.1.0
-      '@smithy/util-defaults-mode-node': 1.1.0
-      '@smithy/util-retry': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      fast-xml-parser: 4.5.4
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-env@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.370.0':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.370.0
-      '@aws-sdk/credential-provider-process': 3.370.0
-      '@aws-sdk/credential-provider-sso': 3.370.0
-      '@aws-sdk/credential-provider-web-identity': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/credential-provider-imds': 1.1.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.370.0':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.370.0
-      '@aws-sdk/credential-provider-ini': 3.370.0
-      '@aws-sdk/credential-provider-process': 3.370.0
-      '@aws-sdk/credential-provider-sso': 3.370.0
-      '@aws-sdk/credential-provider-web-identity': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/credential-provider-imds': 1.1.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.370.0':
-    dependencies:
-      '@aws-sdk/client-sso': 3.370.0
-      '@aws-sdk/token-providers': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/hash-stream-node@3.374.0':
-    dependencies:
-      '@smithy/hash-stream-node': 1.1.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-bucket-endpoint@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-arn-parser': 3.310.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-config-provider': 1.1.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-expect-continue@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.374.0':
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-crypto/crc32c': 3.0.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/is-array-buffer': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-host-header@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-location-constraint@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-arn-parser': 3.310.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-sts@3.370.0':
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-signing@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/signature-v4': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-middleware': 1.1.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-ssec@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@aws-sdk/util-endpoints': 3.370.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/signature-v4': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.370.0':
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.370.0
-      '@aws-sdk/types': 3.370.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/types@3.370.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-arn-parser@3.310.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-locate-window@3.310.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/types': 1.2.0
-      bowser: 2.11.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.370.0':
-    dependencies:
-      '@aws-sdk/types': 3.370.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@aws-sdk/util-utf8-browser@3.259.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.310.0':
-    dependencies:
-      tslib: 2.8.1
 
   '@babel/code-frame@7.21.4':
     dependencies:
@@ -13357,34 +12159,6 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-
-  '@bundlr-network/client@0.7.17(bufferutil@4.0.7)(debug@4.4.3)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@supercharge/promise-pool': 2.4.0
-      algosdk: 1.24.1
-      arbundles: 0.6.22(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(debug@4.4.3)(utf-8-validate@5.0.10)
-      arweave: 1.14.0
-      async-retry: 1.3.3
-      axios: 0.30.2(debug@4.4.3)
-      base64url: 3.0.1
-      bignumber.js: 9.0.2
-      bs58: 4.0.1
-      commander: 8.3.0
-      csv: 6.3.1
-      ethers: 5.7.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-      inquirer: 8.2.5
-      js-sha256: 0.9.0
-      mime-types: 2.1.35
-      near-api-js: 0.44.2
-      near-seed-phrase: 0.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - typescript
-      - utf-8-validate
 
   '@clack/core@0.3.5':
     dependencies:
@@ -14244,12 +13018,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@hapi/hoek@9.3.0': {}
-
-  '@hapi/topo@5.1.0':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -14673,30 +13441,6 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@metaplex-foundation/beet-solana@0.1.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.7.1
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@metaplex-foundation/beet-solana@0.3.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.7.1
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      bs58: 5.0.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@metaplex-foundation/beet-solana@0.4.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@metaplex-foundation/beet': 0.7.1
@@ -14710,30 +13454,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@metaplex-foundation/beet@0.2.0':
-    dependencies:
-      ansicolors: 0.3.2
-      bn.js: 5.2.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@metaplex-foundation/beet@0.4.0':
-    dependencies:
-      ansicolors: 0.3.2
-      bn.js: 5.2.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@metaplex-foundation/beet@0.6.1':
-    dependencies:
-      ansicolors: 0.3.2
-      bn.js: 5.2.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@metaplex-foundation/beet@0.7.1':
     dependencies:
       ansicolors: 0.3.2
@@ -14743,92 +13463,6 @@ snapshots:
       - supports-color
 
   '@metaplex-foundation/cusper@0.0.2': {}
-
-  '@metaplex-foundation/js@0.11.7(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.377.0
-      '@bundlr-network/client': 0.7.17(bufferutil@4.0.7)(debug@4.4.3)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/beet': 0.2.0
-      '@metaplex-foundation/beet-solana': 0.1.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/mpl-auction-house': 2.5.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/mpl-candy-machine': 4.7.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/mpl-token-metadata': 2.13.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/spl-token': 0.2.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      abort-controller: 3.0.0
-      bignumber.js: 9.0.2
-      bn.js: 5.2.1
-      bs58: 5.0.0
-      buffer: 6.0.3
-      cross-fetch: 3.2.0
-      debug: 4.4.3
-      eventemitter3: 4.0.7
-      lodash.clonedeep: 4.5.0
-      mime: 3.0.0
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - aws-crt
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@metaplex-foundation/mpl-auction-house@2.5.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.6.1
-      '@metaplex-foundation/beet-solana': 0.3.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/cusper': 0.0.2
-      '@solana/spl-token': 0.3.8(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      bn.js: 5.2.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@metaplex-foundation/mpl-candy-machine@4.7.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.4.0
-      '@metaplex-foundation/beet-solana': 0.3.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/cusper': 0.0.2
-      '@metaplex-foundation/mpl-core': 0.6.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@metaplex-foundation/mpl-core@0.6.1(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      bs58: 4.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-
-  '@metaplex-foundation/mpl-token-metadata@2.13.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/beet': 0.7.1
-      '@metaplex-foundation/beet-solana': 0.4.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@metaplex-foundation/cusper': 0.0.2
-      '@solana/spl-token': 0.3.8(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      bn.js: 5.2.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   '@metaplex-foundation/mpl-token-metadata@3.4.0(@metaplex-foundation/umi@0.9.2)':
     dependencies:
@@ -15017,8 +13651,6 @@ snapshots:
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
-
-  '@noble/ed25519@1.7.3': {}
 
   '@noble/hashes@1.5.0': {}
 
@@ -16139,12 +14771,6 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@randlabs/communication-bridge@1.0.1': {}
-
-  '@randlabs/myalgo-connect@1.4.2':
-    dependencies:
-      '@randlabs/communication-bridge': 1.0.1
-
   '@react-hook/debounce@4.0.0(react@19.2.6)':
     dependencies:
       '@react-hook/latest': 1.0.3(react@19.2.6)
@@ -16548,14 +15174,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sideway/address@4.1.4':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-
-  '@sideway/formula@3.0.1': {}
-
-  '@sideway/pinpoint@2.0.0': {}
-
   '@sinclair/typebox@0.25.24': {}
 
   '@sinclair/typebox@0.27.10': {}
@@ -16575,289 +15193,6 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@smithy/abort-controller@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/chunked-blob-reader-native@1.1.0':
-    dependencies:
-      '@smithy/util-base64': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/chunked-blob-reader@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/config-resolver@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      '@smithy/util-config-provider': 1.1.0
-      '@smithy/util-middleware': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@1.1.0':
-    dependencies:
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@1.1.0':
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-hex-encoding': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@1.1.0':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@1.1.0':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@1.1.0':
-    dependencies:
-      '@smithy/eventstream-codec': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@1.1.0':
-    dependencies:
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/querystring-builder': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-base64': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/hash-blob-browser@1.1.0':
-    dependencies:
-      '@smithy/chunked-blob-reader': 1.1.0
-      '@smithy/chunked-blob-reader-native': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/hash-node@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      '@smithy/util-buffer-from': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/hash-stream-node@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/md5-js@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@1.1.0':
-    dependencies:
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@1.1.0':
-    dependencies:
-      '@smithy/middleware-serde': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/url-parser': 1.1.0
-      '@smithy/util-middleware': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@1.1.0':
-    dependencies:
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/service-error-classification': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-middleware': 1.1.0
-      '@smithy/util-retry': 1.1.0
-      tslib: 2.8.1
-      uuid: 9.0.0
-
-  '@smithy/middleware-serde@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@1.1.0':
-    dependencies:
-      '@smithy/property-provider': 1.2.0
-      '@smithy/shared-ini-file-loader': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@1.1.0':
-    dependencies:
-      '@smithy/abort-controller': 1.1.0
-      '@smithy/protocol-http': 1.2.0
-      '@smithy/querystring-builder': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/property-provider@1.2.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@1.2.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      '@smithy/util-uri-escape': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/service-error-classification@1.1.0': {}
-
-  '@smithy/shared-ini-file-loader@1.1.0':
-    dependencies:
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@1.1.0':
-    dependencies:
-      '@smithy/eventstream-codec': 1.1.0
-      '@smithy/is-array-buffer': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-hex-encoding': 1.1.0
-      '@smithy/util-middleware': 1.1.0
-      '@smithy/util-uri-escape': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@1.1.0':
-    dependencies:
-      '@smithy/middleware-stack': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-stream': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/types@1.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@1.1.0':
-    dependencies:
-      '@smithy/querystring-parser': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-base64@1.1.0':
-    dependencies:
-      '@smithy/util-buffer-from': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@1.1.0':
-    dependencies:
-      '@smithy/is-array-buffer': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@1.1.0':
-    dependencies:
-      '@smithy/property-provider': 1.2.0
-      '@smithy/types': 1.2.0
-      bowser: 2.11.0
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@1.1.0':
-    dependencies:
-      '@smithy/config-resolver': 1.1.0
-      '@smithy/credential-provider-imds': 1.1.0
-      '@smithy/node-config-provider': 1.1.0
-      '@smithy/property-provider': 1.2.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-retry@1.1.0':
-    dependencies:
-      '@smithy/service-error-classification': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/util-stream@1.1.0':
-    dependencies:
-      '@smithy/fetch-http-handler': 1.1.0
-      '@smithy/node-http-handler': 1.1.0
-      '@smithy/types': 1.2.0
-      '@smithy/util-base64': 1.1.0
-      '@smithy/util-buffer-from': 1.1.0
-      '@smithy/util-hex-encoding': 1.1.0
-      '@smithy/util-utf8': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@1.1.0':
-    dependencies:
-      '@smithy/util-buffer-from': 1.1.0
-      tslib: 2.8.1
-
-  '@smithy/util-waiter@1.1.0':
-    dependencies:
-      '@smithy/abort-controller': 1.1.0
-      '@smithy/types': 1.2.0
-      tslib: 2.8.1
 
   '@solana-developers/helpers@2.8.1(patch_hash=3404536e2e71cf96a8aa5675d9b2c17a94f209253305827d7d8dca7686d0c388)(bufferutil@4.0.7)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -18326,19 +16661,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/spl-token@0.2.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      start-server-and-test: 1.15.4
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@solana/spl-token@0.3.8(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
@@ -18772,23 +17094,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solflare-wallet/utl-sdk@1.4.0(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@metaplex-foundation/js': 0.11.7(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)
-      axios: 0.30.2
-      eventemitter3: 5.0.1
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - aws-crt
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@sqds/multisig@2.1.3(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@metaplex-foundation/beet': 0.7.1
@@ -18937,8 +17242,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  '@supercharge/promise-pool@2.4.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -19139,8 +17442,6 @@ snapshots:
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 22.15.3
-
-  '@types/node@11.11.6': {}
 
   '@types/node@12.20.55': {}
 
@@ -19762,28 +18063,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algo-msgpack-with-bigint@2.1.1: {}
-
-  algosdk@1.24.1:
-    dependencies:
-      algo-msgpack-with-bigint: 2.1.1
-      buffer: 6.0.3
-      cross-fetch: 3.2.0
-      hi-base32: 0.5.1
-      js-sha256: 0.9.0
-      js-sha3: 0.8.0
-      js-sha512: 0.8.0
-      json-bigint: 1.0.0
-      tweetnacl: 1.0.3
-      vlq: 2.0.4
-    transitivePeerDependencies:
-      - encoding
-
   anser@1.4.10: {}
-
-  ansi-escapes@4.3.2:
-    dependencies:
-      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -19805,35 +18085,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
-
-  arbundles@0.6.22(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))(bufferutil@4.0.7)(debug@4.4.3)(utf-8-validate@5.0.10):
-    dependencies:
-      '@noble/ed25519': 1.7.3
-      '@randlabs/myalgo-connect': 1.4.2
-      '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.0.7)(typescript@5.7.3)(utf-8-validate@5.0.10))
-      algosdk: 1.24.1
-      arweave: 1.14.0
-      arweave-stream-tx: 1.2.2(arweave@1.14.0)
-      avsc: https://codeload.github.com/Irys-xyz/avsc/tar.gz/a730cc8018b79e114b6a3381bbb57760a24c6cef
-      axios: 0.30.2(debug@4.4.3)
-      base64url: 3.0.1
-      bs58: 4.0.1
-      ethers: 5.7.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)
-      keccak: 3.0.3
-      multistream: 4.1.0
-      process: 0.11.10
-      secp256k1: 4.0.4
-      tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - '@solana/web3.js'
-      - bufferutil
-      - debug
-      - encoding
-      - utf-8-validate
-
-  arconnect@0.4.2:
-    dependencies:
-      arweave: 1.14.0
 
   arg@5.0.2: {}
 
@@ -19968,18 +18219,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  arweave-stream-tx@1.2.2(arweave@1.14.0):
-    dependencies:
-      arweave: 1.14.0
-      exponential-backoff: 3.1.1
-
-  arweave@1.14.0:
-    dependencies:
-      arconnect: 0.4.2
-      asn1.js: 5.4.1
-      base64-js: 1.5.1
-      bignumber.js: 9.0.2
-
   asap@2.0.6: {}
 
   asn1.js@4.10.1:
@@ -19987,13 +18226,6 @@ snapshots:
       bn.js: 4.12.0
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-
-  asn1.js@5.4.1:
-    dependencies:
-      bn.js: 4.12.0
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      safer-buffer: 2.1.2
 
   assert@2.1.0:
     dependencies:
@@ -20019,10 +18251,6 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
-  async-retry@1.3.3:
-    dependencies:
-      retry: 0.13.1
-
   asynckit@0.4.0: {}
 
   atob@2.1.2: {}
@@ -20043,35 +18271,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  avsc@https://codeload.github.com/Irys-xyz/avsc/tar.gz/a730cc8018b79e114b6a3381bbb57760a24c6cef: {}
-
   axe-core@4.10.3: {}
 
   axe-core@4.12.0: {}
-
-  axios@0.30.2:
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@0.30.2(debug@4.3.4):
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.3.4)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@0.30.2(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.15.6(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axobject-query@4.1.0: {}
 
@@ -20153,8 +18355,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  base64url@3.0.1: {}
-
   baseline-browser-mapping@2.10.20: {}
 
   bech32@1.1.4: {}
@@ -20171,23 +18371,7 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  bip39-light@1.0.7:
-    dependencies:
-      create-hash: 1.2.0
-      pbkdf2: 3.1.3
-
-  bip39@3.0.2:
-    dependencies:
-      '@types/node': 11.11.6
-      create-hash: 1.2.0
-      pbkdf2: 3.1.3
-      randombytes: 2.1.0
-
-  bluebird@3.7.2: {}
-
   bn.js@4.12.0: {}
-
-  bn.js@5.2.0: {}
 
   bn.js@5.2.1: {}
 
@@ -20222,8 +18406,6 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.53.0)
       react: 19.2.6
-
-  bowser@2.11.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -20401,8 +18583,6 @@ snapshots:
       svg-pathdata: 6.0.3
     optional: true
 
-  capability@0.2.5: {}
-
   ccount@2.0.1: {}
 
   chai@5.3.3:
@@ -20434,8 +18614,6 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chardet@0.7.0: {}
-
   chardet@2.1.1: {}
 
   chart.js@4.3.0:
@@ -20443,8 +18621,6 @@ snapshots:
       '@kurkle/color': 0.3.2
 
   check-error@2.1.1: {}
-
-  check-more-types@2.24.0: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -20503,17 +18679,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
-
-  cli-width@3.0.0: {}
 
   cli-width@4.1.0: {}
 
@@ -20600,8 +18770,6 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
-
-  commander@8.3.0: {}
 
   commondir@1.0.1: {}
 
@@ -20740,19 +18908,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  csv-generate@4.2.6: {}
-
-  csv-parse@5.4.0: {}
-
-  csv-stringify@6.4.0: {}
-
-  csv@6.3.1:
-    dependencies:
-      csv-generate: 4.2.6
-      csv-parse: 5.4.0
-      csv-stringify: 6.4.0
-      stream-transform: 3.2.6
-
   damerau-levenshtein@1.0.8: {}
 
   data-urls@3.0.2:
@@ -20811,10 +18966,6 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
-
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
 
   debug@4.4.3:
     dependencies:
@@ -20886,8 +19037,6 @@ snapshots:
   delay@5.0.0: {}
 
   delayed-stream@1.0.0: {}
-
-  depd@1.1.2: {}
 
   depd@2.0.0: {}
 
@@ -20967,8 +19116,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  duplexer@0.1.2: {}
-
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
@@ -21010,12 +19157,6 @@ snapshots:
       tapable: 2.3.3
 
   entities@4.5.0: {}
-
-  error-polyfill@0.1.3:
-    dependencies:
-      capability: 0.2.5
-      o3: 1.0.3
-      u3: 0.1.1
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -21646,16 +19787,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  event-stream@3.3.4:
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.1.0
-      pause-stream: 0.0.11
-      split: 0.3.3
-      stream-combiner: 0.0.4
-      through: 2.3.8
-
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -21675,18 +19806,6 @@ snapshots:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
 
-  execa@5.1.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 6.0.1
-      human-signals: 2.1.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
   expect-type@1.3.0: {}
 
   expect@29.5.0:
@@ -21696,8 +19815,6 @@ snapshots:
       jest-matcher-utils: 29.5.0
       jest-message-util: 29.5.0
       jest-util: 29.5.0
-
-  exponential-backoff@3.1.1: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -21740,12 +19857,6 @@ snapshots:
       - supports-color
 
   extend@3.0.2: {}
-
-  external-editor@3.1.0:
-    dependencies:
-      chardet: 0.7.0
-      iconv-lite: 0.4.24
-      tmp: 0.2.4
 
   eyes@0.1.8: {}
 
@@ -21803,10 +19914,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@4.5.4:
-    dependencies:
-      strnum: 1.1.2
-
   fast-xml-parser@5.7.0:
     dependencies:
       '@nodable/entities': 2.1.0
@@ -21835,10 +19942,6 @@ snapshots:
       picomatch: 4.0.4
 
   fflate@0.8.2: {}
-
-  figures@3.2.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -21898,14 +20001,6 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
-  follow-redirects@1.15.6(debug@4.3.4):
-    optionalDependencies:
-      debug: 4.3.4
-
-  follow-redirects@1.15.6(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -21927,14 +20022,6 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-
   format@0.2.2: {}
 
   forwarded-parse@2.1.2: {}
@@ -21946,8 +20033,6 @@ snapshots:
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
-
-  from@0.1.7: {}
 
   fs.realpath@1.0.0: {}
 
@@ -22006,8 +20091,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@6.0.1: {}
 
   get-symbol-description@1.0.2:
     dependencies:
@@ -22206,8 +20289,6 @@ snapshots:
     dependencies:
       hermes-estree: 0.35.0
 
-  hi-base32@0.5.1: {}
-
   hmac-drbg@1.0.1:
     dependencies:
       hash.js: 1.1.7
@@ -22233,14 +20314,6 @@ snapshots:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
     optional: true
-
-  http-errors@1.8.1:
-    dependencies:
-      depd: 1.1.2
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 1.5.0
-      toidentifier: 1.0.1
 
   http-errors@2.0.1:
     dependencies:
@@ -22281,17 +20354,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-signals@2.1.0: {}
-
   humanize-duration-ts@2.1.1: {}
 
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
-
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -22342,24 +20409,6 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.4: {}
-
-  inquirer@8.2.5:
-    dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-width: 3.0.0
-      external-editor: 3.1.0
-      figures: 3.2.0
-      lodash: 4.17.21
-      mute-stream: 0.0.8
-      ora: 8.2.0
-      run-async: 2.4.1
-      rxjs: 7.8.1
-      string-width: 4.2.3
-      strip-ansi: 7.1.0
-      through: 2.3.8
-      wrap-ansi: 7.0.0
 
   internal-slot@1.0.5:
     dependencies:
@@ -22571,8 +20620,6 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
-
-  is-stream@2.0.1: {}
 
   is-string@1.0.7:
     dependencies:
@@ -22848,14 +20895,6 @@ snapshots:
   jiti@2.4.2:
     optional: true
 
-  joi@17.9.2:
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.4
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
-
   jose@6.2.3: {}
 
   jotai@2.15.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.6):
@@ -22870,8 +20909,6 @@ snapshots:
   js-sha256@0.9.0: {}
 
   js-sha3@0.8.0: {}
-
-  js-sha512@0.8.0: {}
 
   js-tokens@10.0.0: {}
 
@@ -22955,10 +20992,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-bigint@1.0.0:
-    dependencies:
-      bignumber.js: 9.0.2
-
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -23009,12 +21042,6 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
-  keccak@3.0.3:
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.6.0
-      readable-stream: 3.6.2
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -23028,8 +21055,6 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.22
-
-  lazy-ass@1.6.0: {}
 
   leb@1.0.0: {}
 
@@ -23121,8 +21146,6 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
-  lodash.clonedeep@4.5.0: {}
-
   lodash.escaperegexp@4.1.2: {}
 
   lodash.isboolean@3.0.3: {}
@@ -23185,8 +21208,6 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
-
-  map-stream@0.1.0: {}
 
   markdown-table@3.0.4: {}
 
@@ -23775,10 +21796,6 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mime@3.0.0: {}
-
-  mimic-fn@2.1.0: {}
-
   mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
@@ -23825,8 +21842,6 @@ snapshots:
 
   ms@2.0.0: {}
 
-  ms@2.1.2: {}
-
   ms@2.1.3: {}
 
   msw-storybook-addon@2.0.7(msw@2.14.6(@types/node@22.15.3)(typescript@5.7.3)):
@@ -23861,15 +21876,6 @@ snapshots:
 
   multiformats@13.4.2: {}
 
-  multistream@4.1.0:
-    dependencies:
-      once: 1.4.0
-      readable-stream: 3.6.2
-
-  mustache@4.2.0: {}
-
-  mute-stream@0.0.8: {}
-
   mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
@@ -23883,35 +21889,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
-
-  near-api-js@0.44.2:
-    dependencies:
-      bn.js: 5.2.0
-      borsh: 0.7.0
-      bs58: 4.0.1
-      depd: 2.0.0
-      error-polyfill: 0.1.3
-      http-errors: 1.8.1
-      js-sha256: 0.9.0
-      mustache: 4.2.0
-      node-fetch: 2.7.0
-      text-encoding-utf-8: 1.0.2
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - encoding
-
-  near-hd-key@1.2.1:
-    dependencies:
-      bip39: 3.0.2
-      create-hmac: 1.1.7
-      tweetnacl: 1.0.3
-
-  near-seed-phrase@0.2.0:
-    dependencies:
-      bip39-light: 1.0.7
-      bs58: 4.0.1
-      near-hd-key: 1.2.1
-      tweetnacl: 1.0.3
 
   negotiator@1.0.0: {}
 
@@ -23949,15 +21926,12 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  node-addon-api@2.0.2: {}
-
-  node-addon-api@5.1.0: {}
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.6.0: {}
+  node-gyp-build@4.6.0:
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -23999,19 +21973,11 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  npm-run-path@4.0.1:
-    dependencies:
-      path-key: 3.1.1
-
   nullthrows@1.1.1: {}
 
   nwsapi@2.2.18: {}
 
   nwsapi@2.2.4: {}
-
-  o3@1.0.3:
-    dependencies:
-      capability: 0.2.5
 
   ob1@0.83.7:
     dependencies:
@@ -24101,10 +22067,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  onetime@5.1.2:
-    dependencies:
-      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -24326,10 +22288,6 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  pause-stream@0.0.11:
-    dependencies:
-      through: 2.3.8
-
   pbkdf2@3.1.3:
     dependencies:
       create-hash: 1.1.3
@@ -24513,10 +22471,6 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
-
-  ps-tree@1.2.0:
-    dependencies:
-      event-stream: 3.3.4
 
   psl@1.9.0: {}
 
@@ -24957,17 +22911,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
-
-  retry@0.13.1: {}
 
   rettime@0.11.11: {}
 
@@ -25048,8 +22995,6 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
-  run-async@2.4.1: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -25057,6 +23002,7 @@ snapshots:
   rxjs@7.8.1:
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   safe-array-concat@1.1.2:
     dependencies:
@@ -25130,12 +23076,6 @@ snapshots:
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
   scrypt-js@3.0.1: {}
-
-  secp256k1@4.0.4:
-    dependencies:
-      elliptic: 6.6.1
-      node-addon-api: 5.1.0
-      node-gyp-build: 4.6.0
 
   semver@6.3.1: {}
 
@@ -25383,10 +23323,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  split@0.3.3:
-    dependencies:
-      through: 2.3.8
-
   sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
@@ -25403,19 +23339,6 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
-
-  start-server-and-test@1.15.4:
-    dependencies:
-      arg: 5.0.2
-      bluebird: 3.7.2
-      check-more-types: 2.24.0
-      debug: 4.3.4
-      execa: 5.1.1
-      lazy-ass: 1.6.0
-      ps-tree: 1.2.0
-      wait-on: 7.0.1(debug@4.3.4)
-    transitivePeerDependencies:
-      - supports-color
 
   statuses@1.5.0: {}
 
@@ -25462,18 +23385,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  stream-combiner@0.0.4:
-    dependencies:
-      duplexer: 0.1.2
-
   stream-http@3.2.0:
     dependencies:
       builtin-status-codes: 3.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
       xtend: 4.0.2
-
-  stream-transform@3.2.6: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -25581,8 +23498,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-final-newline@2.0.0: {}
-
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
@@ -25590,8 +23505,6 @@ snapshots:
   strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
-
-  strnum@1.1.2: {}
 
   strnum@2.2.3: {}
 
@@ -25774,12 +23687,6 @@ snapshots:
     dependencies:
       tldts-core: 7.4.2
 
-  tmp-promise@3.0.3:
-    dependencies:
-      tmp: 0.2.4
-
-  tmp@0.2.4: {}
-
   tmpl@1.0.5: {}
 
   to-buffer@1.2.1:
@@ -25905,8 +23812,6 @@ snapshots:
 
   type-detect@4.0.8: {}
 
-  type-fest@0.21.3: {}
-
   type-fest@0.7.1: {}
 
   type-fest@5.7.0:
@@ -25992,8 +23897,6 @@ snapshots:
       - supports-color
 
   typescript@5.7.3: {}
-
-  u3@0.1.1: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -26262,8 +24165,6 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  vlq@2.0.4: {}
-
   vm-browserify@1.1.2: {}
 
   w3c-xmlserializer@4.0.0:
@@ -26273,16 +24174,6 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
-
-  wait-on@7.0.1(debug@4.3.4):
-    dependencies:
-      axios: 0.30.2(debug@4.3.4)
-      joi: 17.9.2
-      lodash: 4.17.21
-      minimist: 1.2.8
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - debug
 
   walker@1.0.8:
     dependencies:


### PR DESCRIPTION
## Description

`app/utils/token-info.ts` instantiated `@solflare-wallet/utl-sdk`'s `Client` in the browser. Under Next 16 + Turbopack that crashes: Next's unconditional `modularizeImports.lodash` rewrites `import { chain, chunk } from 'lodash'` in `utl-sdk/lib/esm/utils.js` into `import chain from 'lodash/chain'`, and `lodash/chain.js` never registers the lazy `.flatten()` / `.map()` methods on the wrapper prototype. The result was `chain(...).flatten is not a function` — an unhandled rejection on **every transaction with token movements**, so token symbols never loaded in `TokenBalancesCard`.

Both halves of the lookup now live behind `/api/token-info`, which accepts an array of addresses:

1. **UTL list** — the existing server-only `getTokenInfos` (`entities/token-info/api/fetch-token-mints.ts`).
2. **On-chain Metaplex fallback** — for mints the list does not carry, built on the Umi pipeline already in `entities/nft` (added in #911). It keeps the SDK's behaviour: `Fungible`-only token standard, `verified: false`, null-padding stripped from on-chain names, and the 5s per-mint `metaplexTimeout`.

The fallback is **opt-in** (`includeOnChainFallback`). The SDK's `fetchMints` included it, so batch callers get it; `getTokenInfoWithoutOnChainFallback` does not, keeping the contract each function already documented and avoiding new RPC cost on single-mint lookups.

The RPC endpoint is resolved server-side via `serverClusterUrl` rather than sent from the browser — a client-supplied URL would let a caller point the route at an arbitrary host.

### Why now

The SDK's last release was **2023-01-11** and it dragged `axios@0.27` plus the deprecated `@metaplex-foundation/js@0.11.7` (1.4 MB unminified) into the client bundle. Dropping it cuts **First Load JS by ~500–600 kB on every route** — see the regenerated `bench/BUILD.md` (e.g. `/address/[address]` 1.42 MB → 910 kB). No dependency changes landed between the previous `BUILD.md` baseline and `master`, so the delta is this branch.

### Also in here

- The SDK's `ChainId` and `Token` types are replaced by local equivalents, since removing the package takes its type exports with it.
- The two fetchers moved from `lib/` to the **`api/` segment** to match the convention used by `cluster`, `domain` and `idl`; `lib/` keeps only pure helpers.
- Three `boundaries/dependencies` allowlist entries are **retired** by routing `chain-id` access through a new `@x/token-info` public API instead of importing across entities directly.
- `getMetadataJson` stays browser-only, and it now checks `response.ok`. It passed every response to `processJson`, which only rejects a payload naming no artwork — so the proxy's `{ error }` body for a blocked or dead URI was handed back as an NFT's metadata. Its write-only `localStorage` cache is removed too: nothing ever read it, and it competed for the ~5 MB origin quota with `explorer:savedClusters`, whose writes are unguarded.
- **`ipfs://` metadata URIs resolve on the server path as well.** `fetchResource` speaks only http(s), so handing it a mint's raw on-chain `uri` cost every IPFS-hosted mint its logo. The gateway mapping `getProxiedUri` already did in the browser moved to **`app/shared/lib/ipfs.ts`** and is applied on both paths, rather than duplicated. An unparseable URI now short-circuits instead of failing inside `fetchResource`.
- The route validates its body with **superstruct**, as the other API routes here do, and so does the UTL response in `fetch-token-mints.ts`, which previously cast. Validation there is per token rather than per batch, so one malformed entry does not blank every symbol in a transaction. `decimals` and `logoURI` are `optional(nullable(…))`, not just `nullable`: UTL omits those keys outright for some tokens, and requiring them would drop the whole token — losing its name and symbol over a missing logo. `normalizeToken` puts back the `null` that `TokenInfo` declares. This matches `features/search/api/discover-with-utl.ts`, which reads the same API.
- The off-chain logo reads in the fallback run at **8 in flight** with a shared 10s per-batch deadline, instead of one socket per mint. Past the deadline the queued mints report `logoURI: null`, so names, symbols and decimals still arrive. The route carries `maxDuration = 30` as a platform backstop above that.

## Type of change

-   [x] Bug fix
-   [x] Other: removes an abandoned dependency and moves the lookup server-side

## Testing

Manual testing on the preview deployment. `PREVIEW` below is `https://explorer-git-fork-hoodieshq-refactor-r-f07d5c-solana-foundation.vercel.app`.

The on-chain fallback is reached from **one** surface: the transaction **Tokens** card. It is the only caller of `app/utils/token-info.ts#getTokenInfos`, which is where `includeOnChainFallback` is set. Every `<Address>`-based surface — a wallet's **Tokens** tab, token history, and a mint's *own* address page — resolves through `useTokenInfo` and the batched server action in `fetch-token-mints.ts`, which reads the UTL list only and does not opt in. Extending the fallback to those is follow-up work, not part of this PR.

-   [Transaction with an unlisted mint](https://explorer-git-fork-hoodieshq-refactor-r-f07d5c-solana-foundation.vercel.app/tx/3tRve9HV9xBthpQEKEM8ne4aRQWfhNoUXef33AQvCT69S4nHV7tB18mxrFzWe7W9T3iLy7JwLWjBvJTdhWM1wDhN) — the **Tokens** card should read `DECK` and `SOL`. `HWDHz1yh…afE7X` is absent from the UTL list, so its symbol comes from the new on-chain Metaplex read. Also covers de-duplication: 7 token-balance rows across only 2 distinct mints, so the request must collapse to 2 lookups.
-   [Wallet holding that unlisted mint](https://explorer-git-fork-hoodieshq-refactor-r-f07d5c-solana-foundation.vercel.app/address/94YQq71S3f8ERutz6JYw9XxJpgDRCBRbEs2JWXsyC4re/tokens) — **expected to be identical to production**: still the bare mint, with no symbol or logo. This surface goes through the batched server action, which does not opt into the fallback, so the link is a check that the transport change did not regress it rather than a place to look for a difference.
-   [Transaction with listed mints only](https://explorer-git-fork-hoodieshq-refactor-r-f07d5c-solana-foundation.vercel.app/tx/oeBBkD3HxhirfwesS7jg6CJFqZAHj2kBWLxWU672oC3V5DEFXBa7vkoqpcPfZUQPX9kBCL5sKHebkPTkfEz8DxP) — `USDC` / `SOL` from the UTL list, exercising the transport change without the fallback.
-   [A mint's own page](https://explorer-git-fork-hoodieshq-refactor-r-f07d5c-solana-foundation.vercel.app/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v) — **expected to be identical to production.** It resolves through `getTokenInfoWithoutOnChainFallback`, which deliberately does not opt in, so this page is a check that nothing regressed rather than a place to look for a difference.

### Checking the route directly

The clearest way to see the change is the route itself, against the same unlisted mint. Production has no array form and no fallback:

```
curl -s https://explorer.solana.com/api/token-info -X POST -H 'Content-Type: application/json' \
  -d '{"address":"HWDHz1yhoHMSUGwectxheAa7L1XLnwsBWTRd1cXafE7X","cluster":0}'
→ {}

curl -s https://explorer.solana.com/api/token-info -X POST -H 'Content-Type: application/json' \
  -d '{"addresses":["HWDHz1yhoHMSUGwectxheAa7L1XLnwsBWTRd1cXafE7X"],"cluster":0,"includeOnChainFallback":true}'
→ {"error":"Invalid request"}
```

On the preview the array form is accepted, and opting in resolves the mint on chain:

```
curl -s $PREVIEW/api/token-info -X POST -H 'Content-Type: application/json' \
  -d '{"addresses":["HWDHz1yhoHMSUGwectxheAa7L1XLnwsBWTRd1cXafE7X"],"cluster":0}'
→ {"content":[]}

curl -s $PREVIEW/api/token-info -X POST -H 'Content-Type: application/json' \
  -d '{"addresses":["HWDHz1yhoHMSUGwectxheAa7L1XLnwsBWTRd1cXafE7X"],"cluster":0,"includeOnChainFallback":true}'
→ {"content":[{"address":"HWDHz1yh…afE7X","decimals":6,"logoURI":"https://…/QmQhZNEPuG…",
               "name":"Chain Deck","symbol":"DECK","verified":false}]}
```

The `logoURI` confirms the off-chain JSON read works through the proxy's `fetchResource` in process, and `verified: false` marks data that did not come from a curated list.

## Related Issues

Closes [HOO-610](https://linear.app/solana-fndn/issue/HOO-610/remove-solflare-walletutl-sdk-from-client)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm format`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

Two behaviours differ from the old SDK on purpose:

- **Decimals of `0` are preserved.** `transformMetaplexToken` used `decimalsMap[mint] || 6`, turning a legitimate `0` into `6`.
- **No jsdelivr CDN fallback** when the UTL backend errors. The server-only `fetch-token-mints.ts` this reuses returns `[]` instead; the on-chain fallback now partly covers that case. Restoring the CDN path belongs in `fetch-token-mints.ts` as separate work.

The `Fungible`-only filter is carried over deliberately — it means unlisted legacy mints with no `tokenStandard` set are still skipped, exactly as before.

One pre-existing issue this brushes against but does not fix: `app/features/custom-cluster/lib/cluster-storage.ts` writes to `localStorage` unguarded, so a full quota throws. Removing the dead metadata cache makes that far less likely to trigger, but the fragility remains. Happy to open a follow-up.






