### PR TITLE
feat: buffer decode in pmp instructions

### DIFF
--- a/.storybook/__mocks__/MockAccountsProvider.tsx
+++ b/.storybook/__mocks__/MockAccountsProvider.tsx
@@ -47,6 +47,11 @@ const mockFetchers = {
 
 type MockAccountsProviderProps = {
     children: React.ReactNode;
+    /**
+     * Extra cache entries, merged over the built-in program accounts. Lets a story drive a component that reads
+     * an account by address without touching this shared fixture - see `withMockTransactions`.
+     */
+    accounts?: State['entries'];
 };
 
 /**
@@ -74,9 +79,14 @@ type MockAccountsProviderProps = {
  *
  * To add more mock accounts, add entries to the `mockState.entries` object.
  */
-export function MockAccountsProvider({ children }: MockAccountsProviderProps) {
+export function MockAccountsProvider({ accounts, children }: MockAccountsProviderProps) {
+    const state: State = React.useMemo(
+        () => (accounts ? { ...mockState, entries: { ...mockState.entries, ...accounts } } : mockState),
+        [accounts],
+    );
+
     return (
-        <StateContext.Provider value={mockState}>
+        <StateContext.Provider value={state}>
             <DispatchContext.Provider value={() => {}}>
                 <FetchersContext.Provider value={mockFetchers as any}>{children}</FetchersContext.Provider>
             </DispatchContext.Provider>

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -156,12 +156,13 @@ export const withStats: Decorator = Story => (
 /**
  * Wraps stories with ClusterProvider, MockTransactionsProvider, and MockAccountsProvider.
  * Replaces the production TransactionsProvider so consumers don't fire RPC calls.
- * Usage: `decorators: [withMockTransactions]`
+ * Seeds the accounts cache from `parameters.accounts` (built-in program accounts only when omitted).
+ * Usage: `decorators: [withMockTransactions]`, optionally `parameters: { accounts: {...} }`
  */
-export const withMockTransactions: Decorator = Story => (
+export const withMockTransactions: Decorator = (Story, context) => (
     <ClusterProvider>
         <MockTransactionsProvider>
-            <MockAccountsProvider>
+            <MockAccountsProvider accounts={context.parameters.accounts}>
                 <Story />
             </MockAccountsProvider>
         </MockTransactionsProvider>

--- a/app/components/inspector/InstructionsSection.tsx
+++ b/app/components/inspector/InstructionsSection.tsx
@@ -2,6 +2,7 @@ import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
 import { isParsedInstruction, toParsedTransaction, useInstructionParser } from '@entities/instruction-parser';
 import { AssociatedTokenDetailsCard } from '@features/decode-instruction-associated-token';
 import { LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
+import { isProgramMetadataInstruction } from '@features/decode-instruction-pmp/detection';
 import { IdlInstructionCard, useIdlInstructionDecode } from '@features/decode-instruction-with-idl';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { useCluster } from '@providers/cluster';
@@ -14,6 +15,7 @@ import {
     type VersionedMessage,
 } from '@solana/web3.js';
 import { getProgramName } from '@utils/tx';
+import dynamic from 'next/dynamic';
 import React, { useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -33,6 +35,14 @@ import { UnknownDetailsCard } from './UnknownDetailsCard';
 
 const INSPECTOR_RESULT = { err: null };
 const INSPECTOR_SIGNATURE = '';
+
+// The PMP card carries the generated client plus pako/yaml/smol-toml (~35 kB gzip), which only a transaction that
+// actually touches the program needs. `isProgramMetadataInstruction` comes from the light `/detection` entry so
+// the branch below can stay static.
+const PmpDetailsCard = dynamic(() => import('@features/decode-instruction-pmp').then(mod => mod.PmpDetailsCard), {
+    loading: () => <LoadingCard />,
+    ssr: false,
+});
 
 export function InstructionsSection({
     message,
@@ -124,6 +134,37 @@ function InspectorInstructionCard({
 
     // Dynamic IDL tier — shared with the tx page. See app/features/transaction/ui/InstructionsSection.tsx.
     const idlDecode = useIdlInstructionDecode({ programId: programId.toString(), raw: ix });
+
+    // PMP owns every instruction on its program id: `setData`/`initialize`/`write` render decoded content from
+    // the bundled typed decoders (no IDL needed), and the housekeeping instructions delegate to the IDL tier
+    // from inside the card. Must sit before the generic idlDecode tier so it wins for the content instructions.
+    if (isProgramMetadataInstruction(ix)) {
+        return (
+            <PmpDetailsCard
+                ix={ix}
+                index={index}
+                result={INSPECTOR_RESULT}
+                innerCards={innerCards}
+                InstructionCardComponent={BaseInstructionCard}
+                // The card cannot import the IDL feature (boundaries/dependencies), so this surface decides what
+                // a non-content PMP instruction falls back to. Same two outcomes as before the branch existed.
+                fallback={
+                    idlDecode ? (
+                        <IdlInstructionCard
+                            decoded={idlDecode}
+                            ix={ix}
+                            index={index}
+                            result={INSPECTOR_RESULT}
+                            signature={INSPECTOR_SIGNATURE}
+                        />
+                    ) : (
+                        <UnknownDetailsCard index={index} ix={ix} programName={programName} innerCards={innerCards} />
+                    )
+                }
+            />
+        );
+    }
+
     if (idlDecode) {
         return (
             <IdlInstructionCard

--- a/app/components/inspector/__tests__/InstructionsSection-Pmp.spec.tsx
+++ b/app/components/inspector/__tests__/InstructionsSection-Pmp.spec.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { gen } from '@__fixtures__/gen';
+import { PMP_ADDRESS } from '@features/decode-instruction-pmp';
+import { type MessageV0, PublicKey, TransactionInstruction, TransactionMessage } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { InstructionParserProvider } from '@/app/entities/instruction-parser';
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
+
+import { InstructionsSection } from '../InstructionsSection';
+
+// The IDL tiers (`useAnchorProgram`, `useProgramMetadataIdl`) read through SWR. Stub it to "no IDL" so the PMP
+// branch is exercised without a network-resolved IDL - which is exactly the case the p1 spec cares about.
+vi.mock('swr', () => ({
+    __esModule: true,
+    default: vi.fn(() => ({
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+    })),
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/'),
+    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('next/link', () => ({
+    __esModule: true,
+    default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+function renderMessage(message: MessageV0) {
+    return render(
+        <ScrollAnchorProvider>
+            <ClusterProvider>
+                <TransactionsProvider>
+                    <AccountsProvider>
+                        <InstructionParserProvider dispatcher={instructionParserDispatcher}>
+                            <InstructionsSection message={message} />
+                        </InstructionParserProvider>
+                    </AccountsProvider>
+                </TransactionsProvider>
+            </ClusterProvider>
+        </ScrollAnchorProvider>,
+    );
+}
+
+function buildMessage(data: Uint8Array): MessageV0 {
+    const ix = new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: [
+            { isSigner: false, isWritable: true, pubkey: gen.publicKey(2) },
+            { isSigner: false, isWritable: false, pubkey: gen.publicKey(3) },
+        ],
+        programId: new PublicKey(PMP_ADDRESS),
+    });
+    return new TransactionMessage({
+        instructions: [ix],
+        payerKey: gen.publicKey(0),
+        recentBlockhash: PublicKey.default.toBase58(),
+    }).compileToV0Message();
+}
+
+describe('Inspector InstructionsSection with a Program Metadata instruction', () => {
+    test('should decode and render an inline setData payload with no IDL resolved', async () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: new TextEncoder().encode('{"name":"company","version":"1.0.0"}'),
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        renderMessage(buildMessage(data));
+
+        expect(await screen.findByText(/ProgramMetadata: SetData/i)).toBeInTheDocument();
+
+        // The section opens on the Raw tab and Radix unmounts the inactive panel, so the decoded document is only
+        // in the DOM once the reader switches.
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('company');
+    });
+
+    test('should leave a housekeeping instruction to the existing tiers', async () => {
+        const data = getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array;
+
+        renderMessage(buildMessage(data));
+
+        expect(await screen.findAllByText(/Program Metadata Program/i)).not.toHaveLength(0);
+        expect(screen.queryByTestId('pmp-payload-section')).not.toBeInTheDocument();
+    });
+});

--- a/app/components/instruction/codama/CodamaInstructionBody.tsx
+++ b/app/components/instruction/codama/CodamaInstructionBody.tsx
@@ -22,12 +22,19 @@ export function CodamaInstructionBody({
     programName,
     accounts,
     namedAccounts,
+    accountNames,
     data,
 }: {
     programId: PublicKey;
     programName: string;
     accounts: readonly AccountLike[];
     namedAccounts?: Record<string, AccountMeta<string>>;
+    /**
+     * FINAL positional row labels, rendered verbatim, for callers with no Codama parse to read names from (the
+     * PMP card decodes IDL-free). Takes precedence over `namedAccounts`, whose camelCase keys still go through
+     * `camelToTitleCase`. Verbatim rather than title-cased so a caller can match Codama's own capitalisation.
+     */
+    accountNames?: readonly string[];
     data?: Record<string, unknown>;
 }) {
     // Codama emits `namedAccounts` in instruction-account order, so the Nth
@@ -35,7 +42,9 @@ export function CodamaInstructionBody({
     // name-by-address map: two accounts can share the same address (e.g.
     // MemoryWrite's payer and sourceAccount), which would collapse in a map and
     // mislabel one of the rows.
-    const namedAccountNames = namedAccounts ? Object.keys(namedAccounts) : [];
+    const namedAccountNames = namedAccounts ? Object.keys(namedAccounts) : undefined;
+    // `accountNames` arrives pre-formatted, `namedAccounts` keys do not, so the two differ only in formatting.
+    const names = accountNames ?? namedAccountNames?.map(camelToTitleCase);
 
     return (
         <>
@@ -56,10 +65,10 @@ export function CodamaInstructionBody({
                     <BaseTable.Row key={keyIndex} data-testid={`account-row-${keyIndex}`}>
                         <BaseTable.Cell>
                             <div className="mr-1.5 md:inline">
-                                {namedAccounts
-                                    ? keyIndex < namedAccountNames.length
-                                        ? camelToTitleCase(namedAccountNames[keyIndex])
-                                        : `Remaining Account #${keyIndex + 1 - namedAccountNames.length}`
+                                {names
+                                    ? keyIndex < names.length
+                                        ? names[keyIndex]
+                                        : `Remaining Account #${keyIndex + 1 - names.length}`
                                     : `Account #${keyIndex + 1}`}
                             </div>
                             {isWritableRole(role) && (

--- a/app/components/shared/RawDataField.tsx
+++ b/app/components/shared/RawDataField.tsx
@@ -27,9 +27,10 @@ export type RawDataFieldProps = {
     data: ByteArray | undefined;
     loading?: boolean;
     filename: string;
+    extraButton?: React.ReactNode;
 };
 
-export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
+export function RawDataField({ data, loading, filename, extraButton }: RawDataFieldProps) {
     const [tab, setTab] = useState<'hex' | 'base64'>('hex');
     const [expanded, setExpanded] = useState(false);
     const [copyState, copy] = useCopyToClipboard();
@@ -87,6 +88,7 @@ export function RawDataField({ data, loading, filename }: RawDataFieldProps) {
                     {data !== undefined && !loading && (
                         <span className="whitespace-nowrap text-xs text-outer-space-300">{data.length} bytes</span>
                     )}
+                    {Boolean(extraButton) && extraButton}
                     <Button
                         variant="outline"
                         size="sm"

--- a/app/features/decode-instruction-pmp/detection.ts
+++ b/app/features/decode-instruction-pmp/detection.ts
@@ -1,0 +1,10 @@
+/**
+ * The feature's LIGHT public entry point, for surfaces that only need to recognise a PMP instruction.
+ *
+ * Everything reachable from here is library-free, so importing it costs a string compare. `index.ts` re-exports
+ * the decode modules and the card, which pull the generated client (and with it pako, yaml and smol-toml), so a
+ * consumer that statically imported the guard from there would drag that whole stack into its first-load JS.
+ * Same split as `@explorer/decoder-serum/detection` next to `@features/instruction-program-serum`.
+ */
+export { isProgramMetadataInstruction } from './lib/is-program-metadata-instruction';
+export { PMP_ADDRESS } from './lib/program-address';

--- a/app/features/decode-instruction-pmp/index.ts
+++ b/app/features/decode-instruction-pmp/index.ts
@@ -1,0 +1,15 @@
+// The FULL surface, which pulls the generated client and pako. Consumers that only recognise a PMP instruction
+// must import from `./detection` instead, and reach the card through `dynamic(() => import(...))`, so this weight
+// stays out of the `/tx/*` first-load JS. See `detection.ts`.
+export { isProgramMetadataInstruction, PMP_ADDRESS } from './detection';
+export { decodePmpBufferAccount } from './lib/decode-pmp-buffer-account';
+export { decodePmpContentInstruction } from './lib/decode-pmp-instruction';
+export { decodePmpPayload } from './lib/decode-pmp-payload';
+export type {
+    PmpAccountContent,
+    PmpAccountSnapshot,
+    PmpContentInstruction,
+    PmpDecodeConfig,
+    PmpDecodedPayload,
+} from './lib/types';
+export { PmpDetailsCard } from './ui/PmpDetailsCard';

--- a/app/features/decode-instruction-pmp/lib/__tests__/analytics.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/analytics.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '@/app/shared/lib/analytics';
+
+import { pmpAnalytics } from '../analytics';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+describe('pmpAnalytics', () => {
+    beforeEach(() => {
+        vi.mocked(trackEvent).mockClear();
+    });
+
+    it('should emit pmp_data_tab_opened when the decoded tab is opened', () => {
+        pmpAnalytics.trackTabOpened({
+            dataSource: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            source: 'instruction',
+            tab: 'decoded',
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            source: 'instruction',
+            tab: 'decoded',
+        });
+    });
+
+    it('should emit pmp_data_tab_opened for a non-Direct data source', () => {
+        pmpAnalytics.trackTabOpened({
+            dataSource: 'url',
+            format: 'json',
+            instruction: 'initialize',
+            source: 'instruction',
+            tab: 'raw',
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'url',
+            format: 'json',
+            instruction: 'initialize',
+            source: 'instruction',
+            tab: 'raw',
+        });
+    });
+
+    it('should carry the account source when the tabs render fetched account content', () => {
+        pmpAnalytics.trackTabOpened({
+            dataSource: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            source: 'account',
+            tab: 'raw',
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', expect.objectContaining({ source: 'account' }));
+    });
+
+    it('should expose no decode-outcome event', () => {
+        // Pins the deliberate removal: whether a payload decodes is a property of the instruction's bytes, not of
+        // anything the reader did, so it is not tracked. Guards against the old event being reinstated by habit.
+        expect('trackDecodeCompleted' in pmpAnalytics).toBe(false);
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-buffer-account.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-buffer-account.spec.ts
@@ -1,0 +1,245 @@
+import { gen } from '@__fixtures__/gen';
+import type { Address } from '@solana/kit';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getBufferEncoder,
+    getMetadataEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { concat } from '@/app/shared/lib/bytes';
+import { Logger } from '@/app/shared/lib/logger';
+
+import { PMP_ADDRESS } from '../constants';
+import { decodePmpBufferAccount } from '../decode-pmp-buffer-account';
+import type { PmpDecodeConfig } from '../types';
+
+const PROGRAM = gen.address(1) as Address;
+const AUTHORITY = gen.address(2) as Address;
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+/** The same document as `DOC`, indented - a `Format.Json` payload is re-serialised before it reaches the card. */
+const DOC_PRETTY = '{\n  "name": "company",\n  "version": "1.0.0"\n}';
+
+/** The instruction's hints. A Buffer account is decoded with these, a Metadata account with its own. */
+const IX_CONFIG: PmpDecodeConfig = { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json };
+
+/** The library's own producer, so every body below is a byte-exact round trip of what the client puts on chain. */
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+/** Both encoders inject their own discriminator, so these fixtures carry the real 96-byte header. */
+function bufferAccount(body: Uint8Array): Uint8Array {
+    return getBufferEncoder().encode({
+        authority: AUTHORITY,
+        canonical: true,
+        data: body,
+        program: PROGRAM,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function metadataAccount({
+    body,
+    config = IX_CONFIG,
+    dataLength,
+}: {
+    body: Uint8Array;
+    config?: PmpDecodeConfig;
+    dataLength?: number;
+}): Uint8Array {
+    return getMetadataEncoder().encode({
+        authority: AUTHORITY,
+        canonical: true,
+        compression: config.compression,
+        data: body,
+        dataLength: dataLength ?? body.length,
+        dataSource: DataSource.Direct,
+        encoding: config.encoding,
+        format: config.format,
+        mutable: true,
+        program: PROGRAM,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function read(data: Uint8Array | undefined, overrides: { lamports?: number; owner?: string } = {}) {
+    return decodePmpBufferAccount({
+        account: { data, lamports: overrides.lamports ?? 1_000_000, owner: overrides.owner ?? PMP_ADDRESS },
+        config: IX_CONFIG,
+    });
+}
+
+describe('decodePmpBufferAccount', () => {
+    // The Logger is a global no-op mock (test-setup.specs.ts), so these read the calls the decode makes.
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should decode a Buffer account body with the instruction hints', () => {
+        const result = read(bufferAccount(pack(DOC, Compression.None)));
+
+        expect(result).toEqual({
+            account: 'buffer',
+            body: expect.any(Uint8Array),
+            config: IX_CONFIG,
+            kind: 'payload',
+            payload: expect.objectContaining({ kind: 'decoded', text: DOC_PRETTY }),
+        });
+    });
+
+    it('should decompress a Buffer account body when the instruction says it is compressed', () => {
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(pack(DOC, Compression.Zlib)), lamports: 1, owner: PMP_ADDRESS },
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+        });
+
+        expect(result.kind === 'payload' && result.payload).toMatchObject({ kind: 'decoded', text: DOC_PRETTY });
+    });
+
+    it('should decode a Metadata account with the account hints rather than the instruction hints', () => {
+        // The account is Zlib, the instruction claims None. Decoding with the instruction's hints would hand raw
+        // deflate bytes to the UTF-8 step, so a correct document proves the account's own header won.
+        const accountConfig = { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json };
+        const result = read(metadataAccount({ body: pack(DOC, Compression.Zlib), config: accountConfig }));
+
+        expect(result).toMatchObject({
+            account: 'metadata',
+            config: accountConfig,
+            kind: 'payload',
+            payload: { kind: 'decoded', text: DOC_PRETTY },
+        });
+    });
+
+    it('should ignore the slack an untrimmed extend leaves past dataLength', () => {
+        const body = pack(DOC, Compression.None);
+        // `data` is a remainder field, so an account grown by `extend` and never trimmed hands back the padding
+        // too. Only `dataLength` bytes are the payload.
+        const result = read(metadataAccount({ body: concat([body, new Uint8Array(512)]), dataLength: body.length }));
+
+        expect(result.kind === 'payload' && result.body).toEqual(body);
+        expect(result.kind === 'payload' && result.payload).toMatchObject({ kind: 'decoded', text: DOC_PRETTY });
+    });
+
+    it('should report absent for the closed-account shape the provider hands back', () => {
+        expect(read(new Uint8Array(0), { lamports: 0 })).toEqual({ kind: 'absent' });
+        expect(read(undefined, { lamports: 0 })).toEqual({ kind: 'absent' });
+    });
+
+    it('should report unreadable when the account is not owned by the Program Metadata Program', () => {
+        const result = read(bufferAccount(pack(DOC, Compression.None)), { owner: PROGRAM });
+
+        expect(result).toEqual({ kind: 'unreadable', reason: expect.stringContaining(PROGRAM) });
+    });
+
+    it('should report unreadable when the account is shorter than the header', () => {
+        expect(read(new Uint8Array(95))).toEqual({ kind: 'unreadable', reason: expect.stringContaining('96-byte') });
+    });
+
+    it('should not call a live account short when it was fetched without its data', () => {
+        // The provider caches by address across three fetch modes, and a `skip` fetch stores an account with no
+        // bytes. That is an absent FETCH, not an absent or short ACCOUNT, so it must not claim a length.
+        const result = read(undefined, { lamports: 2_000_000 });
+
+        expect(result).toEqual({ kind: 'unreadable', reason: expect.stringContaining('without its data') });
+        expect(result.kind === 'unreadable' && result.reason).not.toContain('96-byte');
+    });
+
+    it('should report unreadable for a discriminator that carries no payload', () => {
+        const empty = bufferAccount(pack(DOC, Compression.None));
+        empty[0] = 0; // AccountDiscriminator.Empty
+
+        expect(read(empty)).toEqual({ kind: 'unreadable', reason: expect.stringContaining('discriminator 0') });
+    });
+
+    it('should report unreadable when a Metadata header carries an out-of-range hint', () => {
+        const account = metadataAccount({ body: pack(DOC, Compression.None) });
+        account[83] = 9; // the `encoding` byte, past every variant the enum defines
+
+        expect(read(account)).toEqual({ kind: 'unreadable', reason: expect.any(String) });
+    });
+
+    it('should surface a body that does not decode as a payload failure, not an unreadable account', () => {
+        // The account itself parses fine - it is the CONTENT that is not the zlib stream the hints promise. That
+        // distinction is what the UI renders differently, so it must survive here.
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(new Uint8Array([1, 2, 3, 4])), lamports: 1, owner: PMP_ADDRESS },
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+        });
+
+        expect(result).toMatchObject({ kind: 'payload', payload: { kind: 'failed' } });
+    });
+
+    it('should not report an Empty discriminator, which is an ordinary allocated-but-unwritten account', () => {
+        const empty = bufferAccount(pack(DOC, Compression.None));
+        empty[0] = 0; // AccountDiscriminator.Empty
+
+        read(empty);
+
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should report a discriminator outside the enum to Sentry, since it means an unknown account layout', () => {
+        const unknown = bufferAccount(pack(DOC, Compression.None));
+        unknown[0] = 9; // past every variant AccountDiscriminator defines
+
+        expect(read(unknown)).toEqual({ kind: 'unreadable', reason: expect.stringContaining('discriminator 9') });
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('unknown PMP account discriminator'),
+            expect.objectContaining({ sentry: true, sentryExtras: expect.objectContaining({ discriminator: 9 }) }),
+        );
+    });
+
+    it('should report a decoder throw to Sentry with the original error as the cause', () => {
+        const account = metadataAccount({ body: pack(DOC, Compression.None) });
+        account[83] = 9; // the `encoding` byte, past every variant the enum defines
+
+        read(account);
+
+        // Only the PMP program writes these headers and it validates its own enums, so an out-of-range hint means
+        // the layout this slice decodes has drifted from the program's - that is ours, so it goes to Sentry.
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ cause: expect.any(Error) }),
+            expect.objectContaining({ sentry: true, sentryExtras: expect.objectContaining({ discriminator: 2 }) }),
+        );
+    });
+
+    it('should report a header-only Buffer account as an empty payload, not a blank document', () => {
+        // `allocate` leaves exactly this: 96 bytes of header, discriminator Buffer, no body yet. It clears the
+        // short-account guard, and the remainder decoder hands back zero bytes.
+        const account = bufferAccount(new Uint8Array(0));
+
+        expect(account).toHaveLength(96);
+        expect(read(account)).toMatchObject({ kind: 'payload', payload: { kind: 'empty' } });
+    });
+
+    it('should report a Metadata account whose dataLength is zero as an empty payload', () => {
+        const result = read(metadataAccount({ body: new Uint8Array(0) }));
+
+        expect(result).toMatchObject({ account: 'metadata', kind: 'payload', payload: { kind: 'empty' } });
+    });
+
+    it('should log nothing when an account decodes', () => {
+        read(bufferAccount(pack(DOC, Compression.None)));
+
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should report the payload oversized above the render cap without decoding it', () => {
+        const body = pack('a'.repeat(4096), Compression.None);
+        const result = decodePmpBufferAccount({
+            account: { data: bufferAccount(body), lamports: 1, owner: PMP_ADDRESS },
+            cap: 1024,
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.None },
+        });
+
+        expect(result).toMatchObject({ kind: 'payload', payload: { kind: 'oversized' } });
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-instruction.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-instruction.spec.ts
@@ -1,0 +1,239 @@
+import { gen } from '@__fixtures__/gen';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { PMP_ADDRESS } from '../constants';
+import { decodePmpContentInstruction } from '../decode-pmp-instruction';
+import { isProgramMetadataInstruction } from '../is-program-metadata-instruction';
+
+const PMP = new PublicKey(PMP_ADDRESS);
+const FOREIGN_BUFFER = gen.publicKey(1);
+const METADATA_PDA = gen.publicKey(2);
+// `Uint8Array.from` is load-bearing, not redundant: under jsdom `TextEncoder` returns a Uint8Array built with a
+// DIFFERENT realm's constructor, and Vitest's `toEqual` compares prototypes, so a bare `encode()` result never
+// deep-equals a same-realm Uint8Array ("Compared values have no visual difference"). Re-wrap to this realm.
+const DOC_BYTES = Uint8Array.from(new TextEncoder().encode('{"name":"company"}'));
+
+function makeIx(data: Uint8Array, accounts: PublicKey[] = []): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: accounts.map(pubkey => ({ isSigner: false, isWritable: false, pubkey })),
+        programId: PMP,
+    });
+}
+
+describe('isProgramMetadataInstruction', () => {
+    it('should accept an instruction targeting the PMP program', () => {
+        expect(isProgramMetadataInstruction(makeIx(new Uint8Array([3, 1, 0, 1])))).toBe(true);
+    });
+
+    it('should reject an instruction targeting another program', () => {
+        const ix = new TransactionInstruction({
+            data: Buffer.from([0]),
+            keys: [],
+            programId: PublicKey.default,
+        });
+
+        expect(isProgramMetadataInstruction(ix)).toBe(false);
+    });
+});
+
+describe('decodePmpContentInstruction', () => {
+    it('should decode a setData carrying an inline Direct payload', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.Zlib,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: DOC_BYTES,
+        });
+    });
+
+    it('should decode a 4-byte header-only setData without a dataSource and without throwing', () => {
+        // The generated decoder throws on this shape ("Codec [u8] cannot decode empty byte arrays") and the
+        // generated ENCODER cannot build it, so it has to be a literal. It is on-chain valid: the Rust CLI emits
+        // it to change `format` without touching the stored bytes.
+        const result = decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 0, 1]), [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            kind: 'setData',
+        });
+    });
+
+    it('should reject a header-only setData whose hint byte is out of range instead of casting it', () => {
+        // The header-only shape is the only path that reads hint bytes raw, so `PmpDecodeConfigStruct` is what
+        // stops an out-of-range byte reaching the card as a number no label map can resolve. `format = 7` here.
+        expect(
+            decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 0, 7]), [METADATA_PDA, PMP, PMP])),
+        ).toBeUndefined();
+    });
+
+    it('should reject a header-only setData whose encoding and compression bytes are out of range', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 9, 0, 1])))).toBeUndefined();
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 1, 9, 1])))).toBeUndefined();
+    });
+
+    it('should accept every in-range hint combination on the header-only shape', () => {
+        // Guards against the struct being too strict - e.g. listing the enum variants wrongly, or `Object.values`
+        // on a numeric enum admitting its reverse-mapping label strings.
+        for (const encoding of [0, 1, 2, 3]) {
+            for (const compression of [0, 1, 2]) {
+                for (const format of [0, 1, 2, 3]) {
+                    const result = decodePmpContentInstruction(
+                        makeIx(new Uint8Array([3, encoding, compression, format])),
+                    );
+                    expect(result).toEqual({ config: { compression, encoding, format }, kind: 'setData' });
+                }
+            }
+        }
+    });
+
+    it('should report the foreign buffer when setData carries no inline payload', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, FOREIGN_BUFFER]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            sourceBuffer: FOREIGN_BUFFER.toBase58(),
+        });
+    });
+
+    it('should not report a source buffer when account index 2 holds the program id', () => {
+        const data = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+        });
+    });
+
+    it('should decode an initialize carrying an inline payload with its seed', () => {
+        const data = getInitializeInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+            seed: 'idl',
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: METADATA_PDA.toBase58(),
+            payload: DOC_BYTES,
+            seed: 'idl',
+        });
+    });
+
+    it('should report the metadata account when initialize is the in-place shape', () => {
+        const data = getInitializeInstructionDataEncoder().encode({
+            compression: Compression.None,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+            seed: 'idl',
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA]));
+
+        expect(result).toEqual({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: METADATA_PDA.toBase58(),
+            seed: 'idl',
+        });
+    });
+
+    it('should decode a write carrying an inline chunk at its logical offset', () => {
+        const data = getWriteInstructionDataEncoder().encode({
+            data: new Uint8Array([1, 2, 3]),
+            offset: 7,
+        }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, PMP]));
+
+        expect(result).toEqual({ chunk: new Uint8Array([1, 2, 3]), kind: 'write', offset: 7 });
+    });
+
+    it('should report the source buffer for a write whose chunk is not in the transaction', () => {
+        const data = getWriteInstructionDataEncoder().encode({ offset: 7 }) as Uint8Array;
+
+        const result = decodePmpContentInstruction(makeIx(data, [METADATA_PDA, PMP, FOREIGN_BUFFER]));
+
+        expect(result).toEqual({ kind: 'write', offset: 7, sourceBuffer: FOREIGN_BUFFER.toBase58() });
+    });
+
+    it('should return undefined for a housekeeping instruction so the caller falls through to the IDL tier', () => {
+        const data = getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array;
+
+        expect(decodePmpContentInstruction(makeIx(data, [METADATA_PDA]))).toBeUndefined();
+    });
+
+    it('should return undefined for an unrecognised discriminator instead of throwing', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([99])))).toBeUndefined();
+    });
+
+    it('should return undefined for empty instruction data instead of throwing', () => {
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([])))).toBeUndefined();
+    });
+
+    it('should return undefined for a truncated setData instead of throwing', () => {
+        // Discriminator 3 with only one hint byte: identify succeeds, the typed decoder then fails.
+        expect(decodePmpContentInstruction(makeIx(new Uint8Array([3, 1])))).toBeUndefined();
+    });
+
+    it('should return undefined for a setData whose enum byte is out of range', () => {
+        const valid = getSetDataInstructionDataEncoder().encode({
+            compression: Compression.None,
+            data: DOC_BYTES,
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format: Format.Json,
+        }) as Uint8Array;
+        const corrupt = Uint8Array.from(valid);
+        corrupt[3] = 7; // the `format` byte
+
+        expect(decodePmpContentInstruction(makeIx(corrupt, [METADATA_PDA, PMP, PMP]))).toBeUndefined();
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-payload.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/decode-pmp-payload.spec.ts
@@ -1,0 +1,282 @@
+import { Compression, Encoding, Format, packDirectData } from '@solana-program/program-metadata';
+import { gzip } from 'pako';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+import { PMP_DECODE_BUDGET_BYTES, PMP_DECODED_RENDER_CAP_BYTES, PMP_MAX_UNPACKED_BYTES } from '../constants';
+import { decodePmpPayload } from '../decode-pmp-payload';
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+/** The same document as `DOC`, indented - a `Format.Json` payload is re-serialised before it reaches the card. */
+const DOC_PRETTY = '{\n  "name": "company",\n  "version": "1.0.0"\n}';
+
+// `packDirectData` is the library's own producer, so every fixture below is a byte-exact round trip of what the
+// canonical client puts on chain. Its `encoding` argument INTERPRETS the content string, so Utf8 is the only
+// realistic choice for a JSON document (with Base64 the content would have to be base64 text already).
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+describe('decodePmpPayload', () => {
+    // The Logger is a global no-op mock (test-setup.specs.ts), so these read the calls the decode makes.
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should decode an uncompressed UTF-8 JSON payload into a pretty-printed document', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack(DOC, Compression.None),
+        });
+
+        expect(result).toEqual({
+            bytes: expect.any(Uint8Array),
+            kind: 'decoded',
+            text: DOC_PRETTY,
+        });
+    });
+
+    it('should decompress a Zlib payload before decoding', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack(DOC, Compression.Zlib),
+        });
+
+        expect(result.kind === 'decoded' && result.text).toEqual(DOC_PRETTY);
+    });
+
+    it('should decompress a Gzip payload before decoding', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Yaml },
+            data: pack('name: company\n', Compression.Gzip),
+        });
+
+        expect(result.kind === 'decoded' && result.text).toEqual('name: company\n');
+    });
+
+    it('should render Encoding None as hex rather than as text', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+
+        expect(result.kind === 'decoded' && result.text).toEqual('deadbeef');
+    });
+
+    it('should report oversized with the full decompressed bytes when the payload exceeds the cap', () => {
+        const result = decodePmpPayload({
+            cap: 4,
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3, 4, 5, 6, 7]),
+        });
+
+        expect(result.kind).toBe('oversized');
+        expect(result.kind === 'oversized' && result.bytes.length).toBe(7);
+    });
+
+    it('should not report oversized when the payload is exactly at the cap', () => {
+        const result = decodePmpPayload({
+            cap: 4,
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        expect(result.kind).toBe('decoded');
+    });
+
+    it('should default a linear encoding to the shared render cap', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            data: new Uint8Array(PMP_DECODED_RENDER_CAP_BYTES + 1),
+        });
+
+        expect(result).toMatchObject({ budget: PMP_DECODED_RENDER_CAP_BYTES, kind: 'oversized' });
+    });
+
+    it('should hold Base58 to a budget well below the shared render cap', () => {
+        // `getBase58Decoder()` folds the payload into one BigInt and divides it down, so its cost grows with the
+        // SQUARE of the length: at the shared cap a base58 payload blocks the render for minutes. Anything past the
+        // base58 budget has to come back oversized rather than reaching `decodeData`.
+        const budget = PMP_DECODE_BUDGET_BYTES[Encoding.Base58];
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Base58, format: Format.None },
+            data: new Uint8Array(budget + 1),
+        });
+
+        // Fails if the two are ever collapsed back into one global cap.
+        expect(budget).toBeLessThan(PMP_DECODED_RENDER_CAP_BYTES);
+        expect(result).toMatchObject({ budget, kind: 'oversized' });
+    });
+
+    it('should still decode a Base58 payload that sits inside its budget', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Base58, format: Format.None },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        expect(result.kind).toBe('decoded');
+    });
+
+    it('should abandon a payload that expands past the unpack ceiling', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            data: gzip(new Uint8Array(2 * PMP_MAX_UNPACKED_BYTES)),
+        });
+
+        expect(result).toEqual({ kind: 'unpack-overflow', limit: PMP_MAX_UNPACKED_BYTES });
+    });
+
+    it('should not apply the unpack ceiling to an uncompressed payload', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.None },
+            data: new Uint8Array(PMP_MAX_UNPACKED_BYTES + 1),
+        });
+
+        expect(result).toMatchObject({ budget: PMP_DECODE_BUDGET_BYTES[Encoding.Utf8], kind: 'oversized' });
+    });
+
+    it('should unpack a payload that sits exactly at the unpack ceiling', () => {
+        const result = decodePmpPayload({
+            cap: 1024,
+            config: { compression: Compression.Gzip, encoding: Encoding.None, format: Format.None },
+            data: gzip(new Uint8Array(PMP_MAX_UNPACKED_BYTES)),
+        });
+
+        expect(result).toMatchObject({ kind: 'oversized' });
+        expect(result.kind === 'oversized' && result.bytes.length).toBe(PMP_MAX_UNPACKED_BYTES);
+    });
+
+    it('should report failed with a reason when the compressed stream is corrupt', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'incorrect header check' });
+    });
+
+    it('should report a truncated stream as incomplete rather than as an internal error', () => {
+        const truncated = gzip(new Uint8Array(300 * 1024));
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            data: truncated.subarray(0, Math.floor(truncated.length * 0.6)),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'the compressed stream is incomplete' });
+    });
+
+    it('should report a stream carrying nothing but a header as incomplete', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            data: gzip(new Uint8Array(64)).subarray(0, 10),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'the compressed stream is incomplete' });
+    });
+
+    it('should report failed rather than throwing when the compression value is out of range', () => {
+        const result = decodePmpPayload({
+            config: { compression: 99 as Compression, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3]),
+        });
+
+        expect(result.kind).toBe('failed');
+    });
+
+    it('should report failed rather than an empty document when the encoding value is out of range', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: 99 as Encoding, format: Format.None },
+            data: new Uint8Array([1, 2, 3]),
+        });
+
+        expect(result).toEqual({ kind: 'failed', reason: 'unsupported encoding (99)' });
+    });
+
+    it('should report a non-string decode result to Sentry, because only our own drift produces it', () => {
+        decodePmpPayload({
+            config: { compression: Compression.None, encoding: 99 as Encoding, format: Format.None },
+            data: new Uint8Array([1, 2, 3]),
+        });
+
+        // The encoding value has to ride in `sentryExtras`: plain context fields never leave the console, and the
+        // console is suppressed in the browser.
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('non-string'),
+            expect.objectContaining({ sentry: true, sentryExtras: expect.objectContaining({ encoding: 99 }) }),
+        );
+    });
+
+    it('should log a payload that fails its own hints without reporting it to Sentry', () => {
+        decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array([1, 2, 3, 4]),
+        });
+
+        // The unpack returns its failure rather than throwing it, so `reason` is what carries pako's message now.
+        expect(Logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ message: expect.stringContaining('failed to unpack') }),
+            expect.objectContaining({ reason: 'incorrect header check' }),
+        );
+        // Malformed chain data is not an incident, and the `Url`/`External` panels reach this state by design, so
+        // an event per render would be pure noise. Fails if `sentry: true` is ever added here.
+        expect(Logger.error).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ sentry: true }));
+    });
+
+    it('should log at debug when a Json payload does not parse as JSON', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack('not json', Compression.None),
+        });
+
+        // The text still renders verbatim, so this is a hint/content mismatch rather than a decode failure.
+        expect(result.kind === 'decoded' && result.text).toEqual('not json');
+        expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining('Format.Json'), expect.anything());
+        expect(Logger.error).not.toHaveBeenCalled();
+        expect(Logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should report zero bytes as empty rather than as a successful blank document', () => {
+        // Every encoding decodes nothing to the empty string, so without this state the card renders an empty
+        // `pre` styled exactly like a real document. Checked per encoding because each has its own decoder.
+        for (const encoding of [Encoding.None, Encoding.Utf8, Encoding.Base58, Encoding.Base64]) {
+            const result = decodePmpPayload({
+                config: { compression: Compression.None, encoding, format: Format.Json },
+                data: new Uint8Array(0),
+            });
+
+            expect(result).toEqual({ kind: 'empty' });
+        }
+    });
+
+    it('should report zero bytes as empty even when the hints declare a compression', () => {
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            data: new Uint8Array(0),
+        });
+
+        expect(result).toEqual({ kind: 'empty' });
+    });
+
+    it('should report a real stream that decompresses to nothing as empty', () => {
+        const packed = pack('', Compression.Gzip);
+        const result = decodePmpPayload({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            data: packed,
+        });
+
+        expect(packed.length).toBeGreaterThan(0);
+        expect(result).toEqual({ kind: 'empty' });
+    });
+
+    it('should log nothing at all when the payload decodes', () => {
+        decodePmpPayload({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            data: pack(DOC, Compression.Zlib),
+        });
+
+        expect(Logger.debug).not.toHaveBeenCalled();
+        expect(Logger.warn).not.toHaveBeenCalled();
+        expect(Logger.error).not.toHaveBeenCalled();
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/program-address.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/program-address.spec.ts
@@ -1,0 +1,13 @@
+import { PROGRAM_METADATA_PROGRAM_ADDRESS } from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { PMP_ADDRESS } from '../program-address';
+
+describe('PMP_ADDRESS', () => {
+    // The literal exists so the detection path does not import the generated client (see `program-address.ts`).
+    // This is what replaces the compile-time guarantee that re-export gave: importing the client is free here,
+    // because a spec never enters a route bundle.
+    it('should match the address the generated client decodes against', () => {
+        expect(PMP_ADDRESS).toBe(PROGRAM_METADATA_PROGRAM_ADDRESS);
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/__tests__/to-document-text.spec.ts
+++ b/app/features/decode-instruction-pmp/lib/__tests__/to-document-text.spec.ts
@@ -1,0 +1,36 @@
+import { Format } from '@solana-program/program-metadata';
+import { describe, expect, it } from 'vitest';
+
+import { toDocumentText } from '../decode-pmp-payload';
+
+describe('toDocumentText', () => {
+    it('should pretty-print a minified JSON document', () => {
+        expect(toDocumentText('{"name":"company","version":"1.0.0"}', Format.Json)).toBe(
+            '{\n  "name": "company",\n  "version": "1.0.0"\n}',
+        );
+    });
+
+    it('should pretty-print a JSON array document', () => {
+        expect(toDocumentText('[1,2]', Format.Json)).toBe('[\n  1,\n  2\n]');
+    });
+
+    it('should fall back to verbatim text when Format is Json but the text does not parse', () => {
+        expect(toDocumentText('{not json', Format.Json)).toBe('{not json');
+    });
+
+    it('should round-trip a Json payload that parses to a scalar', () => {
+        // A bare scalar has no structure to indent, so re-serialising it is a no-op rather than a special case.
+        expect(toDocumentText('42', Format.Json)).toBe('42');
+        expect(toDocumentText('null', Format.Json)).toBe('null');
+        expect(toDocumentText('"hello"', Format.Json)).toBe('"hello"');
+    });
+
+    it('should render Yaml and Toml verbatim without pulling in a parser', () => {
+        expect(toDocumentText('name: company\n', Format.Yaml)).toBe('name: company\n');
+        expect(toDocumentText('name = "company"', Format.Toml)).toBe('name = "company"');
+    });
+
+    it('should render Format None verbatim', () => {
+        expect(toDocumentText('deadbeef', Format.None)).toBe('deadbeef');
+    });
+});

--- a/app/features/decode-instruction-pmp/lib/analytics.ts
+++ b/app/features/decode-instruction-pmp/lib/analytics.ts
@@ -1,0 +1,38 @@
+import { type GA4EventName, trackEvent } from '@/app/shared/lib/analytics';
+
+/** Which panel of the Decoded Content section the reader switched to. */
+type PmpTab = 'decoded' | 'raw';
+
+/** Where the bytes in the section came from: the instruction itself, or the account it points at. */
+type PmpPayloadSource = 'account' | 'instruction';
+
+const PMP_TAB_OPENED = 'pmp_data_tab_opened';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile error if the name exceeds GA4's 40-char cap
+const _assertGA4Length: typeof PMP_TAB_OPENED extends GA4EventName<typeof PMP_TAB_OPENED> ? true : never = true;
+
+export const pmpAnalytics = {
+    /**
+     * Fires on a reader-initiated tab switch only. Radix's `onValueChange` does not fire for the tab that is
+     * selected on mount, so the default panel never produces an event and the counts stay comparable.
+     *
+     * `dataSource` is carried because the tabs now render for `Url` and `External` too, where the decoded panel
+     * shows the on-chain pointer rather than a document - without it those clicks are indistinguishable.
+     * `source` separates the two panels that share these tabs, which open on different default tabs.
+     */
+    trackTabOpened({
+        dataSource,
+        format,
+        instruction,
+        source,
+        tab,
+    }: {
+        dataSource: string;
+        format: string;
+        instruction: string;
+        source: PmpPayloadSource;
+        tab: PmpTab;
+    }): void {
+        trackEvent(PMP_TAB_OPENED, { data_source: dataSource, format, instruction, source, tab });
+    },
+};

--- a/app/features/decode-instruction-pmp/lib/constants.ts
+++ b/app/features/decode-instruction-pmp/lib/constants.ts
@@ -92,6 +92,18 @@ export const PMP_COMPRESSION_LABELS: Record<Compression, string> = {
     [Compression.Zlib]: 'Zlib',
 };
 
+/**
+ * Badge labels for the bytes a payload panel holds, naming the compression rather than inventing a verb per variant,
+ * so a Zlib payload reads as plainly as a Gzip one instead of as "zlibbed". `Compression.None` is excluded because
+ * there is no distinction to label then: the stored bytes and the unpacked bytes are the same bytes.
+ */
+export const PMP_COMPRESSED_BYTES_LABELS: Record<Exclude<Compression, Compression.None>, string> = {
+    [Compression.Gzip]: 'gzipped',
+    [Compression.Zlib]: 'zlib',
+};
+
+export const PMP_UNCOMPRESSED_BYTES_LABEL = 'uncompressed';
+
 export const PMP_FORMAT_LABELS: Record<Format, string> = {
     [Format.Json]: 'JSON',
     [Format.None]: 'None',

--- a/app/features/decode-instruction-pmp/lib/constants.ts
+++ b/app/features/decode-instruction-pmp/lib/constants.ts
@@ -1,0 +1,144 @@
+import { ACCOUNT_HEADER_LENGTH, Compression, DataSource, Encoding, Format } from '@solana-program/program-metadata';
+
+/**
+ * Re-exported for the decode modules alongside, which already pull the library. The definition lives in its own
+ * library-free module so the detection path can reach it without the client - see `program-address.ts`.
+ */
+export { PMP_ADDRESS } from './program-address';
+
+/**
+ * Program label for the card title and the Program row, matching what `CodamaInstructionCard` derives from the
+ * IDL for the six housekeeping instructions: the rootNode program name `programMetadata` with its first letter
+ * upper-cased. Deliberately NOT the registry name `PROGRAM_NAMES.PROGRAM_METADATA` ('Program Metadata Program'),
+ * so a transaction carrying both a `setData` and an `allocate` labels both cards identically.
+ */
+export const PMP_CODAMA_PROGRAM_NAME = 'ProgramMetadata';
+
+/**
+ * Render cap for decoded content, shared by the three encodings whose decode cost is linear. Above it the card
+ * renders a bounded raw view plus a download affordance instead of the full document. Measured on the
+ * DECOMPRESSED payload bytes, so an oversized payload is never handed to `decodeData` or `JSON.parse` at all.
+ */
+export const PMP_DECODED_RENDER_CAP_BYTES = 256 * 1024;
+
+/**
+ * Decode budget per encoding, because the four encodings do not cost the same per byte.
+ *
+ * `decodeData(bytes, Encoding.Base58)` resolves to `getBase58Decoder()`, which folds the whole payload into one
+ * BigInt and divides it down digit by digit, so it is QUADRATIC in the byte length. Measured against the installed
+ * `@solana/codecs-strings`:
+ *
+ *      4 KB ->   26 ms       16 KB ->  427 ms       64 KB -> 7065 ms
+ *      8 KB ->  101 ms       32 KB -> 1746 ms
+ *
+ * At the shared render cap that is minutes of blocked main thread, and the decode runs synchronously inside a
+ * render memo, so nothing can paint while it runs. 16 KB is a deliberate pick: about 430 ms worst case, a visible
+ * stall rather than a freeze. Do NOT raise it casually - the cost grows with the SQUARE of the budget, so doubling
+ * it quadruples the stall.
+ *
+ * A `Record` keyed by the library enum rather than a lookup with a default, so a new variant breaks the build here
+ * instead of silently inheriting a budget that was never measured for it.
+ */
+export const PMP_DECODE_BUDGET_BYTES: Record<Encoding, number> = {
+    [Encoding.Base58]: 16 * 1024,
+    [Encoding.Base64]: PMP_DECODED_RENDER_CAP_BYTES,
+    [Encoding.None]: PMP_DECODED_RENDER_CAP_BYTES,
+    [Encoding.Utf8]: PMP_DECODED_RENDER_CAP_BYTES,
+};
+
+/**
+ * Ceiling on the DECOMPRESSED output, enforced DURING the unpack rather than after it: `inflateBounded` stops the
+ * stream as soon as the running total passes this, so peak allocation is this plus one 64 KB pako chunk. Applies
+ * only to a COMPRESSED payload - `Compression.None` unpacks nothing, so there is nothing to bound on that path.
+ *
+ * Deliberately above every per-encoding budget, so a payload between its budget and this limit still reaches
+ * `oversized`, which carries the decompressed bytes for copy and download. Only past this are there no bytes.
+ */
+export const PMP_MAX_UNPACKED_BYTES = 1024 * 1024;
+
+/** Download base names. `DownloadDropdown` appends `_<encoding>.txt`, so no extension belongs here. */
+export const PMP_RAW_DOWNLOAD_FILENAME = 'pmp-payload-raw';
+export const PMP_DECODED_DOWNLOAD_FILENAME = 'pmp-payload-decoded';
+export const PMP_WRITE_CHUNK_DOWNLOAD_FILENAME = 'pmp-write-chunk';
+export const PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME = 'pmp-account-raw';
+
+/**
+ * Both PMP account layouts put the payload body at byte 96, so anything shorter cannot carry one.
+ *
+ * Buffer:   disc [0,1) program [1,33) authority [33,65) canonical [65,66) seed [66,82) padding [82,96)
+ * Metadata: disc [0,1) program [1,33) authority [33,65) mutable [65,66) canonical [66,67) seed [67,83)
+ *           encoding [83,84) compression [84,85) format [85,86) dataSource [86,87) dataLength [87,91) padding [91,96)
+ */
+export const PMP_ACCOUNT_HEADER_LEN: number = ACCOUNT_HEADER_LENGTH;
+
+/** setData carries `dataSource` as an optional trailing byte, so 4 bytes is the header-only hint-update shape. */
+export const HEADER_ONLY_SET_DATA_LEN = 4;
+
+/** setData's optional `buffer` and write's optional `sourceBuffer` both sit at account index 2. */
+export const PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX = 2;
+
+// Explicit label maps rather than the numeric enums' reverse mapping: a new library variant then breaks the
+// build here instead of rendering `undefined` in the card.
+export const PMP_ENCODING_LABELS: Record<Encoding, string> = {
+    [Encoding.Base58]: 'Base58',
+    [Encoding.Base64]: 'Base64',
+    [Encoding.None]: 'None (hex)',
+    [Encoding.Utf8]: 'UTF-8',
+};
+
+export const PMP_COMPRESSION_LABELS: Record<Compression, string> = {
+    [Compression.Gzip]: 'Gzip',
+    [Compression.None]: 'None',
+    [Compression.Zlib]: 'Zlib',
+};
+
+export const PMP_FORMAT_LABELS: Record<Format, string> = {
+    [Format.Json]: 'JSON',
+    [Format.None]: 'None',
+    [Format.Toml]: 'TOML',
+    [Format.Yaml]: 'YAML',
+};
+
+export const PMP_DATA_SOURCE_LABELS: Record<DataSource, string> = {
+    [DataSource.Direct]: 'Direct',
+    [DataSource.External]: 'External',
+    [DataSource.Url]: 'Url',
+};
+
+/** Lowercase GA param values, so the event vocabulary stays stable if the display labels change. */
+export const PMP_FORMAT_ANALYTICS_NAMES: Record<Format, string> = {
+    [Format.Json]: 'json',
+    [Format.None]: 'none',
+    [Format.Toml]: 'toml',
+    [Format.Yaml]: 'yaml',
+};
+
+export const PMP_DATA_SOURCE_ANALYTICS_NAMES: Record<DataSource, string> = {
+    [DataSource.Direct]: 'direct',
+    [DataSource.External]: 'external',
+    [DataSource.Url]: 'url',
+};
+
+export const PMP_ANALYTICS_IX_NAMES = {
+    initialize: 'initialize',
+    setData: 'set_data',
+} as const;
+
+/**
+ * Instruction account order, verified against the generated client's `getXInstruction` builders.
+ * These are FINAL row labels, rendered verbatim. They carry Codama's own capitalisation (first letter upper,
+ * no word split) so a `setData` card labels its accounts exactly like the `allocate` card next to it, which
+ * `CodamaInstructionCard` builds with `charAt(0).toUpperCase() + slice(1)`.
+ */
+export const PMP_ACCOUNT_NAMES = {
+    initialize: ['Metadata', 'Authority', 'Program', 'ProgramData', 'System'],
+    setData: ['Metadata', 'Authority', 'Buffer', 'Program', 'ProgramData'],
+    write: ['Buffer', 'Authority', 'SourceBuffer'],
+} as const;
+
+/** Instruction labels in Codama's style (the IDL name with its first letter upper-cased), for the same reason. */
+export const PMP_IX_TITLES = {
+    initialize: 'Initialize',
+    setData: 'SetData',
+    write: 'Write',
+} as const;

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-buffer-account.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-buffer-account.ts
@@ -1,0 +1,122 @@
+import type { ReadonlyUint8Array } from '@solana/kit';
+import { AccountDiscriminator, getBufferDecoder, getMetadataDecoder } from '@solana-program/program-metadata';
+
+import { bytes } from '@/app/shared/lib/bytes';
+import { Logger } from '@/app/shared/lib/logger';
+
+import { PMP_ACCOUNT_HEADER_LEN, PMP_ADDRESS } from './constants';
+import { decodePmpPayload } from './decode-pmp-payload';
+import type { PmpAccountContent, PmpAccountKind, PmpAccountSnapshot, PmpDecodeConfig } from './types';
+
+/**
+ * Decodes the payload a PMP account currently holds, for the instructions that carry no inline bytes: a `setData`
+ * whose payload came from a foreign buffer, and an `initialize` that finalized bytes pre-written to its metadata
+ * PDA. Pure - the caller supplies the already-fetched account.
+ *
+ * This reads CURRENT state. It is not a reconstruction of what the viewed transaction wrote, and it makes no
+ * attempt to be: no write history, no execution-position bound, no length derivation. The UI says so.
+ *
+ * `config` is used only for a Buffer account, whose header carries no encoding/compression/format of its own. A
+ * Metadata account carries its own hints, and those are the ones that match the bytes it currently holds.
+ */
+export function decodePmpBufferAccount({
+    account,
+    config,
+    cap,
+}: {
+    account: PmpAccountSnapshot;
+    config: PmpDecodeConfig;
+    cap?: number;
+}): PmpAccountContent {
+    const { data, lamports, owner } = account;
+
+    // The accounts provider models "no such account" as zero lamports plus an empty raw buffer, which is exactly
+    // what a closed PMP buffer leaves behind. No account can hold data at zero lamports, so this is unambiguous.
+    if (lamports === 0 && (data === undefined || data.length === 0)) return { kind: 'absent' };
+
+    if (owner !== PMP_ADDRESS) {
+        return {
+            kind: 'unreadable',
+            reason: `the account is owned by ${owner}, not the Program Metadata Program`,
+        };
+    }
+
+    if (data === undefined) {
+        return { kind: 'unreadable', reason: 'the account was fetched without its data' };
+    }
+
+    if (data.length < PMP_ACCOUNT_HEADER_LEN) {
+        return {
+            kind: 'unreadable',
+            reason: `the account is shorter than the ${PMP_ACCOUNT_HEADER_LEN}-byte header`,
+        };
+    }
+
+    try {
+        switch (data[0]) {
+            case AccountDiscriminator.Buffer: {
+                // A buffer has no length field: its body runs to the end of the account, which is what the
+                // remainder decoder hands back.
+                const bufferData = getBufferDecoder().decode(data).data;
+                return decodeAccountContent('buffer', config, bufferData, cap);
+            }
+            case AccountDiscriminator.Metadata: {
+                const metadata = getMetadataDecoder().decode(data);
+                // The `data` field is a REMAINDER, so an account grown by `extend` and never trimmed carries
+                // slack past the payload. `dataLength` is what the program itself treats as the payload.
+                const bufferData = metadata.data.subarray(0, metadata.dataLength);
+                const accountConfig = {
+                    compression: metadata.compression,
+                    encoding: metadata.encoding,
+                    format: metadata.format,
+                };
+                return decodeAccountContent('metadata', accountConfig, bufferData, cap);
+            }
+            case AccountDiscriminator.Empty: {
+                // Allocated and not written yet. An ordinary state, so it is reported to the reader and nowhere
+                // else - but reading it as a payload would still decode padding as content.
+                return noPayloadContent(data[0]);
+            }
+            default: {
+                Logger.warn('[pmp:decode-account] unknown PMP account discriminator', {
+                    sentry: true,
+                    sentryExtras: { discriminator: data[0], length: data.length },
+                });
+                return noPayloadContent(data[0]);
+            }
+        }
+    } catch (error) {
+        Logger.error(new Error('[pmp:decode-account] PMP account decode error', { cause: error }), {
+            sentry: true,
+            sentryExtras: { discriminator: data[0], length: data.length },
+        });
+        return { kind: 'unreadable', reason: toReason(error) };
+    }
+}
+
+function noPayloadContent(discriminator: number): PmpAccountContent {
+    return { kind: 'unreadable', reason: `the account holds no PMP payload (discriminator ${discriminator})` };
+}
+
+/**
+ * The body is copied out rather than kept as a view. The provider hands back web3.js's Node `Buffer`, so every
+ * slice of it is a `Buffer` sitting at an offset into Node's shared allocation pool - which would leak that
+ * pool's lifetime and `Buffer`'s own `toJSON` into everything downstream, exactly as the inline path avoids.
+ */
+function decodeAccountContent(
+    account: PmpAccountKind,
+    config: PmpDecodeConfig,
+    data: ReadonlyUint8Array,
+    cap: number | undefined,
+): PmpAccountContent {
+    const body = bytes(data);
+    const payload = decodePmpPayload({ cap, config, data: body });
+    return { account, body, config, kind: 'payload', payload };
+}
+
+/** The generated decoders throw plain Errors, but a non-Error throw stays handled rather than read as `undefined`. */
+function toReason(error: unknown): string {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return 'unknown account decode error';
+}

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-instruction.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-instruction.ts
@@ -1,0 +1,117 @@
+import { unwrapOption } from '@solana/kit';
+import type { TransactionInstruction } from '@solana/web3.js';
+import {
+    getInitializeInstructionDataDecoder,
+    getSetDataInstructionDataDecoder,
+    getWriteInstructionDataDecoder,
+    identifyProgramMetadataInstruction,
+    ProgramMetadataInstruction,
+} from '@solana-program/program-metadata';
+import { is } from 'superstruct';
+
+import { HEADER_ONLY_SET_DATA_LEN, PMP_ADDRESS, PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX } from './constants';
+import type { PmpContentInstruction } from './types';
+import { PmpDecodeConfigStruct } from './validators';
+
+/**
+ * Decodes the config and payload of a content-carrying PMP instruction from its RAW bytes, using the library's
+ * typed decoders. Needs no IDL, because those decoders ship with the installed package.
+ *
+ * Returns undefined for the six housekeeping instructions and for any shape the decoders reject, so the caller
+ * falls through to its remaining tiers (the dynamic IDL card, then Unknown) exactly as it does today.
+ */
+export function decodePmpContentInstruction(ix: TransactionInstruction): PmpContentInstruction | undefined {
+    try {
+        switch (identifyProgramMetadataInstruction(ix.data)) {
+            case ProgramMetadataInstruction.SetData:
+                return decodeSetData(ix);
+            case ProgramMetadataInstruction.Initialize:
+                return decodeInitialize(ix);
+            case ProgramMetadataInstruction.Write:
+                return decodeWrite(ix);
+            default:
+                // allocate, setAuthority, setImmutable, trim, extend, close carry no payload.
+                return undefined;
+        }
+    } catch {
+        // Three shapes land here:
+        // - an unknown or empty discriminator (identify throws)
+        // - a truncated body,
+        // - an out-of-range enum byte ("Enum discriminator out of range").
+        // All fall through to the IDL tier and then to Unknown.
+        return undefined;
+    }
+}
+
+function decodeSetData(ix: TransactionInstruction): PmpContentInstruction | undefined {
+    // setData carries `dataSource` as an OPTIONAL trailing byte, so a 4-byte instruction is the header-only hint
+    // update and `getSetDataInstructionDataDecoder()` throws on it. Branch on the length before decoding.
+    if (ix.data.length === HEADER_ONLY_SET_DATA_LEN) {
+        const [, encoding, compression, format] = ix.data;
+        const config = { compression, encoding, format };
+        // These are the slice's only unvalidated bytes, so superstruct narrows them to the library enums rather
+        // than an `as` cast asserting a range nothing checked. An out-of-range hint then falls through like every
+        // other malformed shape, instead of reaching the card as a number no label map can resolve.
+        return is(config, PmpDecodeConfigStruct) ? { config, kind: 'setData' } : undefined;
+    }
+
+    const decoded = getSetDataInstructionDataDecoder().decode(ix.data);
+    const payload = toPayload(unwrapOption(decoded.data));
+    return {
+        config: { compression: decoded.compression, encoding: decoded.encoding, format: decoded.format },
+        dataSource: decoded.dataSource,
+        kind: 'setData',
+        payload,
+        // A 5-byte setData with `buffer == programId` is InvalidInstructionData on chain, so "no payload plus a
+        // foreign buffer at index 2" is the only reachable buffer-sourced shape.
+        sourceBuffer: payload ? undefined : sourceBufferAt(ix),
+    };
+}
+
+function decodeInitialize(ix: TransactionInstruction): PmpContentInstruction {
+    // `initialize`'s `dataSource` is a fixed struct field, so its decoder always applies - no length branch.
+    const decoded = getInitializeInstructionDataDecoder().decode(ix.data);
+    return {
+        config: { compression: decoded.compression, encoding: decoded.encoding, format: decoded.format },
+        dataSource: decoded.dataSource,
+        kind: 'initialize',
+        // The in-place path finalises bytes already written to the metadata PDA at account index 0.
+        metadataAccount: ix.keys[0]?.pubkey.toBase58(),
+        payload: toPayload(unwrapOption(decoded.data)),
+        seed: decoded.seed,
+    };
+}
+
+function decodeWrite(ix: TransactionInstruction): PmpContentInstruction {
+    const { data, offset } = getWriteInstructionDataDecoder().decode(ix.data);
+    const chunk = toPayload(unwrapOption(data));
+    return {
+        chunk,
+        kind: 'write',
+        offset,
+        sourceBuffer: chunk ? undefined : sourceBufferAt(ix),
+    };
+}
+
+/**
+ * `unwrapOption` returns null for None, and the `data` field is a REMAINDER option, so none() and some(empty)
+ * encode to the same bytes. Both collapse to "no payload here" - account index 2 is what tells a source-buffer
+ * copy apart from a zero-length inline write.
+ *
+ * `TransactionInstruction.data` is a Node `Buffer`, so the remainder slice the decoder hands back is a Buffer
+ * VIEW, not a plain `Uint8Array`. Copy it into one: the declared type says `Uint8Array`, the repo is migrating
+ * off `Buffer`, and `Buffer` carries its own `toJSON`, which would change how a payload serialises downstream.
+ * Copied rather than re-viewed because a Buffer view sits at a non-zero offset into Node's shared allocation
+ * pool, which leaks that offset (and the whole pool's lifetime) into everything downstream. Inline payloads are
+ * transaction-size bounded, so the copy is at most ~1 KB.
+ */
+function toPayload(value: unknown): Uint8Array | undefined {
+    if (!(value instanceof Uint8Array) || value.length === 0) return undefined;
+    return new Uint8Array(value);
+}
+
+/** The optional buffer/sourceBuffer slot. Codama's "programId" strategy fills an omitted optional with the id. */
+function sourceBufferAt(ix: TransactionInstruction): string | undefined {
+    const account = ix.keys[PMP_OPTIONAL_BUFFER_ACCOUNT_INDEX]?.pubkey.toBase58();
+    return account && account !== PMP_ADDRESS ? account : undefined;
+}

--- a/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
+++ b/app/features/decode-instruction-pmp/lib/decode-pmp-payload.ts
@@ -1,0 +1,194 @@
+import { Compression, decodeData, Format } from '@solana-program/program-metadata';
+import { Inflate } from 'pako';
+
+import { bytes, concat } from '@/app/shared/lib/bytes';
+import { Logger } from '@/app/shared/lib/logger';
+
+import { PMP_DECODE_BUDGET_BYTES, PMP_MAX_UNPACKED_BYTES } from './constants';
+import type { PmpDecodeConfig, PmpDecodedPayload } from './types';
+
+/**
+ * Decodes an inline PMP payload: unpack, enforce the decode budget, then decode per `encoding` and present per
+ * `format`. Never throws - every failure comes back as `{ kind: 'failed' }` so the card can degrade locally
+ * without losing its accounts and config tables.
+ *
+ * Two bounds apply, because they guard different costs:
+ * - `PMP_MAX_UNPACKED_BYTES` on the DECOMPRESSED output, enforced WHILE the stream inflates, because a small
+ *   deflate stream can expand into hundreds of megabytes and pako offers no output limit of its own.
+ * - the per-encoding budget on the unpacked bytes, checked BEFORE the encoding step so an oversized payload is
+ *   never handed to `decodeData` or `JSON.parse`. That is the cost the budget exists to avoid, and it is where the
+ *   render stays responsive: with `Encoding.Base58` the decode is quadratic. See `PMP_DECODE_BUDGET_BYTES`.
+ *
+ * `cap` overrides the per-encoding budget for the whole call. It exists so tests and stories can reach the guard
+ * states without building a fixture hundreds of kilobytes wide.
+ *
+ * Zero payload bytes come back as `empty`, never as `decoded`. Every encoding decodes nothing to the empty string,
+ * which would otherwise render as a blank document styled exactly like a successful one.
+ */
+export function decodePmpPayload({
+    config,
+    data,
+    cap,
+}: {
+    config: PmpDecodeConfig;
+    data: Uint8Array;
+    cap?: number;
+}): PmpDecodedPayload {
+    const budget = cap ?? PMP_DECODE_BUDGET_BYTES[config.encoding];
+
+    // Checked before the unpack: an empty stream emits no bytes and never ends, so a declared compression would
+    // otherwise report an account that simply holds nothing as a truncated one.
+    if (data.length === 0) {
+        return { kind: 'empty' };
+    }
+
+    // `Compression.None` unpacks nothing, so the stored bytes ARE the payload. Modelled as an already-unpacked
+    // result rather than a separate branch, so every outcome below is read off one union.
+    const unpacked: BoundedUnpackResult =
+        config.compression === Compression.None
+            ? { bytes: data, kind: 'ok' }
+            : unpackBounded(data, PMP_MAX_UNPACKED_BYTES);
+
+    if (unpacked.kind === 'overflow') {
+        return { kind: 'unpack-overflow', limit: unpacked.limit };
+    }
+
+    if (unpacked.kind === 'incomplete' || unpacked.kind === 'error') {
+        // A buffer read while its `write` chunks are still landing holds a truncated stream, so `incomplete` is an
+        // ordinary thing for this card to meet rather than corruption. Both leave the reader with no document, so
+        // both present as `failed` and differ only in the reason.
+        const reason = unpacked.kind === 'incomplete' ? 'the compressed stream is incomplete' : unpacked.reason;
+        Logger.error(new Error('[pmp:decode-payload] failed to unpack'), { compression: config.compression, reason });
+        return { kind: 'failed', reason };
+    }
+
+    const { bytes } = unpacked;
+
+    if (bytes.length > budget) {
+        return { budget, bytes, kind: 'oversized' };
+    }
+
+    if (bytes.length === 0) {
+        return { kind: 'empty' };
+    }
+
+    try {
+        const text = decodeData(bytes, config.encoding);
+        if (typeof text !== 'string') {
+            // No validated config can reach this: both entry points narrow `encoding` to the library enum first.
+            // If it fires, `Encoding` grew a variant whose decoder returns something other than a string, and
+            // every card holding that encoding renders a decode failure. Reported, because it is our drift.
+            Logger.warn('[pmp:decode-payload] decodeData returned a non-string for a declared encoding', {
+                sentry: true,
+                sentryExtras: { compression: config.compression, encoding: config.encoding },
+            });
+            return { kind: 'failed', reason: `unsupported encoding (${config.encoding})` };
+        }
+
+        return { bytes, kind: 'decoded', text: toDocumentText(text, config.format) };
+    } catch (error) {
+        const reason = toDecodeFailureReason(error);
+        Logger.error(new Error('[pmp:decode-payload] failed to decode', { cause: error }), {
+            compression: config.compression,
+            encoding: config.encoding,
+            reason,
+        });
+        return { kind: 'failed', reason };
+    }
+}
+
+/**
+ * Signal that unwinds the inflate loop from inside pako's `onData`.
+ */
+class UnpackOverflow extends Error {}
+const UNPACK_OVERFLOW_ERROR = new UnpackOverflow('[pmp:decode-payload] unpack exceeded its output limit');
+
+/**
+ * `incomplete` is its own outcome rather than an error, because pako reports it by NOT ending: a truncated stream
+ * leaves `err` at zero and simply never reaches the end of the stream. That is the state `uncompressData` turns
+ * into a silent `undefined`, which used to surface as a TypeError from the length check below it.
+ */
+type BoundedUnpackResult =
+    | { kind: 'ok'; bytes: Uint8Array }
+    | { kind: 'overflow'; limit: number }
+    | { kind: 'incomplete' }
+    | { kind: 'error'; reason: string };
+
+/**
+ * Inflates a gzip or zlib stream, refusing to produce more than `limit` bytes.
+ *
+ * Stands in for `uncompressData`, which is a switch over `pako.ungzip`/`pako.inflate` - the SAME autodetecting
+ * function in pako 2.x, and the one this calls, so one path covers both compressions. What it adds is a bound on
+ * the OUTPUT: pako has no `maxOutputLength`, so the library helper allocates whatever the stream expands to before
+ * any caller can measure it. `onData` fires once per output chunk, so the check here runs DURING the inflate and
+ * peak allocation is `limit` plus one 64 KB chunk. Measured against a stream expanding to 100 MB: ~6 ms holding
+ * ~1 MB, where the unbounded call took ~240 ms and allocated all 100 MB.
+ *
+ * Never throws. The library helper signals a corrupt stream by throwing a bare string and an incomplete one by
+ * returning `undefined`, and both arrive here as a typed result instead.
+ */
+function unpackBounded(data: Uint8Array, limit: number): BoundedUnpackResult {
+    const inflator = new Inflate();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let overflow = false;
+    let ended = false;
+
+    // Deliberately does not call through to pako's own `onData`, which leaves its internal chunk list empty. That
+    // is what makes the `onEnd` call-through below free: it flattens nothing instead of copying the payload again.
+    inflator.onData = chunk => {
+        const data = bytes(chunk);
+        total += data.length;
+        if (total > limit) {
+            overflow = true;
+            throw UNPACK_OVERFLOW_ERROR;
+        }
+        chunks.push(data);
+    };
+
+    // `err` and `msg` are assigned by pako's own `onEnd`, so it still has to run. `ended` records that it ran at
+    // all, which is the only signal for a truncated stream: pako sets no error there, it just never ends.
+    const fillErrAndMsg = inflator.onEnd.bind(inflator);
+    inflator.onEnd = status => {
+        ended = true;
+        fillErrAndMsg(status);
+    };
+
+    try {
+        inflator.push(data, true);
+    } catch (error) {
+        if (error !== UNPACK_OVERFLOW_ERROR) throw error;
+    }
+
+    if (overflow) return { kind: 'overflow', limit };
+    if (inflator.err !== 0) return { kind: 'error', reason: inflator.msg || `inflate error ${inflator.err}` };
+    if (!ended) return { kind: 'incomplete' };
+
+    // A stream that decompresses to nothing emits no chunk at all, so this is an empty payload, not a failure.
+    return { bytes: concat(chunks), kind: 'ok' };
+}
+
+/** Not every decoder throws an Error: pako threw bare strings before the unpack moved in-house, so this stays. */
+function toDecodeFailureReason(error: unknown): string {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return 'unknown decode error';
+}
+
+/**
+ * Renders an already-decoded payload string for display.
+ * Only `Json` is re-serialised with indentation so a minified document is readable.
+ * Yaml/Toml/None stay verbatim - no parser library is pulled in.
+ */
+export function toDocumentText(text: string, format: Format): string {
+    if (format !== Format.Json) {
+        return text;
+    }
+    try {
+        // Every JSON value stringifies back to a string, scalars included, so no shape needs special-casing.
+        return JSON.stringify(JSON.parse(text), undefined, 2);
+    } catch (error) {
+        Logger.debug('[pmp:decode-payload] payload declares Format.Json but does not parse as JSON', { error });
+        return text;
+    }
+}

--- a/app/features/decode-instruction-pmp/lib/is-program-metadata-instruction.ts
+++ b/app/features/decode-instruction-pmp/lib/is-program-metadata-instruction.ts
@@ -1,0 +1,14 @@
+import type { TransactionInstruction } from '@solana/web3.js';
+
+import { PMP_ADDRESS } from './program-address';
+
+/**
+ * Whether an instruction targets the Program Metadata Program. Mirrors the per-program guards it sits alongside
+ * (`isLighthouseInstruction`, `isPythInstruction`, ...) and is used by both the tx page and the inspector.
+ *
+ * Imports the address from `program-address` rather than `constants`, which pulls the generated client: this runs
+ * on every instruction of every transaction, so it is the one PMP module that must stay in first-load JS.
+ */
+export function isProgramMetadataInstruction(ix: TransactionInstruction): boolean {
+    return ix.programId.toBase58() === PMP_ADDRESS;
+}

--- a/app/features/decode-instruction-pmp/lib/program-address.ts
+++ b/app/features/decode-instruction-pmp/lib/program-address.ts
@@ -1,0 +1,12 @@
+/**
+ * The PMP program id as a LITERAL rather than re-exported from `@solana-program/program-metadata`.
+ *
+ * That package ships as one bundled ESM file whose top-level imports include pako, yaml and smol-toml, and its
+ * `exports` map has no subpath that reaches `PROGRAM_METADATA_PROGRAM_ADDRESS` alone. None of those three are
+ * marked side-effect-free, so a single edge from `isProgramMetadataInstruction` - which runs synchronously for
+ * every instruction, so it can never be lazy - keeps ~35 KB gzip in the `/tx/*` first-load JS and makes the
+ * dynamically imported card pointless.
+ *
+ * `__tests__/program-address.spec.ts` pins this to the library constant, so drift fails CI.
+ */
+export const PMP_ADDRESS = 'ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S';

--- a/app/features/decode-instruction-pmp/lib/types.ts
+++ b/app/features/decode-instruction-pmp/lib/types.ts
@@ -1,0 +1,98 @@
+import type { Compression, DataSource, Encoding, Format } from '@solana-program/program-metadata';
+/** The three decode hints `setData` and `initialize` carry on the wire. `format` classifies, it does not decode. */
+export type PmpDecodeConfig = {
+    encoding: Encoding;
+    compression: Compression;
+    format: Format;
+};
+
+/**
+ * The content-carrying PMP instructions. The six housekeeping instructions (allocate, setAuthority,
+ * setImmutable, trim, extend, close) never produce one of these - they fall through to the IDL card.
+ */
+export type PmpContentInstruction =
+    | {
+          kind: 'setData';
+          config: PmpDecodeConfig;
+          /** Absent on the 4-byte header-only shape, which carries no `dataSource` byte and no payload. */
+          dataSource?: DataSource;
+          /** Absent on the header-only shape and when the bytes live in `sourceBuffer`, which is read on demand. */
+          payload?: Uint8Array;
+          /** Account index 2 when it is not the program id, meaning the bytes come from a foreign buffer. */
+          sourceBuffer?: string;
+      }
+    | {
+          kind: 'initialize';
+          config: PmpDecodeConfig;
+          dataSource: DataSource;
+          seed: string;
+          /** Absent on the in-place path, where the bytes were pre-written to the metadata PDA and are read there. */
+          payload?: Uint8Array;
+          /** Account index 0, the metadata PDA that the in-place path pre-wrote. */
+          metadataAccount?: string;
+      }
+    | {
+          kind: 'write';
+          offset: number;
+          /** Absent when the chunk was copied from `sourceBuffer`, whose bytes are not in this transaction. */
+          chunk?: Uint8Array;
+          sourceBuffer?: string;
+      };
+
+/** The two instructions that carry decode hints, so the only two that can produce a decoded document. */
+export type PmpPayloadInstruction = Extract<PmpContentInstruction, { kind: 'setData' | 'initialize' }>;
+
+/**
+ * Result of decoding an inline payload. Four non-document states, and none of them may throw out to the card or
+ * render as a successful document:
+ * - `oversized` is past the decode budget for its encoding. It carries the full decompressed bytes and no text,
+ *   because nothing above the budget is decoded at all, so copy and download still work. `budget` is carried
+ *   because it now varies by encoding, and the alert has to say which limit was hit.
+ * - `unpack-overflow` was abandoned mid-unpack once its output passed the unpack ceiling, so unlike `oversized`
+ *   there are no decompressed bytes to offer: they were never produced. Only the still-packed bytes exist.
+ * - `failed` is a malformed stream or a payload that does not match its declared encoding.
+ * - `empty` is zero payload bytes, which every encoding decodes to the empty string. An ordinary state, not a
+ *   failure: an allocated-but-unwritten buffer reads this way. It carries nothing because there is nothing to
+ *   carry, and it exists so `decoded` can never mean a blank document - see `decodePmpPayload`.
+ *
+ * `text` is display-ready: a `Json` payload arrives pretty-printed, everything else verbatim. The card renders it
+ * as-is, so nothing downstream has to know which format produced it.
+ */
+export type PmpDecodedPayload =
+    | { kind: 'decoded'; text: string; bytes: Uint8Array }
+    | { kind: 'empty' }
+    | { kind: 'oversized'; bytes: Uint8Array; budget: number }
+    | { kind: 'unpack-overflow'; limit: number }
+    | { kind: 'failed'; reason: string };
+
+/** Which PMP account layout the body was read from. A Buffer carries no hints of its own, a Metadata does. */
+export type PmpAccountKind = 'buffer' | 'metadata';
+
+/**
+ * The minimal account shape the pure account decoder needs, so `lib/` stays free of the accounts provider.
+ * `owner` is base58 and `data` is the account's RAW bytes, header included.
+ */
+export type PmpAccountSnapshot = {
+    owner: string;
+    lamports: number;
+    data: Uint8Array | undefined;
+};
+
+/**
+ * Result of reading a payload from the account the instruction points at, rather than from the instruction.
+ *
+ * `absent` is an ordinary outcome, not an error: the canonical client closes a `setData` source buffer right
+ * after the instruction to reclaim its rent, so a historical transaction's buffer is normally gone.
+ */
+export type PmpAccountContent =
+    | { kind: 'absent' }
+    | { kind: 'unreadable'; reason: string }
+    | {
+          kind: 'payload';
+          account: PmpAccountKind;
+          /** The hints the body was decoded with: a Metadata account's own, or the instruction's for a Buffer. */
+          config: PmpDecodeConfig;
+          /** The account body as stored, before decompression - what the Raw tab shows. */
+          body: Uint8Array;
+          payload: PmpDecodedPayload;
+      };

--- a/app/features/decode-instruction-pmp/lib/validators.ts
+++ b/app/features/decode-instruction-pmp/lib/validators.ts
@@ -1,0 +1,17 @@
+import { Compression, Encoding, Format } from '@solana-program/program-metadata';
+import { enums, object } from 'superstruct';
+
+/**
+ * Runtime shape of the three decode hints, for the one path that reads them as raw bytes: the 4-byte header-only
+ * `setData`. Every other shape goes through a generated decoder that already rejects an out-of-range enum byte,
+ * so this is the only place unvalidated chain data enters the slice.
+ *
+ * The variants are listed explicitly rather than derived with `Object.values`, because a numeric TypeScript enum's
+ * runtime object also carries its reverse mapping (`{ 0: 'None', None: 0, ... }`), which would admit the label
+ * strings as valid values. Listing them also means a new library variant is a compile error here.
+ */
+export const PmpDecodeConfigStruct = object({
+    compression: enums([Compression.None, Compression.Gzip, Compression.Zlib]),
+    encoding: enums([Encoding.None, Encoding.Utf8, Encoding.Base58, Encoding.Base64]),
+    format: enums([Format.None, Format.Json, Format.Yaml, Format.Toml]),
+});

--- a/app/features/decode-instruction-pmp/model/use-pmp-account-payload.ts
+++ b/app/features/decode-instruction-pmp/model/use-pmp-account-payload.ts
@@ -1,0 +1,62 @@
+import { useAccountInfo, useFetchAccountInfo } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import { PublicKey } from '@solana/web3.js';
+import React from 'react';
+
+import { decodePmpBufferAccount } from '../lib/decode-pmp-buffer-account';
+import type { PmpAccountContent, PmpDecodeConfig } from '../lib/types';
+
+export type PmpAccountPayloadState =
+    | { status: 'loading' }
+    | { status: 'failed' }
+    | { status: 'ready'; content: PmpAccountContent };
+
+/**
+ * Reads the payload a PMP account currently holds.
+ *
+ * `config` must be referentially stable (pass the memoised instruction's own `config`), because it keys the
+ * decode memo and a fresh object per render would re-decompress the payload on every render.
+ *
+ * `cap` overrides the per-encoding decode budget and is forwarded verbatim, so this path and the inline one are
+ * bounded by the same rule.
+ */
+export function usePmpAccountPayload({
+    address,
+    config,
+    cap,
+}: {
+    address: string;
+    config: PmpDecodeConfig;
+    cap?: number;
+}): PmpAccountPayloadState {
+    const fetchAccountInfo = useFetchAccountInfo();
+    const entry = useAccountInfo(address);
+
+    // Cached is not the same as cached WITH BYTES: all three fetch modes share one slot per address, and the
+    // inspector fills it in `skip` mode, which stores none. Re-requesting settles, because a `raw` fetch always
+    // stores bytes.
+    const needsBytes =
+        entry === undefined || (entry.status === FetchStatus.Fetched && entry.data?.data.raw === undefined);
+
+    React.useEffect(() => {
+        if (!needsBytes) return;
+        fetchAccountInfo(new PublicKey(address), 'raw');
+    }, [address, fetchAccountInfo, needsBytes]);
+
+    return React.useMemo(() => {
+        // `needsBytes` covers both "nothing cached yet" and "cached without bytes"; the effect above is already
+        // requesting them, so both read as loading rather than as a decode of an entry that has nothing to decode.
+        if (needsBytes || entry === undefined || entry.status === FetchStatus.Fetching) return { status: 'loading' };
+        if (entry.status === FetchStatus.FetchFailed || entry.data === undefined) return { status: 'failed' };
+
+        const { data, lamports, owner } = entry.data;
+        return {
+            content: decodePmpBufferAccount({
+                account: { data: data.raw, lamports, owner: owner.toBase58() },
+                cap,
+                config,
+            }),
+            status: 'ready',
+        };
+    }, [cap, config, entry, needsBytes]);
+}

--- a/app/features/decode-instruction-pmp/ui/DataPayloadSection.tsx
+++ b/app/features/decode-instruction-pmp/ui/DataPayloadSection.tsx
@@ -1,0 +1,334 @@
+import { RawDataField } from '@components/shared/RawDataField';
+import { PublicKey } from '@solana/web3.js';
+import { DataSource } from '@solana-program/program-metadata';
+import React from 'react';
+
+import { Address } from '@/app/components/common/Address';
+import { Copyable } from '@/app/components/common/Copyable';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
+import { Alert } from '@/app/shared/ui/Alert';
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import { pmpAnalytics } from '../lib/analytics';
+import {
+    PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME,
+    PMP_ANALYTICS_IX_NAMES,
+    PMP_DATA_SOURCE_ANALYTICS_NAMES,
+    PMP_DECODED_DOWNLOAD_FILENAME,
+    PMP_FORMAT_ANALYTICS_NAMES,
+    PMP_RAW_DOWNLOAD_FILENAME,
+} from '../lib/constants';
+import { decodePmpPayload } from '../lib/decode-pmp-payload';
+import type { PmpAccountContent, PmpDecodedPayload, PmpPayloadInstruction } from '../lib/types';
+import { usePmpAccountPayload } from '../model/use-pmp-account-payload';
+
+/** The card table has three columns, so every row in this section spans all of them. */
+const CARD_TABLE_COLUMNS = 3;
+
+/**
+ * The Decoded Content section of the PMP card. Owns every payload state.
+ * A decode failure degrades to the raw view plus an inline note INSIDE this section (it never throws
+ * out to the card's error boundary, which would discard the accounts and config tables), and an oversized
+ * payload renders a bounded view plus a download rather than the full document.
+ *
+ * Raw bytes always go through `RawDataField`, which owns the hex/base64 tabs, the byte count, copy, download,
+ * show-more and its own too-large guard. Nothing here reimplements those.
+ *
+ * `cap` overrides the per-encoding decode budget on BOTH the inline and the account path. Left undefined in the
+ * app, so each encoding gets the budget measured for it, and set by tests and stories that need a guard state
+ * without a fixture hundreds of kilobytes wide.
+ */
+export function DataPayloadSection({ content, cap }: { content: PmpPayloadInstruction; cap?: number }) {
+    const { config, payload } = content;
+
+    // Decoded for every payload, not just `Direct`: `Url` and `External` also get the Decoded/Raw tabs, where the
+    // decoded panel applies the instruction's own encoding/compression hints to the POINTER bytes. That is a local
+    // decode, not pointer resolution - nothing is fetched and no account is read. Following the pointer is not
+    // done here at all, so a `Url` payload shows the url and stops there.
+    const decoded = React.useMemo(
+        () => (payload ? decodePmpPayload({ cap, config, data: payload }) : undefined),
+        [cap, config, payload],
+    );
+
+    return (
+        <>
+            <BaseTable.Row>
+                <BaseTable.Cell colSpan={CARD_TABLE_COLUMNS} data-testid="pmp-payload-section">
+                    <PayloadBody cap={cap} content={content} decoded={decoded} />
+                </BaseTable.Cell>
+            </BaseTable.Row>
+        </>
+    );
+}
+
+function PayloadBody({
+    cap,
+    content,
+    decoded,
+}: {
+    cap: number | undefined;
+    content: PmpPayloadInstruction;
+    decoded: PmpDecodedPayload | undefined;
+}) {
+    const { dataSource } = content;
+
+    // A 4-byte header-only setData updates the hints and leaves the stored bytes alone - not "no data", and not a decode failure.
+    // Only `setData` reaches here:
+    // `initialize` carries `dataSource` as a fixed struct field, so its decode always produces one.
+    if (dataSource === undefined) {
+        return (
+            <Alert variant="default" data-testid="pmp-header-only-note" className="!mb-0">
+                Instruction carries no new payload.
+            </Alert>
+        );
+    }
+
+    if (content.payload === undefined) {
+        return <AccountSourceSection cap={cap} content={content} dataSource={dataSource} />;
+    }
+
+    // A payload is present, which is exactly what the memo in the parent decodes on, so `decoded` is always set
+    // here. TypeScript cannot relate the two, so narrow once and keep `decoded` NON-optional in everything below -
+    // the impossible state must not cross a component boundary.
+    if (!decoded) return <></>;
+
+    return (
+        <DecodedTabs
+            content={content}
+            dataSource={dataSource}
+            decoded={decoded}
+            payload={content.payload}
+            source="instruction"
+        />
+    );
+}
+
+/**
+ * setData from a foreign buffer, or initialize in-place: the bytes are not in this transaction, they are in the
+ * account this instruction points at. That account can be read, so the section names it and reads it.
+ */
+function AccountSourceSection({
+    cap,
+    content,
+    dataSource,
+}: {
+    cap: number | undefined;
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+}) {
+    const account = content.kind === 'setData' ? content.sourceBuffer : content.metadataAccount;
+    const label = content.kind === 'setData' ? 'Source buffer account' : 'Metadata account';
+
+    if (!account) {
+        return (
+            <Alert variant="default" data-testid="pmp-deferred-source-note" className="!mb-0">
+                This instruction carries no payload bytes.
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-0">
+            <Alert variant="default" data-testid="pmp-deferred-source-note" className="!mb-0 pl-0">
+                <div className="flex w-full flex-row items-center gap-2">
+                    <span>The payload was written to the {label}</span>
+                    <Address noNicknameEditing pubkey={new PublicKey(account)} link raw />
+                </div>
+            </Alert>
+            <AccountPayload account={account} cap={cap} content={content} dataSource={dataSource} />
+        </div>
+    );
+}
+
+/**
+ * Reads what the referenced account holds RIGHT NOW, on render.
+ * Deliberately not a reconstruction of what the viewed transaction wrote, no write-history replay.
+ */
+function AccountPayload({
+    account,
+    cap,
+    content,
+    dataSource,
+}: {
+    account: string;
+    cap: number | undefined;
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+}) {
+    // `content.config` comes from the card's own `decodePmpContentInstruction` memo, so it is referentially
+    // stable across renders, which is what keeps the hook from re-decoding the payload on every render.
+    const state = usePmpAccountPayload({ address: account, cap, config: content.config });
+
+    if (state.status === 'loading') {
+        return (
+            <span data-testid="pmp-account-loading" className="text-xs text-neutral-500">
+                Reading account...
+            </span>
+        );
+    }
+
+    if (state.status === 'failed') {
+        return (
+            <Alert variant="warning" data-testid="pmp-account-failed" className="!mb-0">
+                Could not read this account. The RPC request failed.
+            </Alert>
+        );
+    }
+
+    return <AccountContentBody content={content} dataSource={dataSource} result={state.content} />;
+}
+
+function AccountContentBody({
+    content,
+    dataSource,
+    result,
+}: {
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+    result: PmpAccountContent;
+}) {
+    if (result.kind === 'absent') {
+        return (
+            <Alert variant="warning" data-testid="pmp-account-absent" className="!mb-0">
+                Account does not exist on chain.
+            </Alert>
+        );
+    }
+
+    if (result.kind === 'unreadable') {
+        return (
+            <Alert variant="warning" data-testid="pmp-account-unreadable" className="!mb-0">
+                Could not read account content: {result.reason}.
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-0">
+            <DecodedTabs
+                content={content}
+                dataSource={dataSource}
+                decoded={result.payload}
+                payload={result.body}
+                source="account"
+            />
+        </div>
+    );
+}
+
+function DecodedTabs({
+    content,
+    dataSource,
+    decoded,
+    payload,
+    source,
+}: {
+    content: PmpPayloadInstruction;
+    dataSource: DataSource;
+    decoded: PmpDecodedPayload;
+    payload: Uint8Array;
+    source: 'account' | 'instruction';
+}) {
+    // `onValueChange` fires only on a reader-initiated switch, never for the tab selected on mount, so the
+    // default panel produces no event. Radix hands back a plain string, so narrow it to the tracked union.
+    const handleTabChange = (value: string) => {
+        if (value !== 'decoded' && value !== 'raw') return;
+        pmpAnalytics.trackTabOpened({
+            dataSource: PMP_DATA_SOURCE_ANALYTICS_NAMES[dataSource],
+            format: PMP_FORMAT_ANALYTICS_NAMES[content.config.format],
+            instruction: PMP_ANALYTICS_IX_NAMES[content.kind],
+            source,
+            tab: value,
+        });
+    };
+
+    return (
+        <Tabs defaultValue="raw" onValueChange={handleTabChange}>
+            <TabsList>
+                <TabsTrigger value="raw">Raw</TabsTrigger>
+                <TabsTrigger value="decoded">Decoded</TabsTrigger>
+            </TabsList>
+            <TabsContent value="raw" className="pt-3">
+                <RawBytes payload={payload} source={source} />
+            </TabsContent>
+            <TabsContent value="decoded" className="pt-3">
+                <DecodedBody decoded={decoded} />
+            </TabsContent>
+        </Tabs>
+    );
+}
+
+function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
+    if (decoded.kind === 'failed') {
+        return (
+            <div className="flex flex-col gap-0">
+                <Alert variant="warning" data-testid="pmp-decode-error" className="!mb-0">
+                    Could not decode this payload: {decoded.reason}
+                </Alert>
+            </div>
+        );
+    }
+
+    // Abandoned mid-unpack, so there are no decompressed bytes to offer and no download to promise. The sibling
+    // Raw tab still has the payload as stored, which is the only thing that exists for this state.
+    if (decoded.kind === 'unpack-overflow') {
+        return (
+            <div className="flex flex-col gap-0" data-testid="pmp-payload-unpack-overflow">
+                <Alert variant="warning" className="!mb-0">
+                    Payload expands past the {decoded.limit}-byte limit for unpacking.
+                </Alert>
+            </div>
+        );
+    }
+
+    if (decoded.kind === 'oversized') {
+        return (
+            <div className="flex flex-col gap-3" data-testid="pmp-payload-oversized">
+                <Alert variant="warning" className="!mb-0">
+                    Payload too large to render ({decoded.bytes.length} bytes, limit {decoded.budget}). Copy or download
+                    it instead.
+                </Alert>
+                <RawDataField data={decoded.bytes} filename={PMP_DECODED_DOWNLOAD_FILENAME} />
+            </div>
+        );
+    }
+
+    if (decoded.kind === 'empty') {
+        return (
+            <Alert variant="default" data-testid="pmp-payload-empty" className="!mb-0">
+                The payload is empty.
+            </Alert>
+        );
+    }
+
+    // Plain text rather than a JSON viewer: the common payload is a program IDL, and react-json-view is not
+    // virtualized, so an interactive tree costs thousands of nodes per card. A Json payload arrives already
+    // pretty-printed from `toDocumentText`, so every format renders through this one node.
+    // TODO: follow a `DataSource.Url` or `DataSource.External` pointer. Today its bytes render as text, unresolved.
+    return (
+        <div className="relative">
+            <div className="absolute right-2 top-2 z-10" data-testid="pmp-decoded-copy">
+                <Copyable text={decoded.text} />
+            </div>
+            <pre
+                data-testid="pmp-decoded-text"
+                className="mb-0 max-h-80 overflow-auto whitespace-pre-wrap break-words bg-heavy-metal-900 p-3 pr-8 text-left text-xs"
+            >
+                {decoded.text}
+            </pre>
+        </div>
+    );
+}
+
+/** Thin wrapper so the section's own test id sits on a stable node around the shared field. */
+function RawBytes({ payload, source }: { payload: Uint8Array; source: 'account' | 'instruction' }) {
+    const isAccount = source === 'account';
+    return (
+        <div data-testid={isAccount ? 'pmp-account-raw' : 'pmp-payload-raw'}>
+            <RawDataField
+                data={payload}
+                filename={isAccount ? PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME : PMP_RAW_DOWNLOAD_FILENAME}
+            />
+        </div>
+    );
+}

--- a/app/features/decode-instruction-pmp/ui/DataPayloadSection.tsx
+++ b/app/features/decode-instruction-pmp/ui/DataPayloadSection.tsx
@@ -1,10 +1,11 @@
 import { RawDataField } from '@components/shared/RawDataField';
 import { PublicKey } from '@solana/web3.js';
-import { DataSource } from '@solana-program/program-metadata';
+import { Compression, DataSource } from '@solana-program/program-metadata';
 import React from 'react';
 
 import { Address } from '@/app/components/common/Address';
 import { Copyable } from '@/app/components/common/Copyable';
+import { Badge } from '@/app/components/shared/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/app/components/shared/ui/tabs';
 import { Alert } from '@/app/shared/ui/Alert';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -13,10 +14,12 @@ import { pmpAnalytics } from '../lib/analytics';
 import {
     PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME,
     PMP_ANALYTICS_IX_NAMES,
+    PMP_COMPRESSED_BYTES_LABELS,
     PMP_DATA_SOURCE_ANALYTICS_NAMES,
     PMP_DECODED_DOWNLOAD_FILENAME,
     PMP_FORMAT_ANALYTICS_NAMES,
     PMP_RAW_DOWNLOAD_FILENAME,
+    PMP_UNCOMPRESSED_BYTES_LABEL,
 } from '../lib/constants';
 import { decodePmpPayload } from '../lib/decode-pmp-payload';
 import type { PmpAccountContent, PmpDecodedPayload, PmpPayloadInstruction } from '../lib/types';
@@ -94,6 +97,7 @@ function PayloadBody({
 
     return (
         <DecodedTabs
+            compression={content.config.compression}
             content={content}
             dataSource={dataSource}
             decoded={decoded}
@@ -206,6 +210,7 @@ function AccountContentBody({
     return (
         <div className="flex flex-col gap-0">
             <DecodedTabs
+                compression={result.config.compression}
                 content={content}
                 dataSource={dataSource}
                 decoded={result.payload}
@@ -217,12 +222,14 @@ function AccountContentBody({
 }
 
 function DecodedTabs({
+    compression,
     content,
     dataSource,
     decoded,
     payload,
     source,
 }: {
+    compression: Compression;
     content: PmpPayloadInstruction;
     dataSource: DataSource;
     decoded: PmpDecodedPayload;
@@ -249,16 +256,24 @@ function DecodedTabs({
                 <TabsTrigger value="decoded">Decoded</TabsTrigger>
             </TabsList>
             <TabsContent value="raw" className="pt-3">
-                <RawBytes payload={payload} source={source} />
+                <RawBytes compression={compression} payload={payload} source={source} />
             </TabsContent>
             <TabsContent value="decoded" className="pt-3">
-                <DecodedBody decoded={decoded} />
+                <DecodedBody compression={compression} decoded={decoded} stored={payload.length} />
             </TabsContent>
         </Tabs>
     );
 }
 
-function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
+function DecodedBody({
+    compression,
+    decoded,
+    stored,
+}: {
+    compression: Compression;
+    decoded: PmpDecodedPayload;
+    stored: number;
+}) {
     if (decoded.kind === 'failed') {
         return (
             <div className="flex flex-col gap-0">
@@ -273,7 +288,7 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
     // Raw tab still has the payload as stored, which is the only thing that exists for this state.
     if (decoded.kind === 'unpack-overflow') {
         return (
-            <div className="flex flex-col gap-0" data-testid="pmp-payload-unpack-overflow">
+            <div className="flex flex-col gap-0 whitespace-pre-wrap" data-testid="pmp-payload-unpack-overflow">
                 <Alert variant="warning" className="!mb-0">
                     Payload expands past the {decoded.limit}-byte limit for unpacking.
                 </Alert>
@@ -284,11 +299,15 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
     if (decoded.kind === 'oversized') {
         return (
             <div className="flex flex-col gap-3" data-testid="pmp-payload-oversized">
-                <Alert variant="warning" className="!mb-0">
-                    Payload too large to render ({decoded.bytes.length} bytes, limit {decoded.budget}). Copy or download
-                    it instead.
+                <Alert variant="warning" className="!mb-0 whitespace-pre-wrap">
+                    Payload too large to render ({describeSize(decoded.bytes.length, stored, compression)}, limit{' '}
+                    {decoded.budget}). Copy or download it instead.
                 </Alert>
-                <RawDataField data={decoded.bytes} filename={PMP_DECODED_DOWNLOAD_FILENAME} />
+                <RawDataField
+                    data={decoded.bytes}
+                    extraButton={<BytesBadge compression={compression} side="uncompressed" />}
+                    filename={PMP_DECODED_DOWNLOAD_FILENAME}
+                />
             </div>
         );
     }
@@ -320,13 +339,42 @@ function DecodedBody({ decoded }: { decoded: PmpDecodedPayload }) {
     );
 }
 
-/** Thin wrapper so the section's own test id sits on a stable node around the shared field. */
-function RawBytes({ payload, source }: { payload: Uint8Array; source: 'account' | 'instruction' }) {
+/**
+ * Names WHICH bytes a count refers to, because the two tabs measure two different things:
+ * the Decoded panel counts the UNPACKED payload.
+ * the Raw tab counts the payload as stored.
+ */
+function describeSize(unpacked: number, stored: number, compression: Compression): string {
+    if (compression === Compression.None) return `${unpacked} bytes`;
+    return `${unpacked} bytes unpacked from ${stored} stored`;
+}
+
+function BytesBadge({ compression, side }: { compression: Compression; side: 'compressed' | 'uncompressed' }) {
+    if (compression === Compression.None) return undefined;
+
+    const isCompressed = side === 'compressed';
+    return (
+        <Badge data-testid={`pmp-bytes-badge-${side}`} variant={isCompressed ? 'warning' : 'info'}>
+            {isCompressed ? PMP_COMPRESSED_BYTES_LABELS[compression] : PMP_UNCOMPRESSED_BYTES_LABEL}
+        </Badge>
+    );
+}
+
+function RawBytes({
+    compression,
+    payload,
+    source,
+}: {
+    compression: Compression;
+    payload: Uint8Array;
+    source: 'account' | 'instruction';
+}) {
     const isAccount = source === 'account';
     return (
         <div data-testid={isAccount ? 'pmp-account-raw' : 'pmp-payload-raw'}>
             <RawDataField
                 data={payload}
+                extraButton={<BytesBadge compression={compression} side="compressed" />}
                 filename={isAccount ? PMP_ACCOUNT_RAW_DOWNLOAD_FILENAME : PMP_RAW_DOWNLOAD_FILENAME}
             />
         </div>

--- a/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
+++ b/app/features/decode-instruction-pmp/ui/PmpDetailsCard.tsx
@@ -1,0 +1,200 @@
+import { RawDataField } from '@components/shared/RawDataField';
+import { PublicKey, type SignatureResult, type TransactionInstruction } from '@solana/web3.js';
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { Address } from '@/app/components/common/Address';
+import { CodamaInstructionBody } from '@/app/components/instruction/codama/CodamaInstructionBody';
+import { InstructionCard } from '@/app/components/instruction/InstructionCard';
+import { toKitInstruction } from '@/app/shared/lib/web3js-compat';
+import { BaseTable } from '@/app/shared/ui/Table';
+
+import {
+    PMP_ACCOUNT_NAMES,
+    PMP_CODAMA_PROGRAM_NAME,
+    PMP_COMPRESSION_LABELS,
+    PMP_DATA_SOURCE_LABELS,
+    PMP_ENCODING_LABELS,
+    PMP_FORMAT_LABELS,
+    PMP_IX_TITLES,
+    PMP_WRITE_CHUNK_DOWNLOAD_FILENAME,
+} from '../lib/constants';
+import { decodePmpContentInstruction } from '../lib/decode-pmp-instruction';
+import type { PmpContentInstruction, PmpPayloadInstruction } from '../lib/types';
+import { DataPayloadSection } from './DataPayloadSection';
+
+/** The card table has three columns, matching DataPayloadSection's own constant. */
+const CARD_TABLE_COLUMNS = 3;
+
+type PmpDetailsCardProps = {
+    ix: TransactionInstruction;
+    index: number;
+    result: SignatureResult;
+    innerCards?: React.ReactNode[];
+    childIndex?: number;
+    InstructionCardComponent?: React.FC<Parameters<typeof InstructionCard>[0]>;
+    /**
+     * What to render when this instruction carries no decodable content, and the ErrorBoundary fallback. Each
+     * surface builds it: the IDL card when an IDL resolved, its own Unknown card otherwise. Injected rather than
+     * built here because `boundaries/dependencies` forbids this feature from importing
+     * `@features/decode-instruction-with-idl`, and because it keeps the card free of IDL concepts entirely.
+     */
+    fallback: React.ReactNode;
+};
+
+/**
+ * The single entry point for every Program Metadata Program instruction on both the tx page and the inspector.
+ *
+ * It is keyed on the program id rather than hung off `CodamaInstructionCard` for two reasons: a 4-byte
+ * header-only `setData` never produces a Codama decode at all, and the whole Codama path is gated on runtime
+ * PMP IDL resolution while the typed decoders this card uses ship with the installed library.
+ *
+ * `setData`, `initialize` and `write` get the custom render below. Everything else, including the six
+ * housekeeping instructions, renders `fallback`, which is what those instructions got before this card existed.
+ */
+export function PmpDetailsCard({ fallback, ...props }: PmpDetailsCardProps) {
+    return (
+        <ErrorBoundary fallback={<>{fallback}</>}>
+            <PmpDetailsCardBody {...props} fallback={fallback} />
+        </ErrorBoundary>
+    );
+}
+
+function PmpDetailsCardBody({
+    ix,
+    index,
+    result,
+    innerCards,
+    childIndex,
+    InstructionCardComponent = InstructionCard,
+    fallback,
+}: PmpDetailsCardProps) {
+    const content = React.useMemo(() => decodePmpContentInstruction(ix), [ix]);
+
+    if (!content) {
+        return <>{fallback}</>;
+    }
+
+    // `toKitInstruction` always returns an array, so no `?? []` is needed here.
+    const kitIx = toKitInstruction(ix);
+
+    return (
+        <InstructionCardComponent
+            title={`${PMP_CODAMA_PROGRAM_NAME}: ${PMP_IX_TITLES[content.kind]}`}
+            ix={ix}
+            index={index}
+            result={result}
+            innerCards={innerCards}
+            childIndex={childIndex}
+        >
+            <CodamaInstructionBody
+                programId={ix.programId}
+                programName={PMP_CODAMA_PROGRAM_NAME}
+                accounts={kitIx.accounts}
+                accountNames={PMP_ACCOUNT_NAMES[content.kind]}
+            />
+            {content.kind === 'write' ? (
+                <WriteRows content={content} />
+            ) : (
+                <>
+                    <ConfigRows content={content} />
+                    <DataPayloadSection content={content} />
+                </>
+            )}
+        </InstructionCardComponent>
+    );
+}
+
+/**
+ * The decode hints, rendered from their library enums rather than as raw numbers.
+ *
+ * Every label lookup below is total, with no `Unknown (n)` fallback, because no unvalidated hint ever reaches
+ * here: the 5+ byte shapes come through a generated decoder that rejects an out-of-range enum byte, and the
+ * 4-byte header-only shape is narrowed by `PmpDecodeConfigStruct`. Both reject by falling through to the card's
+ * `fallback` instead. Adding a library variant breaks the build at the label maps, which is the intent.
+ */
+function ConfigRows({ content }: { content: PmpPayloadInstruction }) {
+    return (
+        <>
+            <ArgumentHeaderRow />
+            {content.kind === 'initialize' && <ValueRow testId="pmp-config-seed" label="Seed" value={content.seed} />}
+            <ValueRow
+                testId="pmp-config-encoding"
+                label="Encoding"
+                value={PMP_ENCODING_LABELS[content.config.encoding]}
+            />
+            <ValueRow
+                testId="pmp-config-compression"
+                label="Compression"
+                value={PMP_COMPRESSION_LABELS[content.config.compression]}
+            />
+            <ValueRow testId="pmp-config-format" label="Format" value={PMP_FORMAT_LABELS[content.config.format]} />
+            {content.dataSource !== undefined && (
+                <ValueRow
+                    testId="pmp-config-data-source"
+                    label="Data Source"
+                    value={PMP_DATA_SOURCE_LABELS[content.dataSource]}
+                />
+            )}
+        </>
+    );
+}
+
+/** `write` is a fragment with no hints, so it can never be decoded to a document on its own. */
+function WriteRows({ content }: { content: Extract<PmpContentInstruction, { kind: 'write' }> }) {
+    return (
+        <>
+            <ArgumentHeaderRow />
+            {/* The wire `offset` is LOGICAL, 0-based inside the payload. The 96-byte header offset is a raw
+                account-slicing detail and must not be added here. */}
+            <ValueRow testId="pmp-write-offset" label="Offset" value={String(content.offset)} />
+
+            {content.chunk !== undefined && (
+                <BaseTable.Row data-testid="pmp-write-chunk">
+                    <BaseTable.Cell colSpan={CARD_TABLE_COLUMNS}>
+                        <div className="mb-1.5">Chunk</div>
+                        {/* A chunk runs to ~1 KB, so it gets the same field the raw payload does: hex/base64
+                            tabs, byte count, copy, download and show-more, rather than a bare HexData grid. */}
+                        <RawDataField data={content.chunk} filename={PMP_WRITE_CHUNK_DOWNLOAD_FILENAME} />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
+
+            {content.chunk === undefined && content.sourceBuffer !== undefined && (
+                <BaseTable.Row data-testid="pmp-write-source-buffer">
+                    <BaseTable.Cell>Source Buffer</BaseTable.Cell>
+                    <BaseTable.Cell colSpan={2} className="text-right">
+                        <div className="flex flex-col items-end gap-1.5">
+                            <Address pubkey={new PublicKey(content.sourceBuffer)} alignRight link />
+                            <span className="text-xs text-neutral-500">
+                                The chunk was copied from this buffer, so it is not in this instruction.
+                            </span>
+                        </div>
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+            )}
+        </>
+    );
+}
+
+function ArgumentHeaderRow() {
+    return (
+        <BaseTable.Row className="bg-dark-background text-dk-xs font-semibold uppercase tracking-[0.08em] text-dark-muted-foreground">
+            <BaseTable.Cell>Argument Name</BaseTable.Cell>
+            <BaseTable.Cell className="text-right" colSpan={2}>
+                Value
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}
+
+function ValueRow({ label, testId, value }: { label: string; testId: string; value: string }) {
+    return (
+        <BaseTable.Row data-testid={testId}>
+            <BaseTable.Cell>{label}</BaseTable.Cell>
+            <BaseTable.Cell colSpan={2} className="text-right font-mono text-xs">
+                {value}
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}

--- a/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
+++ b/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
@@ -23,6 +23,7 @@ import {
     withTokenInfoBatch,
 } from '@storybook-config/decorators';
 import type { Meta, StoryObj } from '@storybook-config/types';
+import { gzip } from 'pako';
 
 const PROGRAM_ID = new PublicKey(PROGRAM_METADATA_PROGRAM_ADDRESS);
 
@@ -95,6 +96,22 @@ export const SetDataInlineJson: Story = {
 
 export const SetDataZlibCompressedJson: Story = {
     args: { ...baseArgs, ix: setDataIx({ compression: Compression.Zlib, content: IDL_DOC, format: Format.Json }) },
+};
+
+export const SetDataOversizedGzip: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.Gzip,
+                data: gzip(new Uint8Array(20480)),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Base58,
+                format: Format.None,
+            }) as Uint8Array,
+            5,
+        ),
+    },
 };
 
 export const SetDataYamlVerbatim: Story = {

--- a/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
+++ b/app/features/decode-instruction-pmp/ui/__stories__/PmpDetailsCard.stories.tsx
@@ -1,0 +1,281 @@
+import { gen } from '@__fixtures__/gen';
+import { PmpDetailsCard } from '@features/decode-instruction-pmp';
+import type { Account, State } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getBufferEncoder,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+    packDirectData,
+    PROGRAM_METADATA_PROGRAM_ADDRESS,
+} from '@solana-program/program-metadata';
+import {
+    nextjsParameters,
+    withCluster,
+    withMockTransactions,
+    withScrollAnchor,
+    withTokenInfoBatch,
+} from '@storybook-config/decorators';
+import type { Meta, StoryObj } from '@storybook-config/types';
+
+const PROGRAM_ID = new PublicKey(PROGRAM_METADATA_PROGRAM_ADDRESS);
+
+const IDL_DOC = JSON.stringify({
+    instructions: [{ name: 'initialize' }],
+    name: 'company_program',
+    version: '1.0.0',
+});
+
+// Account addresses are labelled positionally from the card's static name table, so any keys work here. Seeded
+// so the rendered addresses stay pixel-stable across runs.
+function makeIx(data: Uint8Array, accountCount: number): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: Array.from({ length: accountCount }, (_, index) => ({
+            isSigner: false,
+            isWritable: true,
+            pubkey: gen.publicKey(index),
+        })),
+        programId: PROGRAM_ID,
+    });
+}
+
+function setDataIx({
+    compression,
+    content,
+    dataSource = DataSource.Direct,
+    format,
+}: {
+    compression: Compression;
+    content: string;
+    dataSource?: DataSource;
+    format: Format;
+}) {
+    const packed = packDirectData({ compression, content, encoding: Encoding.Utf8 });
+    return makeIx(
+        getSetDataInstructionDataEncoder().encode({
+            compression: packed.compression,
+            data: packed.data,
+            dataSource,
+            encoding: packed.encoding,
+            format,
+        }) as Uint8Array,
+        5,
+    );
+}
+
+const meta = {
+    component: PmpDetailsCard,
+    decorators: [withCluster, withScrollAnchor, withTokenInfoBatch, withMockTransactions],
+    parameters: nextjsParameters,
+    tags: ['autodocs', 'test'],
+    title: 'Features/DecodeInstructionPmp/PmpDetailsCard',
+} satisfies Meta<typeof PmpDetailsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// `fallback` is never exercised by these stories - every fixture below is a content instruction, so the card
+// always takes its custom-render path. `null` is fine here: stories are exempt from `unicorn/no-null`.
+const baseArgs = {
+    fallback: null,
+    index: 0,
+    result: { err: null },
+};
+
+export const SetDataInlineJson: Story = {
+    args: { ...baseArgs, ix: setDataIx({ compression: Compression.None, content: IDL_DOC, format: Format.Json }) },
+};
+
+export const SetDataZlibCompressedJson: Story = {
+    args: { ...baseArgs, ix: setDataIx({ compression: Compression.Zlib, content: IDL_DOC, format: Format.Json }) },
+};
+
+export const SetDataYamlVerbatim: Story = {
+    args: {
+        ...baseArgs,
+        ix: setDataIx({
+            compression: Compression.None,
+            content: 'name: company\nversion: 1.0.0\n',
+            format: Format.Yaml,
+        }),
+    },
+};
+
+export const SetDataEncodingNoneAsHex: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.None,
+                format: Format.None,
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+// The 4-byte header-only shape. The generated encoder cannot build it, so the bytes are a literal:
+// discriminator 3, encoding Utf8, compression None, format Json.
+export const SetDataHeaderOnly: Story = {
+    args: { ...baseArgs, ix: makeIx(new Uint8Array([3, 1, 0, 1]), 5) },
+};
+
+// A Zlib stream that is not a Zlib stream, so the local decode fallback renders instead of the document.
+export const SetDataDecodeFailure: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.Zlib,
+                data: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+export const SetDataUrlSource: Story = {
+    args: {
+        ...baseArgs,
+        ix: setDataIx({
+            compression: Compression.None,
+            content: 'https://example.com/company-idl.json',
+            dataSource: DataSource.Url,
+            format: Format.Json,
+        }),
+    },
+};
+
+export const InitializeInlineJson: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getInitializeInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new TextEncoder().encode(IDL_DOC),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+                seed: 'idl',
+            }) as Uint8Array,
+            5,
+        ),
+    },
+};
+
+export const WriteChunk: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(
+            getWriteInstructionDataEncoder().encode({
+                data: new TextEncoder().encode('{"instructions":['),
+                offset: 0,
+            }) as Uint8Array,
+            3,
+        ),
+    },
+};
+
+export const WriteFromBuffer: Story = {
+    args: {
+        ...baseArgs,
+        ix: makeIx(getWriteInstructionDataEncoder().encode({ offset: 0 }) as Uint8Array, 3),
+    },
+};
+
+// ===== setData sourced from a buffer account =====
+//
+// `data` is empty, so the payload is not in the instruction - it is in the buffer at account index 2, which the
+// card reads on render. These stories pin index 2 to a legible address the mock accounts cache is seeded against.
+
+const BUFFER_ADDRESS = gen.vanityAddress('BUFFer');
+
+/** A `setData` carrying no inline bytes, naming `BUFFER_ADDRESS` as its source buffer. */
+function setDataFromBufferIx({ compression, format }: { compression: Compression; format: Format }) {
+    const ix = makeIx(
+        getSetDataInstructionDataEncoder().encode({
+            compression,
+            // Empty rather than absent: `data` is a REMAINDER option, so both encode to no bytes, which is
+            // exactly the on-chain shape that means "the payload lives in the buffer account".
+            data: new Uint8Array(0),
+            dataSource: DataSource.Direct,
+            encoding: Encoding.Utf8,
+            format,
+        }) as Uint8Array,
+        5,
+    );
+    ix.keys[2].pubkey = new PublicKey(BUFFER_ADDRESS);
+    return ix;
+}
+
+/** The library's own encoder, so the fixture carries the real 96-byte Buffer header. */
+function bufferAccountEntry(content: string, compression: Compression): State['entries'] {
+    const packed = packDirectData({ compression, content, encoding: Encoding.Utf8 });
+    const raw = getBufferEncoder().encode({
+        authority: PROGRAM_METADATA_PROGRAM_ADDRESS,
+        canonical: true,
+        data: packed.data,
+        program: PROGRAM_METADATA_PROGRAM_ADDRESS,
+        seed: 'idl',
+    }) as Uint8Array;
+
+    const data: Account = {
+        data: { raw },
+        executable: false,
+        lamports: 2_000_000,
+        owner: PROGRAM_ID,
+        pubkey: new PublicKey(BUFFER_ADDRESS),
+        space: raw.length,
+    };
+    return { [BUFFER_ADDRESS]: { data, status: FetchStatus.Fetched } };
+}
+
+export const SetDataFromBufferDecoded: Story = {
+    args: { ...baseArgs, ix: setDataFromBufferIx({ compression: Compression.Zlib, format: Format.Json }) },
+    parameters: { accounts: bufferAccountEntry(IDL_DOC, Compression.Zlib) },
+};
+
+// The buffer is still live, but holds bytes that are not the Zlib stream its instruction hints promise.
+export const SetDataFromBufferDecodeFailure: Story = {
+    args: { ...baseArgs, ix: setDataFromBufferIx({ compression: Compression.Zlib, format: Format.Json }) },
+    parameters: { accounts: bufferAccountEntry(IDL_DOC, Compression.None) },
+};
+
+// The common outcome on a historical transaction: the client closes the source buffer in the same flow to
+// reclaim its rent, so there is nothing left to read. The provider models that as zero lamports and no bytes.
+export const SetDataFromBufferClosed: Story = {
+    args: { ...baseArgs, ix: setDataFromBufferIx({ compression: Compression.Zlib, format: Format.Json }) },
+    parameters: {
+        accounts: {
+            [BUFFER_ADDRESS]: {
+                data: {
+                    data: { raw: new Uint8Array(0) },
+                    executable: false,
+                    lamports: 0,
+                    owner: PROGRAM_ID,
+                    pubkey: new PublicKey(BUFFER_ADDRESS),
+                    space: 0,
+                },
+                status: FetchStatus.Fetched,
+            },
+        } satisfies State['entries'],
+    },
+};
+
+// No cache entry at all, and the mock fetcher is a no-op, so the card stays in its reading state.
+export const SetDataFromBufferLoading: Story = {
+    args: { ...baseArgs, ix: setDataFromBufferIx({ compression: Compression.Zlib, format: Format.Json }) },
+};

--- a/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
@@ -296,6 +296,64 @@ describe('DataPayloadSection', () => {
         expect(screen.getByLabelText('Download')).toBeInTheDocument();
     });
 
+    it('should report both the unpacked and the stored size when an oversized payload was compressed', async () => {
+        renderSection(
+            {
+                config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+                dataSource: DataSource.Direct,
+                kind: 'setData',
+                payload: gzip(new Uint8Array(20480)),
+            },
+            8,
+        );
+        await openDecodedTab();
+
+        const oversized = screen.getByTestId('pmp-payload-oversized');
+        expect(oversized).toHaveTextContent('20480 bytes unpacked from 55 stored');
+        // Sits in the field header beside the 20,480, saying which of the two counts this download carries.
+        expect(screen.getByTestId('pmp-bytes-badge-uncompressed')).toHaveTextContent('uncompressed');
+    });
+
+    it('should badge the Raw tab of a compressed payload with the compression it is still in', async () => {
+        renderSection({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.Gzip),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        expect(screen.getByTestId('pmp-bytes-badge-compressed')).toHaveTextContent('gzipped');
+    });
+
+    it('should badge a Zlib payload by name rather than as gzipped', async () => {
+        renderSection({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.Zlib),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        expect(screen.getByTestId('pmp-bytes-badge-compressed')).toHaveTextContent('zlib');
+    });
+
+    it('should badge no tab of an uncompressed payload', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        // Nothing was unpacked, so the Raw tab's count IS the payload length and there is no distinction to mark.
+        expect(screen.queryByTestId('pmp-bytes-badge-compressed')).not.toBeInTheDocument();
+    });
+
     it('should promise no download when the payload expands past the unpack limit', async () => {
         // What separates this from `oversized`: the unpack was abandoned, so no decompressed bytes exist to copy or
         // download. The panel must not offer an affordance it cannot honour.

--- a/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/DataPayloadSection.spec.tsx
@@ -1,0 +1,458 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { gen } from '@__fixtures__/gen';
+import type { Account } from '@providers/accounts';
+import { FetchStatus } from '@providers/cache';
+import type { Address } from '@solana/kit';
+import { PublicKey } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getBufferEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { gzip } from 'pako';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '@/app/shared/lib/analytics';
+
+import { PMP_ADDRESS } from '../../lib/constants';
+import type { PmpPayloadInstruction } from '../../lib/types';
+import { DataPayloadSection } from '../DataPayloadSection';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+// The on-demand account read goes through the shared accounts provider, so the section is exercised against a
+// controllable cache entry rather than a live RPC.
+const { mockFetchAccountInfo, mockUseAccountInfo } = vi.hoisted(() => ({
+    mockFetchAccountInfo: vi.fn(),
+    mockUseAccountInfo: vi.fn(),
+}));
+
+vi.mock('@providers/accounts', () => ({
+    useAccountInfo: mockUseAccountInfo,
+    useFetchAccountInfo: () => mockFetchAccountInfo,
+}));
+
+vi.mock('@/app/components/common/Address', () => ({
+    Address: ({ pubkey }: { pubkey: { toBase58(): string } }) => <div data-testid="address">{pubkey.toBase58()}</div>,
+}));
+
+const DOC = '{"name":"company","version":"1.0.0"}';
+
+function pack(content: string, compression: Compression): Uint8Array {
+    return packDirectData({ compression, content, encoding: Encoding.Utf8 }).data as Uint8Array;
+}
+
+function renderSection(content: PmpPayloadInstruction, cap?: number) {
+    return render(
+        <table>
+            <tbody>
+                <DataPayloadSection content={content} cap={cap} />
+            </tbody>
+        </table>,
+    );
+}
+
+const JSON_CONFIG = { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Json };
+
+const BUFFER_ADDRESS = gen.address(1);
+const METADATA_ADDRESS = gen.address(2);
+
+/** A `setData` whose bytes live in a foreign buffer, which is the shape that offers the account read. */
+const DEFERRED_SET_DATA: PmpPayloadInstruction = {
+    config: JSON_CONFIG,
+    dataSource: DataSource.Direct,
+    kind: 'setData',
+    sourceBuffer: BUFFER_ADDRESS,
+};
+
+/** The library's own encoder, so the fixture carries the real 96-byte Buffer header. */
+function bufferAccountData(body: Uint8Array): Uint8Array {
+    return getBufferEncoder().encode({
+        authority: BUFFER_ADDRESS as Address,
+        canonical: true,
+        data: body,
+        program: BUFFER_ADDRESS as Address,
+        seed: 'idl',
+    }) as Uint8Array;
+}
+
+function fetchedEntry(raw: Uint8Array | undefined, overrides: { lamports?: number; owner?: string } = {}) {
+    const data: Account = {
+        data: { raw },
+        executable: false,
+        lamports: overrides.lamports ?? 1_000_000,
+        owner: new PublicKey(overrides.owner ?? PMP_ADDRESS),
+        pubkey: new PublicKey(BUFFER_ADDRESS),
+    };
+    return { data, status: FetchStatus.Fetched };
+}
+
+/**
+ * The section opens on the Raw tab and Radix unmounts the inactive panel, so nothing decoded is in the DOM until
+ * the reader switches. Every assertion about decoded content has to go through this first.
+ */
+async function openDecodedTab() {
+    await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+}
+
+describe('DataPayloadSection', () => {
+    beforeEach(() => {
+        vi.mocked(trackEvent).mockClear();
+        mockFetchAccountInfo.mockClear();
+        // Nothing in the cache, which is the state every test starts from - a test that needs a resolved read
+        // sets its own return value.
+        mockUseAccountInfo.mockReset().mockReturnValue(undefined);
+    });
+
+    it('should render an inline Direct JSON payload as a pretty-printed document', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+        await openDecodedTab();
+
+        const decoded = screen.getByTestId('pmp-decoded-text');
+        expect(decoded).toHaveTextContent('company');
+        expect(decoded).toHaveTextContent('1.0.0');
+        // Pretty-printed rather than echoed back verbatim, which is what separates a parsed document from the
+        // verbatim-text fallback a Json payload lands on when its bytes do not parse.
+        expect(decoded.textContent).toContain('\n  "name": "company"');
+    });
+
+    it('should also offer the raw encoded bytes on a Raw tab', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Raw' }));
+
+        // RawDataField owns the hex grid and the byte count, so asserting on them proves it is wired up.
+        const raw = screen.getByTestId('pmp-payload-raw');
+        expect(raw).toHaveTextContent('de ad be ef');
+        expect(raw).toHaveTextContent('4 bytes');
+        expect(screen.getByRole('tab', { name: 'Hex' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Base64' })).toBeInTheDocument();
+    });
+
+    it('should decompress a Zlib payload before rendering it', async () => {
+        renderSection({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.Zlib),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('1.0.0');
+    });
+
+    it('should render a Yaml payload as verbatim text rather than as a parsed document', async () => {
+        renderSection({
+            config: { compression: Compression.None, encoding: Encoding.Utf8, format: Format.Yaml },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack('name: company\n', Compression.None),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('name: company');
+    });
+
+    it('should render an Encoding None payload as hex text rather than as characters', async () => {
+        renderSection({
+            config: { compression: Compression.None, encoding: Encoding.None, format: Format.None },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('deadbeef');
+    });
+
+    it('should render a Json-hinted payload that does not parse as verbatim text', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack('{not json', Compression.None),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('{not json');
+    });
+
+    it('should state that a header-only setData carries no new payload without surfacing a decode failure', () => {
+        renderSection({ config: JSON_CONFIG, kind: 'setData' });
+
+        expect(screen.getByTestId('pmp-header-only-note')).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decode-error')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+    });
+
+    it('should show the source buffer address when setData carries no inline payload', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            sourceBuffer: BUFFER_ADDRESS,
+        });
+
+        expect(screen.getByText('The payload was written to the Source buffer account')).toBeInTheDocument();
+        expect(screen.getByTestId('address')).toHaveTextContent(BUFFER_ADDRESS);
+    });
+
+    it('should show the metadata account when initialize is the in-place shape', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'initialize',
+            metadataAccount: METADATA_ADDRESS,
+            seed: 'idl',
+        });
+
+        expect(screen.getByText('The payload was written to the Metadata account')).toBeInTheDocument();
+        expect(screen.getByTestId('address')).toHaveTextContent(METADATA_ADDRESS);
+    });
+
+    it('should render an External payload through the same tabs, opening on the raw bytes', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.External,
+            kind: 'setData',
+            payload: new Uint8Array(40),
+        });
+
+        // A non-Direct source gets no special-cased note in this section: the card's `Data Source` config row
+        // already names it, so the section stays a plain bytes view rather than repeating the same fact.
+        expect(screen.getByTestId('pmp-payload-raw')).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: 'Decoded' })).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+    });
+
+    it('should render a Url payload pointer as decoded text without resolving it', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Url,
+            kind: 'setData',
+            payload: new TextEncoder().encode('https://example.com/idl.json'),
+        });
+        await openDecodedTab();
+
+        // The decoded panel applies the instruction's own hints to the POINTER bytes - a local decode, not
+        // resolution. For a Url payload that is the URL text itself, and nothing is fetched or linked.
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('https://example.com/idl.json');
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should fall back to the raw view with an inline error note when the payload fails to decode', async () => {
+        renderSection({
+            config: { compression: Compression.Zlib, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: new Uint8Array([1, 2, 3, 4]),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decode-error')).toHaveTextContent('incorrect header check');
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+        // The failed panel no longer repeats a raw view of its own - Raw is a sibling tab, so the bytes stay one
+        // click away. Assert the escape hatch is still reachable rather than that it is mounted right now.
+        expect(screen.getByRole('tab', { name: 'Raw' })).toBeInTheDocument();
+    });
+
+    it('should render a bounded view with the byte count and a download when the payload exceeds the cap', async () => {
+        renderSection(
+            {
+                config: JSON_CONFIG,
+                dataSource: DataSource.Direct,
+                kind: 'setData',
+                payload: new Uint8Array(2048).fill(0x41),
+            },
+            8,
+        );
+        await openDecodedTab();
+
+        const oversized = screen.getByTestId('pmp-payload-oversized');
+        expect(oversized).toHaveTextContent(/too large/i);
+        // The DECOMPRESSED size, which is what the cap is measured on - the on-chain payload here is 2048 bytes
+        // uncompressed, so the two happen to match, but the number reported is the decoded one.
+        expect(oversized).toHaveTextContent('2048 bytes');
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+        // The panel carries its OWN copy/download over the decompressed bytes. The sibling Raw tab is not a
+        // substitute: that one serves the on-chain payload, so for a compressed document it would hand back the
+        // compressed bytes. Without this the Alert's "Copy or download it instead" would point at nothing.
+        expect(oversized).toHaveTextContent(/use download\/copy/i);
+        expect(screen.getByLabelText('Download')).toBeInTheDocument();
+    });
+
+    it('should promise no download when the payload expands past the unpack limit', async () => {
+        // What separates this from `oversized`: the unpack was abandoned, so no decompressed bytes exist to copy or
+        // download. The panel must not offer an affordance it cannot honour.
+        renderSection({
+            config: { compression: Compression.Gzip, encoding: Encoding.Utf8, format: Format.Json },
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: gzip(new Uint8Array(2 * 1024 * 1024)),
+        });
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-payload-unpack-overflow')).toHaveTextContent(/limit for unpacking/i);
+        expect(screen.queryByTestId('pmp-payload-oversized')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+        // Radix unmounts the inactive panel, so the Raw tab's own download is not in the DOM either - the only
+        // Download control that could match here would be one this panel rendered, and it must not render one.
+        expect(screen.queryByLabelText('Download')).not.toBeInTheDocument();
+    });
+
+    it('should emit a tab analytics event when the reader opens the decoded tab', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(trackEvent).toHaveBeenCalledWith('pmp_data_tab_opened', {
+            data_source: 'direct',
+            format: 'json',
+            instruction: 'set_data',
+            source: 'instruction',
+            tab: 'decoded',
+        });
+    });
+
+    it('should carry the data source when the tabs render for a non-Direct payload', async () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Url,
+            kind: 'setData',
+            payload: new TextEncoder().encode('https://example.com/idl.json'),
+        });
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(trackEvent).toHaveBeenCalledWith(
+            'pmp_data_tab_opened',
+            expect.objectContaining({ data_source: 'url', tab: 'decoded' }),
+        );
+    });
+
+    it('should emit no analytics event on mount, before any tab is clicked', () => {
+        renderSection({
+            config: JSON_CONFIG,
+            dataSource: DataSource.Direct,
+            kind: 'setData',
+            payload: pack(DOC, Compression.None),
+        });
+
+        // The default panel must not count as an interaction, or every rendered card inflates the tab counts.
+        expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('should emit no analytics event when there are no tabs to click', () => {
+        renderSection({ config: JSON_CONFIG, kind: 'setData' });
+
+        expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('should read the referenced account on render, as raw bytes', () => {
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(mockFetchAccountInfo).toHaveBeenCalledTimes(1);
+        const [pubkey, dataMode] = mockFetchAccountInfo.mock.calls[0];
+        expect(pubkey.toBase58()).toBe(BUFFER_ADDRESS);
+        // `raw` and not `parsed`: the provider only keeps raw bytes for accounts it could not parse natively, and
+        // a PMP buffer has to arrive as bytes for the generated decoder to see its header at all.
+        expect(dataMode).toBe('raw');
+        expect(screen.getByTestId('pmp-account-loading')).toBeInTheDocument();
+    });
+
+    it('should decode the referenced buffer content once the read resolves', async () => {
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(bufferAccountData(pack(DOC, Compression.None))));
+        renderSection(DEFERRED_SET_DATA);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('"name": "company"');
+        expect(screen.getByRole('tab', { name: 'Raw' })).toBeInTheDocument();
+    });
+
+    it('should say the payload is empty rather than render a blank document', async () => {
+        // `allocate` with no `write` yet leaves a live 96-byte buffer: header, no body. Every encoding decodes zero
+        // bytes to the empty string, so the Decoded panel used to hold an empty `pre` that looked like a document
+        // the reader had to scroll for. Lamports are non-zero, so this is NOT the closed-account shape.
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(bufferAccountData(new Uint8Array(0))));
+        renderSection(DEFERRED_SET_DATA);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-payload-empty')).toHaveTextContent(/payload is empty/i);
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-account-absent')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-decode-error')).not.toBeInTheDocument();
+    });
+
+    it('should say the account is gone rather than fail when the buffer was closed', () => {
+        // The provider's closed-account shape, and the common outcome on a historical setData: the client closes
+        // the source buffer in the same flow to reclaim its rent.
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(new Uint8Array(0), { lamports: 0 }));
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-absent')).toHaveTextContent(/does not exist on chain/i);
+        expect(screen.queryByTestId('pmp-account-unreadable')).not.toBeInTheDocument();
+    });
+
+    it('should warn when the referenced account is not owned by the Program Metadata Program', () => {
+        mockUseAccountInfo.mockReturnValue(
+            fetchedEntry(bufferAccountData(pack(DOC, Compression.None)), { owner: BUFFER_ADDRESS }),
+        );
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-unreadable')).toHaveTextContent(BUFFER_ADDRESS);
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+    });
+
+    it('should request the bytes when the cached entry was fetched without them', () => {
+        // The inspector fetches every account in the message in `skip` mode (`AddressWithContext`), which caches
+        // the account with no bytes under the same key this hook reads. Decoding that entry reported a live
+        // buffer as "shorter than the 96-byte header", intermittently, depending on which fetch settled last.
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(undefined, { lamports: 2_000_000 }));
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(mockFetchAccountInfo).toHaveBeenCalledTimes(1);
+        expect(mockFetchAccountInfo.mock.calls[0][1]).toBe('raw');
+        expect(screen.getByTestId('pmp-account-loading')).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-account-unreadable')).not.toBeInTheDocument();
+    });
+
+    it('should surface an RPC failure as its own state', () => {
+        mockUseAccountInfo.mockReturnValue({ status: FetchStatus.FetchFailed });
+        renderSection(DEFERRED_SET_DATA);
+
+        expect(screen.getByTestId('pmp-account-failed')).toBeInTheDocument();
+    });
+
+    it('should mark a tab switch on account content as its own source', async () => {
+        mockUseAccountInfo.mockReturnValue(fetchedEntry(bufferAccountData(pack(DOC, Compression.None))));
+        renderSection(DEFERRED_SET_DATA);
+
+        await openDecodedTab();
+
+        // Without `source` the account panel's switches would be indistinguishable from the inline panel's.
+        expect(trackEvent).toHaveBeenCalledWith(
+            'pmp_data_tab_opened',
+            expect.objectContaining({ source: 'account', tab: 'decoded' }),
+        );
+    });
+});

--- a/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
+++ b/app/features/decode-instruction-pmp/ui/__tests__/PmpDetailsCard.spec.tsx
@@ -1,0 +1,196 @@
+import { gen } from '@__fixtures__/gen';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getAllocateInstructionDataEncoder,
+    getInitializeInstructionDataEncoder,
+    getSetDataInstructionDataEncoder,
+    getWriteInstructionDataEncoder,
+    packDirectData,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PMP_ADDRESS } from '../../lib/constants';
+import { PmpDetailsCard } from '../PmpDetailsCard';
+
+vi.mock('@/app/shared/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+vi.mock('@/app/components/instruction/InstructionCard', () => ({
+    InstructionCard: ({ children, title }: { children: React.ReactNode; title: string }) => (
+        <div data-testid="instruction-card">
+            <div data-testid="instruction-card-title">{title}</div>
+            <table>
+                <tbody>{children}</tbody>
+            </table>
+        </div>
+    ),
+}));
+
+vi.mock('@/app/components/common/Address', () => ({
+    Address: ({ pubkey, overrideText }: { pubkey: PublicKey; overrideText?: string }) => (
+        <div data-testid="address">{overrideText ?? pubkey.toBase58()}</div>
+    ),
+}));
+
+vi.mock('@/app/components/common/Copyable', () => ({
+    Copyable: ({ children }: { children: React.ReactNode }) => <div data-testid="copyable">{children}</div>,
+}));
+
+const PMP = new PublicKey(PMP_ADDRESS);
+const AUTHORITY = gen.publicKey(0);
+const FOREIGN_BUFFER = gen.publicKey(1);
+const METADATA_PDA = gen.publicKey(2);
+const DOC = '{"name":"company","version":"1.0.0"}';
+
+function makeIx(data: Uint8Array, accounts: PublicKey[]): TransactionInstruction {
+    return new TransactionInstruction({
+        data: Buffer.from(data),
+        keys: accounts.map(pubkey => ({ isSigner: false, isWritable: true, pubkey })),
+        programId: PMP,
+    });
+}
+
+function renderCard(ix: TransactionInstruction) {
+    return render(
+        <PmpDetailsCard ix={ix} index={0} result={{ err: null }} fallback={<div data-testid="injected-fallback" />} />,
+    );
+}
+
+/** The payload section opens on the Raw tab and Radix unmounts the inactive panel. See DataPayloadSection.spec. */
+async function openDecodedTab() {
+    await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+}
+
+describe('PmpDetailsCard', () => {
+    it('should render a titled Set Data card with named accounts, config rows and the decoded document', async () => {
+        const packed = packDirectData({ compression: Compression.Zlib, content: DOC, encoding: Encoding.Utf8 });
+        const ix = makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: packed.compression,
+                data: packed.data,
+                dataSource: DataSource.Direct,
+                encoding: packed.encoding,
+                format: Format.Json,
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        // Labels mirror CodamaInstructionCard's style on purpose, so an `allocate` card in the same transaction
+        // reads identically. 'ProgramData' is not a typo for 'Program Data'.
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: SetData');
+        expect(screen.getByTestId('account-row-0')).toHaveTextContent('Metadata');
+        expect(screen.getByTestId('account-row-1')).toHaveTextContent('Authority');
+        expect(screen.getByTestId('account-row-4')).toHaveTextContent('ProgramData');
+        expect(screen.getByTestId('pmp-config-encoding')).toHaveTextContent('UTF-8');
+        expect(screen.getByTestId('pmp-config-compression')).toHaveTextContent('Zlib');
+        expect(screen.getByTestId('pmp-config-format')).toHaveTextContent('JSON');
+        expect(screen.getByTestId('pmp-config-data-source')).toHaveTextContent('Direct');
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('company');
+    });
+
+    it('should render the updated hints and the header-only note for a 4-byte setData', () => {
+        renderCard(makeIx(new Uint8Array([3, 1, 0, 1]), [METADATA_PDA, AUTHORITY, PMP]));
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: SetData');
+        expect(screen.getByTestId('pmp-config-format')).toHaveTextContent('JSON');
+        expect(screen.getByTestId('pmp-header-only-note')).toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-config-data-source')).not.toBeInTheDocument();
+    });
+
+    it('should render an Initialize card with its seed and decoded document', async () => {
+        const ix = makeIx(
+            getInitializeInstructionDataEncoder().encode({
+                compression: Compression.None,
+                data: new TextEncoder().encode(DOC),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+                seed: 'idl',
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: Initialize');
+        expect(screen.getByTestId('pmp-config-seed')).toHaveTextContent('idl');
+        expect(screen.getByTestId('account-row-4')).toHaveTextContent('System');
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('1.0.0');
+    });
+
+    it('should show a Write card with its offset and raw chunk and no decoded document', () => {
+        const ix = makeIx(
+            getWriteInstructionDataEncoder().encode({
+                data: new Uint8Array([0xde, 0xad]),
+                offset: 96,
+            }) as Uint8Array,
+            [FOREIGN_BUFFER, AUTHORITY, PMP],
+        );
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('instruction-card-title')).toHaveTextContent('ProgramMetadata: Write');
+        expect(screen.getByTestId('pmp-write-offset')).toHaveTextContent('96');
+        // RawDataField owns the hex grid and the byte count inside the Chunk row.
+        expect(screen.getByTestId('pmp-write-chunk')).toHaveTextContent('de ad');
+        expect(screen.getByTestId('pmp-write-chunk')).toHaveTextContent('2 bytes');
+        expect(screen.queryByTestId('pmp-decoded-text')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('pmp-payload-section')).not.toBeInTheDocument();
+    });
+
+    it('should show the source buffer note for a Write that copies from another buffer', () => {
+        const ix = makeIx(getWriteInstructionDataEncoder().encode({ offset: 0 }) as Uint8Array, [
+            METADATA_PDA,
+            AUTHORITY,
+            FOREIGN_BUFFER,
+        ]);
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('pmp-write-source-buffer')).toHaveTextContent(FOREIGN_BUFFER.toBase58());
+        expect(screen.queryByTestId('pmp-write-chunk')).not.toBeInTheDocument();
+    });
+
+    it('should render the injected fallback for a housekeeping instruction', () => {
+        const ix = makeIx(getAllocateInstructionDataEncoder().encode({ seed: 'idl' }) as Uint8Array, [
+            METADATA_PDA,
+            AUTHORITY,
+        ]);
+
+        renderCard(ix);
+
+        expect(screen.getByTestId('injected-fallback')).toBeInTheDocument();
+        expect(screen.queryByTestId('instruction-card')).not.toBeInTheDocument();
+    });
+
+    it('should keep the account and config tables when the payload fails to decode', async () => {
+        const ix = makeIx(
+            getSetDataInstructionDataEncoder().encode({
+                compression: Compression.Zlib, // a Zlib stream that is not one
+                data: new Uint8Array([1, 2, 3, 4]),
+                dataSource: DataSource.Direct,
+                encoding: Encoding.Utf8,
+                format: Format.Json,
+            }) as Uint8Array,
+            [METADATA_PDA, AUTHORITY, PMP, PMP, PMP],
+        );
+
+        renderCard(ix);
+        await openDecodedTab();
+
+        expect(screen.getByTestId('pmp-decode-error')).toBeInTheDocument();
+        expect(screen.getByTestId('account-row-0')).toHaveTextContent('Metadata');
+        expect(screen.getByTestId('pmp-config-encoding')).toHaveTextContent('UTF-8');
+        expect(screen.getByTestId('pmp-config-compression')).toHaveTextContent('Zlib');
+        expect(screen.queryByTestId('injected-fallback')).not.toBeInTheDocument();
+    });
+});

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -33,6 +33,7 @@ import {
 } from '@explorer/decoder-serum/detection';
 import { AssociatedTokenDetailsCard } from '@features/decode-instruction-associated-token';
 import { isLighthouseInstruction, LighthouseDetailsCard } from '@features/decode-instruction-lighthouse';
+import { isProgramMetadataInstruction } from '@features/decode-instruction-pmp/detection';
 import { IdlInstructionCard, useIdlInstructionDecode } from '@features/decode-instruction-with-idl';
 import { MetaplexTokenMetadataDetailsCard } from '@features/mpl-token-metadata';
 import { isStakeInstruction, RawStakeDetailsCard, StakeDetailsCard } from '@features/stake';
@@ -70,6 +71,14 @@ const SerumDetailsCard = dynamic(
     () => import('@features/instruction-program-serum').then(mod => mod.SerumDetailsCard),
     { ssr: false },
 );
+
+// The PMP card carries the generated client plus pako/yaml/smol-toml (~35 kB gzip), which only a transaction that
+// actually touches the program needs. `isProgramMetadataInstruction` comes from the light `/detection` entry so
+// the branch above can stay static.
+const PmpDetailsCard = dynamic(() => import('@features/decode-instruction-pmp').then(mod => mod.PmpDetailsCard), {
+    loading: () => <LoadingCard />,
+    ssr: false,
+});
 
 export type InstructionDetailsProps = {
     tx: ParsedTransaction;
@@ -354,6 +363,26 @@ function InstructionCard({
             <ErrorBoundary fallback={<UnknownDetailsCard {...props} />} key={key}>
                 <MetaplexTokenMetadataDetailsCard {...props} />
             </ErrorBoundary>
+        );
+    }
+    // PMP owns every instruction on its program id: `setData`/`initialize`/`write` render decoded content from
+    // the bundled typed decoders (no IDL needed), and the housekeeping instructions delegate to the IDL tier
+    // from inside the card. Must sit before the generic idlDecode tier so it wins for the content instructions.
+    if (isProgramMetadataInstruction(transactionIx)) {
+        return (
+            <PmpDetailsCard
+                key={key}
+                {...props}
+                // The card cannot import the IDL feature (boundaries/dependencies), so this surface decides what
+                // a non-content PMP instruction falls back to. Same two outcomes as before the branch existed.
+                fallback={
+                    idlDecode ? (
+                        <IdlInstructionCard decoded={idlDecode} {...props} />
+                    ) : (
+                        <UnknownDetailsCard {...props} />
+                    )
+                }
+            />
         );
     }
     if (idlDecode) {

--- a/app/features/transaction/ui/__tests__/InstructionsSection-Pmp.spec.tsx
+++ b/app/features/transaction/ui/__tests__/InstructionsSection-Pmp.spec.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
+import { DEFAULT_SIGNATURE, gen } from '@__fixtures__/gen';
+import { PMP_ADDRESS } from '@features/decode-instruction-pmp';
+import { type ParsedTransaction, PublicKey } from '@solana/web3.js';
+import {
+    Compression,
+    DataSource,
+    Encoding,
+    Format,
+    getSetDataInstructionDataEncoder,
+} from '@solana-program/program-metadata';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import bs58 from 'bs58';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { InstructionParserProvider } from '@/app/entities/instruction-parser';
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { TransactionsProvider } from '@/app/providers/transactions';
+import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
+
+import { InstructionsSection } from '../InstructionsSection';
+
+const SIGNATURE = DEFAULT_SIGNATURE;
+const AUTHORITY = gen.publicKey(0);
+const METADATA = gen.publicKey(2);
+
+const SET_DATA = getSetDataInstructionDataEncoder().encode({
+    compression: Compression.None,
+    data: new TextEncoder().encode('{"name":"company","version":"1.0.0"}'),
+    dataSource: DataSource.Direct,
+    encoding: Encoding.Utf8,
+    format: Format.Json,
+}) as Uint8Array;
+
+// A minimal ParsedTransaction with one PMP instruction. `intoTransactionInstruction` looks each ix account up in
+// `message.accountKeys` and base58-decodes `data`, so both have to line up for the raw path to produce an ix.
+// Built once at module scope for a stable identity across renders. Safe to reference from the vi.mock factory
+// below even though vi.mock is hoisted, because it is only ever READ inside the returned arrow, which runs at
+// render time. `as unknown as` because the fixture carries only the fields the section actually reads.
+const PARSED_TX = {
+    message: {
+        accountKeys: [
+            { pubkey: METADATA, signer: false, source: 'transaction', writable: true },
+            { pubkey: AUTHORITY, signer: true, source: 'transaction', writable: false },
+        ],
+        addressTableLookups: null,
+        instructions: [
+            {
+                accounts: [METADATA, AUTHORITY],
+                data: bs58.encode(SET_DATA),
+                programId: new PublicKey(PMP_ADDRESS),
+            },
+        ],
+        recentBlockhash: PublicKey.default.toBase58(),
+    },
+    signatures: [SIGNATURE],
+} as unknown as ParsedTransaction;
+
+vi.mock('swr', () => ({
+    __esModule: true,
+    default: vi.fn(() => ({
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+    })),
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/'),
+    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+vi.mock('next/link', () => ({
+    __esModule: true,
+    default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+// Override only the two cache reads the section makes. `importOriginal` keeps `TransactionsProvider` real, so the
+// raw-details context the InstructionCard reads is still there.
+vi.mock('@providers/transactions', async importOriginal => ({
+    ...(await importOriginal<typeof import('@providers/transactions')>()),
+    useTransactionDetails: vi.fn(() => ({
+        data: { transactionWithMeta: { meta: null, slot: 1, transaction: PARSED_TX } },
+    })),
+    useTransactionStatus: vi.fn(() => ({ data: { info: { result: { err: null } } } })),
+}));
+
+describe('Transaction page InstructionsSection with a Program Metadata instruction', () => {
+    test('should decode and render an inline setData payload with no IDL resolved', async () => {
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <TransactionsProvider>
+                        <AccountsProvider>
+                            <InstructionParserProvider dispatcher={instructionParserDispatcher}>
+                                <InstructionsSection signature={SIGNATURE} />
+                            </InstructionParserProvider>
+                        </AccountsProvider>
+                    </TransactionsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(await screen.findByText(/ProgramMetadata: SetData/i)).toBeInTheDocument();
+
+        // The section opens on the Raw tab and Radix unmounts the inactive panel, so the decoded document is only
+        // in the DOM once the reader switches.
+        await userEvent.click(screen.getByRole('tab', { name: 'Decoded' }));
+
+        expect(screen.getByTestId('pmp-decoded-text')).toHaveTextContent('company');
+    });
+});


### PR DESCRIPTION
## Description

Decodes, unpacks (when compressed) and renders the metadata data payload that a Program Metadata Program (PMP).
`setData` / `initialize` / `write` instruction carries **inline** and Buffer account data, on both the transaction page and the inspector.

PMP instructions previously fell through to the generic Codama/IDL `IdlInstructionCard`.
The new `PmpDetailsCard` is now the single entry point for **every** PMP instruction. It custom-renders the three data-carrying instructions and delegates the six ones (`allocate`, `setAuthority`, `setImmutable`, `trim`, `extend`, `close`) to the the IDL card when an IDL resolved and the Unknown card when it didn't (**Behaviour for those six is unchanged**).

Added **New feature slice** `app/features/decode-instruction-pmp`:

## Type of change

<!-- Check the appropriate options that apply to this PR -->

-   [x] Bug fix
-   [x] New feature

## Screenshots

<img width="1013" height="901" alt="image" src="https://github.com/user-attachments/assets/8b0de673-61a9-4e32-92d0-358806a06c51" />

<img width="1013" height="901" alt="image" src="https://github.com/user-attachments/assets/b49ac022-9004-4f74-96fb-e068729e6533" />

<img width="976" height="814" alt="image" src="https://github.com/user-attachments/assets/ddb2f5ce-e133-4333-8565-394a68c5893b" />

<img width="979" height="998" alt="image" src="https://github.com/user-attachments/assets/b2ffbfe4-d840-46d3-8102-6ef035228d62" />

<img width="822" height="602" alt="image" src="https://github.com/user-attachments/assets/bfa38fcb-8f4e-46a8-8b26-f5f47c73b7c6" />

<img width="990" height="893" alt="image" src="https://github.com/user-attachments/assets/8cbe9c4c-0a9b-4479-be83-09a43050c029" />


## Testing

| Case | Preview | Cluster |
| --- | --- | --- |
| Existing buffer account | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/5fD8uKYsuZcGJAA38BCsyqGqfJcT4WRjLnxFPf5it2MHS69rzRzFZ8xPZSP6PVRsj3EE8xse7jEqMqSccPCvYUF6#ix-2) | [mainnet](https://explorer.solana.com/tx/5fD8uKYsuZcGJAA38BCsyqGqfJcT4WRjLnxFPf5it2MHS69rzRzFZ8xPZSP6PVRsj3EE8xse7jEqMqSccPCvYUF6#ix-2) |
| Closed buffer account | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/3mKzWnSVpgXprYnaVZJdtqCAdbTyTdCKM4xMewrofBqE7KpJ9pxwvD4hSky3uCMtnXxtEponB4om1kWZm5jHADS1) | [mainnet](https://explorer.solana.com/tx/3mKzWnSVpgXprYnaVZJdtqCAdbTyTdCKM4xMewrofBqE7KpJ9pxwvD4hSky3uCMtnXxtEponB4om1kWZm5jHADS1) |
| `write` and `initialize` | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/2otipHMe3P3GRr62nuey3Bkbi1szaoe6PMdtYMSDhUsZPEB5xoxSrMYQYYC4caKqTq8Y1qfHaW2UbMrHBxYDboLN) | [mainnet](https://explorer.solana.com/tx/2otipHMe3P3GRr62nuey3Bkbi1szaoe6PMdtYMSDhUsZPEB5xoxSrMYQYYC4caKqTq8Y1qfHaW2UbMrHBxYDboLN) |
| `setData` with `data` argument payload | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/5fD8uKYsuZcGJAA38BCsyqGqfJcT4WRjLnxFPf5it2MHS69rzRzFZ8xPZSP6PVRsj3EE8xse7jEqMqSccPCvYUF6) | [mainnet](https://explorer.solana.com/tx/5fD8uKYsuZcGJAA38BCsyqGqfJcT4WRjLnxFPf5it2MHS69rzRzFZ8xPZSP6PVRsj3EE8xse7jEqMqSccPCvYUF6) |
| `allocate` + `write` | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/2Rf2iQ5Jd4u46y5LJnzsEkoFpCCWuhxBSj5QfYGQ1bgDnEnAdzCwirNhWF4XMnATGQWsjo7PAeaJGrMuAP7M2kDX) | [mainnet](https://explorer.solana.com/tx/2Rf2iQ5Jd4u46y5LJnzsEkoFpCCWuhxBSj5QfYGQ1bgDnEnAdzCwirNhWF4XMnATGQWsjo7PAeaJGrMuAP7M2kDX) |
| Inspector | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/inspector?message=gAEABQi6NZ9IWKplwVwEZQcCg5W%252FW2e1HNg41wL9Hhb8xJlpvYFR%252FCRr3l7hXC7QagGd%252B1%252F3tV6P1eDZ6oi9FpA%252B%252B2zzplLrXgOGo0rT%252F6UsnULUJyyZUi55TOYDMIVayWEIA9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm%252FlIRcy%252F%252BytunLDm%252Be8jOW7xfcSayxDmzpAAAAAu8d3r7po8BI%252BwMTRt%252B6JbpMBySnFWga6lRghWCWMFan2Ut%252BkcbYo2FJZtmowJriXSbouQCF%252BNtr%252FvuoVY9Q7hwXbF57DPpP5S8MhVwfk%252BwR0PsmvqEoboG9odov2ZTiJQBH3DNgrA9WBcInS2JpukN3ZjRC%252FHaU%252Fpop7ZRFHCogDBAAJA6CGAQAAAAAAAwIAAgwCAAAA0B%252BXAAAAAAAHBQIAAQUGBQMBAgAAAA%253D%253D) | [mainnet](https://explorer.solana.com/tx/inspector?message=gAEABQi6NZ9IWKplwVwEZQcCg5W%252FW2e1HNg41wL9Hhb8xJlpvYFR%252FCRr3l7hXC7QagGd%252B1%252F3tV6P1eDZ6oi9FpA%252B%252B2zzplLrXgOGo0rT%252F6UsnULUJyyZUi55TOYDMIVayWEIA9cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMGRm%252FlIRcy%252F%252BytunLDm%252Be8jOW7xfcSayxDmzpAAAAAu8d3r7po8BI%252BwMTRt%252B6JbpMBySnFWga6lRghWCWMFan2Ut%252BkcbYo2FJZtmowJriXSbouQCF%252BNtr%252FvuoVY9Q7hwXbF57DPpP5S8MhVwfk%252BwR0PsmvqEoboG9odov2ZTiJQBH3DNgrA9WBcInS2JpukN3ZjRC%252FHaU%252Fpop7ZRFHCogDBAAJA6CGAQAAAAAAAwIAAgwCAAAA0B%252BXAAAAAAAHBQIAAQUGBQMBAgAAAA%253D%253D) |
| TOML payload | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/gv4RZZZybvmREwibFwfboDtB2vHNQtFsZcfPUZ6fAWwGzWrVEzP8DQHDxShZYdiHnJbLvzkZup52SEJcbyT8qGh?cluster=devnet) | [devnet](https://explorer.solana.com/tx/gv4RZZZybvmREwibFwfboDtB2vHNQtFsZcfPUZ6fAWwGzWrVEzP8DQHDxShZYdiHnJbLvzkZup52SEJcbyT8qGh?cluster=devnet) |
| `setData`, inline gzip JSON -> OVERSIZED. Utf8 / Gzip / Json, 505 B ix data, 500 B payload, 409,670 B unpacked > 256 KB render cap | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/4kNwV87VUL96t3zRDKK65JW1pX2vWG1mM9e9Jb3HAodwyq2FJJ3JqntFDaa8up2hL5KESmNXZVgTdqtzpKvyuw46?cluster=devnet) | [devnet](https://explorer.solana.com/tx/4kNwV87VUL96t3zRDKK65JW1pX2vWG1mM9e9Jb3HAodwyq2FJJ3JqntFDaa8up2hL5KESmNXZVgTdqtzpKvyuw46?cluster=devnet) |
| `setData` + `trim`, inline gzip -> OVERSIZED (base58 quadratic-decode budget). Base58 / Gzip / None, 60 B ix data, 55 B payload, 20,480 B unpacked > 16 KB budget | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/3PQ7JcXbohxjsNF6fbA48B1ehLHDAirsmZywYb17k23ECb7fdKFLLvXSh1hNbxXsxzL3uPnQ5L4HT8NHLnwnqK8M?cluster=devnet) | [devnet](https://explorer.solana.com/tx/3PQ7JcXbohxjsNF6fbA48B1ehLHDAirsmZywYb17k23ECb7fdKFLLvXSh1hNbxXsxzL3uPnQ5L4HT8NHLnwnqK8M?cluster=devnet) |
| `setData`, buffer gzip. UTF-8 / Gzip / JSON | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/tx/5nzAVaW4ph3kX8iiHFYH9NaZjehZKdMEDZkLARHyPpo4zPN9yhV8XmNSQzqysjXQQggKnbDCzZzUrZzCxpnSZYfc?cluster=devnet) | [devnet](https://explorer.solana.com/tx/5nzAVaW4ph3kX8iiHFYH9NaZjehZKdMEDZkLARHyPpo4zPN9yhV8XmNSQzqysjXQQggKnbDCzZzUrZzCxpnSZYfc?cluster=devnet) |
| Any other PMP instruction renders unchanged (pick from the list) | [preview](https://explorer-git-fork-hoodieshq-hoo-943-pa-07fdb7-solana-foundation.vercel.app/address/ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S) | [mainnet](https://explorer.solana.com/address/ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S) |


## Related issues

[HOO-943](https://linear.app/solana-fndn/issue/HOO-943/parse-program-metadata-program-buffer-accounts-in-inspector)

## Checklist

<!-- Verify that you have completed the following before requesting review -->

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes
