### PR TITLE
feat(stake): show lifetime total reward on the stake delegation card

### DIFF
--- a/app/api/stake-rewards/[address]/__tests__/route.spec.ts
+++ b/app/api/stake-rewards/[address]/__tests__/route.spec.ts
@@ -1,0 +1,320 @@
+import { SignatureHistoryUnavailableError } from '@entities/stake-rewards/server';
+import {
+    makeStakeAccount,
+    makeUndelegatedStakeAccount,
+    makeUnparsedAccount,
+    STAKE_ACCOUNT_ADDRESS,
+} from '@features/stake/__fixtures__/stake-account';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Logger } from '@/app/shared/lib/logger';
+import { Cluster } from '@/app/utils/cluster';
+
+const mocks = vi.hoisted(() => ({
+    getAccountInfo: vi.fn(),
+    getEpochInfo: vi.fn(),
+    getOldestSignatureSlot: vi.fn(),
+    sumInflationRewards: vi.fn(),
+}));
+
+// The sweep and the epoch-range rule have their own specs. This one covers the transport edge:
+// param parsing, the not-a-stake-account guard, response shaping, cache headers, and the
+// error-to-HTTP policy.
+vi.mock('@entities/stake-rewards/server', async () => {
+    const actual = await vi.importActual<typeof import('@entities/stake-rewards/server')>(
+        '@entities/stake-rewards/server',
+    );
+    return {
+        ...actual,
+        getOldestSignatureSlot: mocks.getOldestSignatureSlot,
+        sumInflationRewards: mocks.sumInflationRewards,
+    };
+});
+
+// Only `createSolanaRpc` is replaced. `address()` stays real, so the invalid-address case still
+// exercises the route's own guard rather than a mock's.
+vi.mock('@solana/kit', async () => {
+    const actual = await vi.importActual<typeof import('@solana/kit')>('@solana/kit');
+    return {
+        ...actual,
+        createSolanaRpc: () => ({
+            getAccountInfo: () => ({ send: mocks.getAccountInfo }),
+            getEpochInfo: () => ({ send: mocks.getEpochInfo }),
+        }),
+    };
+});
+
+describe('GET /api/stake-rewards/[address]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(Logger, 'warn').mockImplementation(() => {});
+        mocks.getEpochInfo.mockResolvedValue(EPOCH_INFO);
+        mocks.getAccountInfo.mockResolvedValue({ value: makeStakeAccount() });
+        // Created in epoch 943, the epoch it was also delegated in.
+        mocks.getOldestSignatureSlot.mockResolvedValue(407_506_361n);
+        mocks.sumInflationRewards.mockResolvedValue(4200824);
+    });
+
+    it('should return the total with its epoch range and CDN cache headers', async () => {
+        const response = await callRoute();
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ fromEpoch: 943, toEpoch: 1011, totalReward: 4200824 });
+        expect(response.headers.get('Cache-Control')).toContain('s-maxage=14400');
+    });
+
+    it('should sweep only the account own epoch range', async () => {
+        await callRoute();
+
+        expect(mocks.sumInflationRewards).toHaveBeenCalledWith(
+            expect.objectContaining({ range: { fromEpoch: 943, toEpoch: 1011 } }),
+        );
+    });
+
+    it('should start the sweep at the creation epoch when the account has been re-delegated', async () => {
+        // The shape measured on `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs`: delegated in 1005,
+        // but created in slot 364,763,481, which is epoch 844. Sweeping from 1005 would have
+        // reported 10,482,997 lamports of the 55,208,535 the account actually earned.
+        mocks.getAccountInfo.mockResolvedValue({ value: makeStakeAccount({ activationEpoch: '1005' }) });
+        mocks.getOldestSignatureSlot.mockResolvedValue(364_763_481n);
+
+        await callRoute();
+
+        expect(mocks.sumInflationRewards).toHaveBeenCalledWith(
+            expect.objectContaining({ range: { fromEpoch: 844, toEpoch: 1011 } }),
+        );
+    });
+
+    it('should return an uncached 502 rather than a short total when the account cannot be dated', async () => {
+        mocks.getOldestSignatureSlot.mockRejectedValue(new SignatureHistoryUnavailableError('too many signatures'));
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({ error: 'Cannot determine account creation epoch' });
+        expect(response.headers.get('Cache-Control')).toBeNull();
+    });
+
+    it('should not sweep any epoch when the account cannot be dated', async () => {
+        mocks.getOldestSignatureSlot.mockRejectedValue(new SignatureHistoryUnavailableError('too many signatures'));
+
+        await callRoute();
+
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+        expect(Logger.warn).toHaveBeenCalledWith(
+            '[api:stake-rewards] Could not date the account from its signature history',
+            expect.objectContaining({ reason: 'too many signatures' }),
+        );
+    });
+
+    it('should fail rather than fall back to a short total when the signature lookup fails', async () => {
+        mocks.getOldestSignatureSlot.mockRejectedValue(new Error('rpc down'));
+
+        expect((await callRoute()).status).toBe(502);
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should stop the range at the deactivation epoch', async () => {
+        mocks.getAccountInfo.mockResolvedValue({ value: makeStakeAccount({ deactivationEpoch: '1000' }) });
+
+        await callRoute();
+
+        expect(mocks.sumInflationRewards).toHaveBeenCalledWith(
+            expect.objectContaining({ range: { fromEpoch: 943, toEpoch: 1000 } }),
+        );
+    });
+
+    it('should return zero without sweeping when the account has no completed epochs', async () => {
+        mocks.getAccountInfo.mockResolvedValue({ value: makeStakeAccount({ activationEpoch: '1012' }) });
+        // Created in epoch 1012 as well — a brand new account, delegated on the spot.
+        mocks.getOldestSignatureSlot.mockResolvedValue(437_200_000n);
+
+        const response = await callRoute();
+
+        expect(await response.json()).toEqual({ totalReward: 0 });
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should still sweep an older account delegated this epoch, which may have earned before', async () => {
+        // Delegated this epoch but created in 943, so an earlier delegation could have paid it.
+        // Bounding this by `activationEpoch` is exactly the case that reported a short total.
+        mocks.getAccountInfo.mockResolvedValue({ value: makeStakeAccount({ activationEpoch: '1012' }) });
+
+        await callRoute();
+
+        expect(mocks.sumInflationRewards).toHaveBeenCalledWith(
+            expect.objectContaining({ range: { fromEpoch: 943, toEpoch: 1011 } }),
+        );
+    });
+
+    it('should return 400 when the cluster param is missing', async () => {
+        expect((await callRoute({ omitCluster: true })).status).toBe(400);
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when the cluster param is not a known cluster', async () => {
+        expect((await callRoute({ cluster: '99' })).status).toBe(400);
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when the address is not valid base58', async () => {
+        expect((await callRoute({ address: 'not-an-address' })).status).toBe(400);
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when the account does not exist', async () => {
+        mocks.getAccountInfo.mockResolvedValue(MISSING_ACCOUNT);
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({ error: 'Account not found' });
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when the address is not a stake account', async () => {
+        mocks.getAccountInfo.mockResolvedValue({ value: makeUnparsedAccount() });
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Not a stake account' });
+    });
+
+    it('should tell an undelegated stake account apart from a missing one', async () => {
+        mocks.getAccountInfo.mockResolvedValue({ value: makeUndelegatedStakeAccount() });
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({ error: 'Stake account has never been delegated' });
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should not cache a client error', async () => {
+        mocks.getAccountInfo.mockResolvedValue(MISSING_ACCOUNT);
+
+        expect((await callRoute()).headers.get('Cache-Control')).toBeNull();
+    });
+
+    it('should return an uncached 502 when the sweep fails', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(new Error('rpc down'));
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(502);
+        expect(response.headers.get('Cache-Control')).toBeNull();
+        expect(Logger.warn).toHaveBeenCalled();
+    });
+
+    it('should not return a partial total when the sweep fails', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(new Error('rpc down'));
+
+        expect(await (await callRoute()).json()).not.toHaveProperty('totalReward');
+    });
+
+    it('should bound the RPC calls that precede the sweep with a timeout', async () => {
+        await callRoute();
+
+        const boundedCall = expect.objectContaining({ abortSignal: expect.any(AbortSignal) });
+        expect(mocks.getEpochInfo).toHaveBeenCalledWith(boundedCall);
+        expect(mocks.getAccountInfo).toHaveBeenCalledWith(boundedCall);
+    });
+
+    it('should return 504 rather than 502 when the sweep times out', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(makeTimeoutError());
+
+        const response = await callRoute();
+
+        expect(response.status).toBe(504);
+        expect(await response.json()).toEqual({ error: 'Upstream RPC timeout' });
+        expect(Logger.warn).toHaveBeenCalled();
+    });
+
+    it('should return 504 when an RPC call before the sweep times out', async () => {
+        mocks.getAccountInfo.mockRejectedValue(makeTimeoutError());
+
+        expect((await callRoute()).status).toBe(504);
+        expect(mocks.sumInflationRewards).not.toHaveBeenCalled();
+    });
+
+    it('should report a timeout to Sentry with the range it was sweeping', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(makeTimeoutError());
+
+        await callRoute();
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            // A static message, so every timeout groups into one Sentry issue.
+            '[api:stake-rewards] Timed out resolving total reward',
+            expect.objectContaining({
+                sentry: true,
+                // Only `sentryExtras` reaches Sentry, so the diagnostics must live there.
+                sentryExtras: expect.objectContaining({
+                    address: STAKE_ACCOUNT_ADDRESS,
+                    cluster: String(Cluster.MainnetBeta),
+                    epochCount: 69,
+                    fromEpoch: 943,
+                    phase: 'sweep',
+                    toEpoch: 1011,
+                }),
+            }),
+        );
+    });
+
+    it('should report which phase timed out when the sweep never started', async () => {
+        mocks.getAccountInfo.mockRejectedValue(makeTimeoutError());
+
+        await callRoute();
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                sentry: true,
+                sentryExtras: expect.objectContaining({ phase: 'account-lookup' }),
+            }),
+        );
+    });
+
+    it('should not report an ordinary RPC failure to Sentry, which would only add noise', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(new Error('rpc down'));
+
+        await callRoute();
+
+        expect(Logger.warn).not.toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ sentry: true }));
+    });
+
+    it('should not cache a timeout, so a retry can resume the sweep', async () => {
+        mocks.sumInflationRewards.mockRejectedValue(makeTimeoutError());
+
+        expect((await callRoute()).headers.get('Cache-Control')).toBeNull();
+    });
+});
+
+/** What `AbortSignal.timeout` rejects with, which the route maps to a 504. */
+function makeTimeoutError(): DOMException {
+    return new DOMException('The operation timed out', 'TimeoutError');
+}
+
+/** kit returns `value: null` for an address with no account. */
+const MISSING_ACCOUNT = { value: null };
+
+/** `getEpochInfo` partway through epoch 1012, which starts at slot 437,184,000. */
+const EPOCH_INFO = {
+    absoluteSlot: 437_284_000n,
+    epoch: 1012n,
+    slotIndex: 100_000n,
+    slotsInEpoch: 432_000n,
+};
+
+async function callRoute({
+    address = STAKE_ACCOUNT_ADDRESS,
+    cluster = String(Cluster.MainnetBeta),
+    omitCluster = false,
+}: { address?: string; cluster?: string; omitCluster?: boolean } = {}) {
+    const { GET } = await import('../route');
+    // An explicit flag, not `cluster: undefined` — a destructuring default fires on undefined.
+    const query = omitCluster ? '' : `?cluster=${cluster}`;
+    return GET(new Request(`https://explorer.test/api/stake-rewards/${address}${query}`), {
+        params: Promise.resolve({ address }),
+    });
+}

--- a/app/api/stake-rewards/[address]/route.ts
+++ b/app/api/stake-rewards/[address]/route.ts
@@ -1,0 +1,176 @@
+import { clusterFromParam, serverClusterUrlFromParam } from '@entities/cluster/server';
+import {
+    getCreationEpoch,
+    getOldestSignatureSlot,
+    getRewardEpochRange,
+    type RewardEpochRange,
+    SignatureHistoryUnavailableError,
+    sumInflationRewards,
+} from '@entities/stake-rewards/server';
+import { parseStakeDelegation, type StakeDelegation } from '@features/stake/server';
+import { CACHE_HEADERS, isTimeoutError } from '@shared/lib/http-utils';
+import { type Address, address, createSolanaRpc } from '@solana/kit';
+import { NextResponse } from 'next/server';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+/**
+ * The sweep bounds itself well inside this (see `SWEEP_BUDGET_MS`); this is the backstop for the
+ * two calls below plus response overhead. Declared rather than inherited, so the ceiling the sweep
+ * budget is chosen against is visible here.
+ */
+export const maxDuration = 60;
+
+/** Applies to the two calls that precede the sweep. The sweep sets its own per-call ceiling. */
+const RPC_TIMEOUT_MS = 10_000;
+
+/**
+ * Lifetime inflation-reward total for one stake account.
+ *
+ * The sweep costs one RPC call per epoch on a cold cache, so this endpoint exists to pay that once
+ * and share it: `CACHE_HEADERS` holds the response at the CDN, and each epoch's RPC response is
+ * cached on its own underneath (see `sumInflationRewards`).
+ *
+ * Error policy: a partial total cannot be told apart from a correct one, so any epoch that fails
+ * fails the whole request with an *uncached* 502 — caching the failure would pin it for the full
+ * four-hour success window. A timeout answers 504 on the same terms. Leaving it uncached is what
+ * makes a long cold sweep viable: each epoch is cached on its own, so a repeat request resumes from
+ * the progress the timed-out one made. A cached error would block those retries for its whole TTL
+ * and stall the sweep short of an answer.
+ *
+ * This composes the pieces here rather than in a slice because the parse lives in the stake feature
+ * and the reward math in the stake-rewards entity; only a route may reach into both.
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ address: string }> }) {
+    const { address: addressParam } = await params;
+    const clusterParam = new URL(request.url).searchParams.get('cluster');
+
+    if (!clusterParam) {
+        return NextResponse.json({ error: 'Missing cluster' }, { status: 400 });
+    }
+
+    const cluster = clusterFromParam(clusterParam);
+    const url = serverClusterUrlFromParam(clusterParam);
+    if (cluster === undefined || !url) {
+        return NextResponse.json({ error: 'Invalid cluster' }, { status: 400 });
+    }
+
+    let stakeAccount: Address;
+    try {
+        stakeAccount = address(addressParam);
+    } catch {
+        return NextResponse.json({ error: 'Invalid address' }, { status: 400 });
+    }
+
+    const logContext = { address: addressParam, cluster: clusterParam };
+
+    /**
+     * Hoisted so a timeout can report the range it was sweeping. The epoch count is the fact that
+     * separates the two causes: an upstream that went slow, or a range that never fit the budget.
+     * Stays `undefined` when the timeout hit one of the two calls that precede the sweep.
+     */
+    let sweptRange: RewardEpochRange | undefined;
+
+    try {
+        const rpc = createSolanaRpc(url);
+        // The signature walk joins the two calls already here rather than following them: it needs
+        // only the address, so it costs the request nothing beyond the slowest of the three.
+        const [epochInfo, accountInfo, oldestSlot] = await Promise.all([
+            rpc.getEpochInfo().send({ abortSignal: AbortSignal.timeout(RPC_TIMEOUT_MS) }),
+            rpc
+                .getAccountInfo(stakeAccount, { encoding: 'jsonParsed' })
+                .send({ abortSignal: AbortSignal.timeout(RPC_TIMEOUT_MS) }),
+            getOldestSignatureSlot({
+                abortSignal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+                address: stakeAccount,
+                rpc,
+            }),
+        ]);
+
+        const delegation = parseStakeDelegation(accountInfo.value);
+        if (delegation.kind !== 'delegated') {
+            return notDelegatedResponse(delegation.kind);
+        }
+
+        sweptRange = getRewardEpochRange({
+            cluster,
+            // Not `delegation.activationEpoch`: re-delegating resets that to the latest delegation,
+            // so it omits everything an earlier delegation earned.
+            creationEpoch: getCreationEpoch({ epochInfo, oldestSlot }),
+            // kit returns the epoch as a bigint; the range rule works in numbers, and an epoch
+            // count stays far below the safe integer range.
+            currentEpoch: Number(epochInfo.epoch),
+            deactivationEpoch: delegation.deactivationEpoch,
+        });
+
+        // No completed reward epochs yet — a real total of zero, not a failure.
+        if (!sweptRange) {
+            return NextResponse.json({ totalReward: 0 }, { headers: CACHE_HEADERS, status: 200 });
+        }
+
+        const totalReward = await sumInflationRewards({ address: addressParam, range: sweptRange, url });
+
+        return NextResponse.json(
+            { fromEpoch: sweptRange.fromEpoch, toEpoch: sweptRange.toEpoch, totalReward },
+            { headers: CACHE_HEADERS, status: 200 },
+        );
+    } catch (error) {
+        // No total rather than a short one. Substituting `activationEpoch` here would answer 200
+        // with a figure wrong by an unknown amount, which is the one outcome this endpoint must
+        // not produce. The card renders its `unavailable` state, not a zero.
+        if (error instanceof SignatureHistoryUnavailableError) {
+            Logger.warn('[api:stake-rewards] Could not date the account from its signature history', {
+                ...logContext,
+                reason: error.message,
+            });
+            return NextResponse.json({ error: 'Cannot determine account creation epoch' }, { status: 502 });
+        }
+
+        // Warn rather than page: an unreachable or slow upstream is not an application fault.
+        if (isTimeoutError(error)) {
+            // Told apart from a 502 because the cure differs: a timed-out sweep made real progress,
+            // and the caller only has to ask again to resume it.
+            //
+            // Reported to Sentry because the budget is a guess that only production can settle. The
+            // message stays static so every timeout groups into one issue; the varying facts go to
+            // `sentryExtras`, which is the only part of this context Sentry receives.
+            Logger.warn('[api:stake-rewards] Timed out resolving total reward', {
+                ...logContext,
+                sentry: true,
+                sentryExtras: {
+                    ...logContext,
+                    ...(sweptRange && {
+                        epochCount: sweptRange.toEpoch - sweptRange.fromEpoch + 1,
+                        fromEpoch: sweptRange.fromEpoch,
+                        toEpoch: sweptRange.toEpoch,
+                    }),
+                    // Distinguishes a timeout inside the sweep from one in the calls before it.
+                    phase: sweptRange ? 'sweep' : 'account-lookup',
+                },
+            });
+            return NextResponse.json({ error: 'Upstream RPC timeout' }, { status: 504 });
+        }
+
+        // Every epoch already retries with backoff, so reaching here means the RPC stayed unhealthy.
+        Logger.warn('[api:stake-rewards] Failed to resolve total reward', {
+            ...logContext,
+            rpcError: error instanceof Error ? error.message : String(error),
+        });
+        return NextResponse.json({ error: 'Upstream RPC error' }, { status: 502 });
+    }
+}
+
+/**
+ * Client errors are kept apart so the caller learns *why* there is no total. None carry cache
+ * headers: an account can be created or delegated at any time, and a cached 404 would outlive it.
+ */
+function notDelegatedResponse(kind: Exclude<StakeDelegation['kind'], 'delegated'>) {
+    switch (kind) {
+        case 'not-found':
+            return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+        case 'not-a-stake-account':
+            return NextResponse.json({ error: 'Not a stake account' }, { status: 400 });
+        case 'undelegated':
+            return NextResponse.json({ error: 'Stake account has never been delegated' }, { status: 400 });
+    }
+}

--- a/app/entities/stake-rewards/api/__tests__/oldest-signature-slot.spec.ts
+++ b/app/entities/stake-rewards/api/__tests__/oldest-signature-slot.spec.ts
@@ -1,0 +1,103 @@
+import { gen } from '@__fixtures__/gen';
+import { type Address, type GetSignaturesForAddressApi, type Rpc } from '@solana/kit';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getOldestSignatureSlot, SignatureHistoryUnavailableError } from '../oldest-signature-slot';
+
+const ADDRESS = gen.vanityAddress('STAKE') as Address;
+
+describe('getOldestSignatureSlot', () => {
+    it('should return the oldest slot on the page', async () => {
+        const rpc = makeRpc([[437_000_000n, 420_000_000n, 407_506_361n]]);
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).resolves.toBe(407_506_361n);
+    });
+
+    it('should read the oldest slot whatever order the RPC returns the page in', async () => {
+        const rpc = makeRpc([[407_506_361n, 437_000_000n, 420_000_000n]]);
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).resolves.toBe(407_506_361n);
+    });
+
+    it('should stop after one page when the page comes back short', async () => {
+        const rpc = makeRpc([[407_506_361n]]);
+
+        await getOldestSignatureSlot({ address: ADDRESS, rpc });
+
+        expect(rpc.getSignaturesForAddress).toHaveBeenCalledTimes(1);
+    });
+
+    it('should page back past a full page rather than give up on it', async () => {
+        // The bug this replaces: a full page used to end the walk and fall back to the activation
+        // epoch, reporting a short total for exactly the accounts with the longest histories.
+        const rpc = makeRpc([fullPage(437_000_000n), [364_763_481n]]);
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).resolves.toBe(364_763_481n);
+        expect(rpc.getSignaturesForAddress).toHaveBeenCalledTimes(2);
+    });
+
+    it('should page back from the oldest signature of the page it just read', async () => {
+        const rpc = makeRpc([fullPage(437_000_000n), [364_763_481n]]);
+
+        await getOldestSignatureSlot({ address: ADDRESS, rpc });
+
+        // The page runs newest first, so its cursor is the last entry.
+        expect(rpc.getSignaturesForAddress).toHaveBeenLastCalledWith(
+            ADDRESS,
+            expect.objectContaining({ before: `sig-${437_000_000n - 999n}` }),
+        );
+    });
+
+    it('should throw rather than answer from a history it could not reach the end of', async () => {
+        const rpc = makeRpc(Array.from({ length: 6 }, (_, page) => fullPage(437_000_000n - BigInt(page * 1000))));
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).rejects.toThrow(
+            SignatureHistoryUnavailableError,
+        );
+    });
+
+    it('should stop paging once it has given up, rather than walk on', async () => {
+        const rpc = makeRpc(Array.from({ length: 6 }, (_, page) => fullPage(437_000_000n - BigInt(page * 1000))));
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).rejects.toThrow();
+
+        expect(rpc.getSignaturesForAddress).toHaveBeenCalledTimes(5);
+    });
+
+    it('should throw when the account has no signatures to date it by', async () => {
+        const rpc = makeRpc([[]]);
+
+        await expect(getOldestSignatureSlot({ address: ADDRESS, rpc })).rejects.toThrow(
+            SignatureHistoryUnavailableError,
+        );
+    });
+
+    it('should pass the abort signal to every page', async () => {
+        const rpc = makeRpc([fullPage(437_000_000n), [364_763_481n]]);
+        const abortSignal = AbortSignal.timeout(10_000);
+
+        await getOldestSignatureSlot({ abortSignal, address: ADDRESS, rpc });
+
+        expect(rpc.send).toHaveBeenCalledTimes(2);
+        expect(rpc.send).toHaveBeenCalledWith({ abortSignal });
+    });
+});
+
+/** A page at the limit, which cannot be the end of the history. */
+function fullPage(newestSlot: bigint): bigint[] {
+    return Array.from({ length: 1_000 }, (_, index) => newestSlot - BigInt(index));
+}
+
+/** An rpc that serves `pages` in order, newest page first, as `getSignaturesForAddress` does. */
+function makeRpc(pages: bigint[][]) {
+    const send = vi.fn();
+    for (const page of pages) {
+        send.mockResolvedValueOnce(page.map(slot => ({ signature: `sig-${slot}`, slot })));
+    }
+    const getSignaturesForAddress = vi.fn(() => ({ send }));
+
+    return { getSignaturesForAddress, send } as unknown as Rpc<GetSignaturesForAddressApi> & {
+        getSignaturesForAddress: ReturnType<typeof vi.fn>;
+        send: typeof send;
+    };
+}

--- a/app/entities/stake-rewards/api/__tests__/sum-inflation-rewards.spec.ts
+++ b/app/entities/stake-rewards/api/__tests__/sum-inflation-rewards.spec.ts
@@ -1,0 +1,209 @@
+import { gen } from '@__fixtures__/gen';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sumInflationRewards } from '../sum-inflation-rewards';
+
+describe('sumInflationRewards', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        vi.clearAllMocks();
+    });
+
+    it('should sum the amounts across the range', async () => {
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(makeRewardResponse(10))
+            .mockResolvedValueOnce(makeRewardResponse(20))
+            .mockResolvedValueOnce(makeRewardResponse(30));
+
+        expect(await sumInflationRewards(makeSweepArgs())).toBe(60);
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should count an epoch that paid no reward as zero', async () => {
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(makeRewardResponse(10))
+            .mockResolvedValueOnce(makeRewardResponse(undefined))
+            .mockResolvedValueOnce(makeRewardResponse(30));
+
+        expect(await sumInflationRewards(makeSweepArgs())).toBe(40);
+    });
+
+    it('should POST, since a JSON-RPC call carries a body', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+
+        await sumInflationRewards(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }));
+
+        expect(initForEpoch(1).method).toBe('POST');
+    });
+
+    it('should request one epoch per call, covering the whole range', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+
+        await sumInflationRewards(makeSweepArgs({ range: { fromEpoch: 5, toEpoch: 7 } }));
+
+        expect(requestedEpochs()).toEqual([5, 6, 7]);
+    });
+
+    it('should cache settled epochs with no expiry', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+
+        await sumInflationRewards(makeSweepArgs());
+
+        expect(initForEpoch(1).cache).toBe('force-cache');
+        expect(initForEpoch(1).next).toEqual({ revalidate: false });
+    });
+
+    it('should not cache the newest epoch, which may not have settled', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+
+        await sumInflationRewards(makeSweepArgs());
+
+        expect(initForEpoch(3).cache).toBe('no-store');
+        expect(initForEpoch(3).next).toBeUndefined();
+    });
+
+    it('should send a deterministic id so the body stays a stable cache key', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+        const args = makeSweepArgs({ range: { fromEpoch: 9, toEpoch: 9 } });
+
+        await sumInflationRewards(args);
+        await sumInflationRewards(args);
+
+        expect(requestBody(0)).toEqual(requestBody(1));
+    });
+
+    it('should bound every request with an abort signal', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRewardResponse(1));
+
+        await sumInflationRewards(makeSweepArgs());
+
+        // Without a signal a hung socket is neither a success nor a failure, so it could never be
+        // retried. Each request carries one, and it must not be aborted up front.
+        for (const epoch of [1, 2, 3]) {
+            expect(initForEpoch(epoch).signal).toBeInstanceOf(AbortSignal);
+            expect(initForEpoch(epoch).signal?.aborted).toBe(false);
+        }
+    });
+
+    it('should retry an epoch whose request timed out', async () => {
+        vi.mocked(global.fetch).mockRejectedValueOnce(makeTimeoutError()).mockResolvedValueOnce(makeRewardResponse(7));
+
+        expect(await sumInflationRewards(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }))).toBe(7);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should surface a timeout as a TimeoutError, so the caller can tell it from an RPC fault', async () => {
+        vi.mocked(global.fetch).mockRejectedValue(makeTimeoutError());
+
+        await expectSweepToReject(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }), 'timed out');
+    });
+
+    it('should throw when an epoch returns a JSON-RPC error', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeRpcErrorResponse('boom'));
+
+        await expectSweepToReject(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }), 'boom');
+    });
+
+    it('should throw when an epoch returns a non-ok response', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({ ok: false, status: 429 } as Response);
+
+        await expectSweepToReject(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }), 'HTTP 429');
+    });
+
+    it('should retry a failing epoch before giving up', async () => {
+        vi.mocked(global.fetch)
+            .mockRejectedValueOnce(new Error('network'))
+            .mockResolvedValueOnce(makeRewardResponse(42));
+
+        expect(await sumInflationRewards(makeSweepArgs({ range: { fromEpoch: 1, toEpoch: 1 } }))).toBe(42);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail the whole sweep when one epoch fails, rather than return a partial total', async () => {
+        vi.mocked(global.fetch).mockImplementation((_url, init) =>
+            epochOf(init) === 2 ? Promise.reject(new Error('epoch 2 down')) : Promise.resolve(makeRewardResponse(10)),
+        );
+
+        await expectSweepToReject(makeSweepArgs(), 'epoch 2 down');
+    });
+});
+
+const ADDRESS = gen.vanityAddress('STAKE');
+const RPC_URL = 'https://rpc.example';
+
+type SweepArgs = Parameters<typeof sumInflationRewards>[0];
+
+/** A three-epoch sweep, so epochs 1 and 2 are settled and epoch 3 is the newest. */
+function makeSweepArgs(overrides: Partial<SweepArgs> = {}): SweepArgs {
+    return {
+        address: ADDRESS,
+        range: { fromEpoch: 1, toEpoch: 3 },
+        url: RPC_URL,
+        ...overrides,
+    };
+}
+
+/** An `amount` of `undefined` models an epoch that paid this account nothing. */
+function makeRewardResponse(amount: number | undefined): Response {
+    const reward = amount === undefined ? null : { amount };
+    return {
+        json: () => Promise.resolve({ id: 1, jsonrpc: '2.0', result: [reward] }),
+        ok: true,
+    } as Response;
+}
+
+/** What `AbortSignal.timeout` rejects with, which `isTimeoutError` matches on. */
+function makeTimeoutError(): DOMException {
+    return new DOMException('The operation timed out', 'TimeoutError');
+}
+
+function makeRpcErrorResponse(message: string): Response {
+    return {
+        json: () => Promise.resolve({ error: { code: -32000, message }, id: 1, jsonrpc: '2.0' }),
+        ok: true,
+    } as Response;
+}
+
+function epochOf(init: RequestInit | undefined): number {
+    return JSON.parse(init?.body as string).params[1].epoch;
+}
+
+function requestBody(call: number) {
+    return JSON.parse(vi.mocked(global.fetch).mock.calls[call][1]?.body as string);
+}
+
+function requestedEpochs(): number[] {
+    return vi
+        .mocked(global.fetch)
+        .mock.calls.map(([, init]) => epochOf(init))
+        .sort((a, b) => a - b);
+}
+
+function initForEpoch(epoch: number): RequestInit {
+    const call = vi.mocked(global.fetch).mock.calls.find(([, init]) => epochOf(init) === epoch);
+    if (!call) {
+        throw new Error(`no request was made for epoch ${epoch}`);
+    }
+    return call[1] as RequestInit;
+}
+
+/**
+ * Drives the retry backoff with fake timers. A failing epoch retries with an escalating delay that
+ * runs past the default test timeout, and the point of these tests is the outcome, not the wait.
+ */
+async function expectSweepToReject(args: SweepArgs, message: string) {
+    vi.useFakeTimers();
+    try {
+        const rejection = expect(sumInflationRewards(args)).rejects.toThrow(message);
+        await vi.runAllTimersAsync();
+        await rejection;
+    } finally {
+        vi.useRealTimers();
+    }
+}

--- a/app/entities/stake-rewards/api/oldest-signature-slot.ts
+++ b/app/entities/stake-rewards/api/oldest-signature-slot.ts
@@ -1,0 +1,74 @@
+import { type Address, type GetSignaturesForAddressApi, type Rpc, type Signature } from '@solana/kit';
+
+/** The largest page `getSignaturesForAddress` serves. */
+const SIGNATURE_PAGE_LIMIT = 1_000;
+
+/**
+ * How far back the walk will page before giving up. Stake accounts hold few signatures, because
+ * epoch rewards are credited by the runtime at the epoch boundary and never appear as transactions.
+ * Sampled on mainnet-beta: 25 accounts delegated in epoch 1005 held a median of 8 signatures and at
+ * most 139; 25 delegated in epoch 300 — some 700 epochs old — held a median of 270 and at most 615.
+ * None reached one page. Five leaves a wide margin over that, at 5 sequential round trips.
+ */
+const MAX_SIGNATURE_PAGES = 5;
+
+/**
+ * Raised when the account cannot be dated: more history than `MAX_SIGNATURE_PAGES` covers, or no
+ * signatures at all. The caller must fail the request rather than substitute another epoch. Any
+ * substitute is a start *later* than the truth, which yields a total short by an unknown amount —
+ * indistinguishable from a correct one, and the failure this whole endpoint is built to avoid.
+ */
+export class SignatureHistoryUnavailableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SignatureHistoryUnavailableError';
+    }
+}
+
+/**
+ * The slot of a stake account's oldest signature, which is the slot it was created in.
+ *
+ * Pages back until a page arrives short, which is the end of the account's history. Paging is
+ * cheap next to the sweep it bounds: one call removes every epoch between the cluster's first
+ * reward epoch and the account's own first.
+ */
+export async function getOldestSignatureSlot({
+    abortSignal,
+    address,
+    rpc,
+}: {
+    abortSignal?: AbortSignal;
+    address: Address;
+    rpc: Rpc<GetSignaturesForAddressApi>;
+}): Promise<bigint> {
+    let before: Signature | undefined;
+    let oldestSlot: bigint | undefined;
+
+    for (let page = 0; page < MAX_SIGNATURE_PAGES; page++) {
+        const signatures = await rpc
+            .getSignaturesForAddress(address, { before, limit: SIGNATURE_PAGE_LIMIT })
+            .send({ abortSignal });
+
+        for (const { slot } of signatures) {
+            if (oldestSlot === undefined || slot < oldestSlot) {
+                oldestSlot = slot;
+            }
+        }
+
+        // A short page has nothing older behind it, so the history is complete.
+        if (signatures.length < SIGNATURE_PAGE_LIMIT) {
+            if (oldestSlot === undefined) {
+                throw new SignatureHistoryUnavailableError(`${address} has no signatures to date it by`);
+            }
+            return oldestSlot;
+        }
+
+        // The cursor, unlike the slot above, does rely on the RPC returning signatures newest
+        // first: paging back needs the oldest entry of the page just read.
+        before = signatures[signatures.length - 1].signature;
+    }
+
+    throw new SignatureHistoryUnavailableError(
+        `${address} has more than ${MAX_SIGNATURE_PAGES * SIGNATURE_PAGE_LIMIT} signatures`,
+    );
+}

--- a/app/entities/stake-rewards/api/sum-inflation-rewards.ts
+++ b/app/entities/stake-rewards/api/sum-inflation-rewards.ts
@@ -1,0 +1,129 @@
+import { fetchAll } from '@utils/fetch-all';
+import { withBackoff } from '@utils/with-backoff';
+
+import { type RewardEpochRange } from '../lib/epoch-range';
+
+/**
+ * Matches the client paths, which use 1 and 2 after #854 traced 429s to parallel fetching. 8 was
+ * measured to rate-limit a cold sweep partway through, and the request that pays for the cold
+ * sweep is the one least able to absorb a failure. After warm-up only the newest epoch is an
+ * uncached call, so a low ceiling costs nothing in the steady state.
+ */
+const SWEEP_CONCURRENCY = 2;
+
+/**
+ * A cold sweep is long enough to trip a provider's rate limit partway through — measured, not
+ * theorised. Recovering from that needs patience rather than speed: the default 300ms/600ms
+ * window is far shorter than any rate-limit window, so it burns its retries and fails.
+ */
+const MAX_RETRIES = 4;
+const RETRY_INITIAL_DELAY_MS = 1_000;
+
+/**
+ * Ceiling for one epoch's call. A healthy RPC answers far inside this; the point is to turn a hung
+ * socket into a rejection. Without it `withBackoff` cannot retry a hang at all — a pending promise
+ * is neither a success nor a failure, so it would hold its concurrency slot, and the sweep, open
+ * until the platform killed the function.
+ */
+const EPOCH_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Ceiling for the whole sweep. Per-call timeouts bound one epoch, never the total: the range grows
+ * with the account's age, and at `SWEEP_CONCURRENCY` a cold sweep of a long-lived account takes
+ * hundreds of sequential rounds. This keeps the sweep inside the route's `maxDuration`, so the
+ * route answers with its own logged error instead of being killed mid-flight.
+ *
+ * Hitting it is not a dead end: every settled epoch that did resolve stays cached, so a retry
+ * resumes where this attempt stopped rather than starting over.
+ */
+const SWEEP_BUDGET_MS = 40_000;
+
+/**
+ * Sums a stake account's inflation rewards across `range`.
+ *
+ * Throws when any epoch still fails after retries. A partial total cannot be told apart from a
+ * correct one, so the caller must surface the failure rather than return what did succeed. The
+ * epochs that did resolve stay in the cache, so a retry re-fetches only what failed.
+ */
+export async function sumInflationRewards({
+    address,
+    range,
+    url,
+}: {
+    address: string;
+    range: RewardEpochRange;
+    url: string;
+}): Promise<number> {
+    const epochs: number[] = [];
+    for (let epoch = range.fromEpoch; epoch <= range.toEpoch; epoch++) {
+        epochs.push(epoch);
+    }
+
+    // One deadline shared by every epoch, including those still queued behind `SWEEP_CONCURRENCY`.
+    const sweepDeadline = AbortSignal.timeout(SWEEP_BUDGET_MS);
+
+    const amounts = await fetchAll(
+        epochs,
+        epoch =>
+            withBackoff(
+                () => fetchEpochReward({ address, epoch, isNewest: epoch === range.toEpoch, sweepDeadline, url }),
+                {
+                    initialDelay: RETRY_INITIAL_DELAY_MS,
+                    maxRetries: MAX_RETRIES,
+                    signal: sweepDeadline,
+                },
+            ),
+        SWEEP_CONCURRENCY,
+    );
+
+    return amounts.reduce((total, amount) => total + amount, 0);
+}
+
+async function fetchEpochReward({
+    address,
+    epoch,
+    isNewest,
+    sweepDeadline,
+    url,
+}: {
+    address: string;
+    epoch: number;
+    isNewest: boolean;
+    sweepDeadline: AbortSignal;
+    url: string;
+}): Promise<number> {
+    const response = await fetch(url, {
+        // The request body is part of the cache key, so this id must be deterministic. A random
+        // or incrementing id would make every call a cache miss.
+        body: JSON.stringify({
+            id: `stake-rewards:${epoch}`,
+            jsonrpc: '2.0',
+            method: 'getInflationReward',
+            params: [[address], { epoch }],
+        }),
+        // A settled epoch's reward never changes, so it is cached with no expiry. The newest epoch
+        // may not have settled yet — caching a not-yet-settled epoch would store a permanent zero.
+        cache: isNewest ? 'no-store' : 'force-cache',
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        // Safe for the cache above: Next hashes a fetch cache key from url, method, headers, body
+        // and `cache` only, so a per-call signal cannot turn a hit into a miss. A fresh timeout per
+        // attempt races the sweep-wide deadline — whichever fires first aborts this call.
+        signal: AbortSignal.any([sweepDeadline, AbortSignal.timeout(EPOCH_REQUEST_TIMEOUT_MS)]),
+        ...(isNewest ? {} : { next: { revalidate: false as const } }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`getInflationReward failed for epoch ${epoch}: HTTP ${response.status}`);
+    }
+
+    const body = await response.json();
+
+    if (body.error) {
+        throw new Error(`getInflationReward failed for epoch ${epoch}: ${body.error.message}`);
+    }
+
+    // A null entry means the epoch paid this account nothing — a delinquent validator, or an epoch
+    // the RPC does not serve. That is a real zero, not a failure.
+    return body.result?.[0]?.amount ?? 0;
+}

--- a/app/entities/stake-rewards/lib/__tests__/creation-epoch.spec.ts
+++ b/app/entities/stake-rewards/lib/__tests__/creation-epoch.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCreationEpoch } from '../creation-epoch';
+
+describe('getCreationEpoch', () => {
+    it('should place the oldest slot in the epoch that contains it', () => {
+        // Measured on mainnet-beta: `116vkzEjoTpFEd3x12XL9HbYJ5EpoC4cZ9a1N5A5mUt` was created in
+        // slot 407,506,361, which is epoch 943 — the epoch it was also delegated in.
+        expect(getCreationEpoch(makeInput(407_506_361n))).toBe(943);
+    });
+
+    it('should date a re-delegated account from creation, not from its latest delegation', () => {
+        // `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs` reports `activationEpoch` 1005 but was
+        // created in slot 364,763,481, in epoch 844. Sweeping from 844 recovers 55,208,535 lamports
+        // against the 10,482,997 that epoch 1005 would have reported.
+        expect(getCreationEpoch(makeInput(364_763_481n))).toBe(844);
+    });
+
+    it('should return the current epoch for an account created in it', () => {
+        expect(getCreationEpoch(makeInput(437_750_000n))).toBe(1013);
+    });
+
+    it('should return the previous epoch for the last slot before the current one', () => {
+        // 437,616,000 is the first slot of epoch 1013, so one slot earlier is still epoch 1012.
+        expect(getCreationEpoch(makeInput(437_615_999n))).toBe(1012);
+    });
+
+    it('should return the current epoch for the first slot of the current epoch', () => {
+        expect(getCreationEpoch(makeInput(437_616_000n))).toBe(1013);
+    });
+});
+
+/** `getEpochInfo` as measured on mainnet-beta during epoch 1013. */
+function makeInput(oldestSlot: bigint) {
+    return {
+        epochInfo: {
+            absoluteSlot: 437_750_351n,
+            epoch: 1013n,
+            slotIndex: 134_351n,
+            slotsInEpoch: 432_000n,
+        },
+        oldestSlot,
+    };
+}

--- a/app/entities/stake-rewards/lib/__tests__/epoch-range.spec.ts
+++ b/app/entities/stake-rewards/lib/__tests__/epoch-range.spec.ts
@@ -1,0 +1,100 @@
+import { Cluster } from '@utils/cluster';
+import { describe, expect, it } from 'vitest';
+
+import { getRewardEpochRange } from '../epoch-range';
+
+describe('getRewardEpochRange', () => {
+    it('should run from the creation epoch to the previous epoch', () => {
+        expect(getRewardEpochRange(makeRangeInput())).toEqual({ fromEpoch: 943, toEpoch: 1011 });
+    });
+
+    it('should exclude the current epoch, which has paid nothing yet', () => {
+        expect(getRewardEpochRange(makeRangeInput({ currentEpoch: 1012 }))?.toEpoch).toBe(1011);
+    });
+
+    it('should start before a re-delegated account activation epoch', () => {
+        // `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs` was created in epoch 844 and reports
+        // `activationEpoch` 1005. Starting at 1005 reported 10,482,997 of 55,208,535 lamports.
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 844 }))).toEqual({
+            fromEpoch: 844,
+            toEpoch: 1011,
+        });
+    });
+
+    it('should floor the start at the first mainnet epoch that paid inflation rewards', () => {
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 10 }))).toEqual({
+            fromEpoch: 132,
+            toEpoch: 1011,
+        });
+    });
+
+    it('should use the testnet floor on testnet', () => {
+        const input = makeRangeInput({ cluster: Cluster.Testnet, creationEpoch: 10, currentEpoch: 500 });
+
+        expect(getRewardEpochRange(input)).toEqual({ fromEpoch: 43, toEpoch: 499 });
+    });
+
+    it('should apply no floor to clusters without a known first reward epoch', () => {
+        const input = makeRangeInput({ cluster: Cluster.Devnet, creationEpoch: 10, currentEpoch: 500 });
+
+        expect(getRewardEpochRange(input)).toEqual({ fromEpoch: 10, toEpoch: 499 });
+    });
+
+    it('should keep the creation epoch when it is later than the floor', () => {
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 400 }))).toEqual({
+            fromEpoch: 400,
+            toEpoch: 1011,
+        });
+    });
+
+    it('should end at the deactivation epoch once the account has stopped earning', () => {
+        expect(getRewardEpochRange(makeRangeInput({ deactivationEpoch: 1000 }))).toEqual({
+            fromEpoch: 943,
+            toEpoch: 1000,
+        });
+    });
+
+    it('should ignore a deactivation epoch that has not been reached yet', () => {
+        expect(getRewardEpochRange(makeRangeInput({ deactivationEpoch: 1050 }))).toEqual({
+            fromEpoch: 943,
+            toEpoch: 1011,
+        });
+    });
+
+    it('should treat an unstripped u64::MAX sentinel as still delegated', () => {
+        const input = makeRangeInput({ deactivationEpoch: Number(0xffffffffffffffffn) });
+
+        expect(getRewardEpochRange(input)).toEqual({ fromEpoch: 943, toEpoch: 1011 });
+    });
+
+    it('should return a single epoch when the account was created one epoch ago', () => {
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 1011 }))).toEqual({
+            fromEpoch: 1011,
+            toEpoch: 1011,
+        });
+    });
+
+    it('should return undefined when the account was created this epoch', () => {
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 1012 }))).toBeUndefined();
+    });
+
+    it('should return undefined when the account deactivated before its first reward epoch', () => {
+        expect(getRewardEpochRange(makeRangeInput({ deactivationEpoch: 942 }))).toBeUndefined();
+    });
+
+    it('should return undefined when the whole range predates the cluster floor', () => {
+        expect(getRewardEpochRange(makeRangeInput({ creationEpoch: 10, currentEpoch: 100 }))).toBeUndefined();
+    });
+});
+
+type RangeInput = Parameters<typeof getRewardEpochRange>[0];
+
+/** A mainnet account created in epoch 943 and still delegated, queried during epoch 1012. */
+function makeRangeInput(overrides: Partial<RangeInput> = {}): RangeInput {
+    return {
+        cluster: Cluster.MainnetBeta,
+        creationEpoch: 943,
+        currentEpoch: 1012,
+        ...overrides,
+    };
+}

--- a/app/entities/stake-rewards/lib/creation-epoch.ts
+++ b/app/entities/stake-rewards/lib/creation-epoch.ts
@@ -1,0 +1,35 @@
+/** The fields of `getEpochInfo` that place a slot in an epoch. */
+type EpochInfo = {
+    absoluteSlot: bigint;
+    epoch: bigint;
+    slotIndex: bigint;
+    slotsInEpoch: bigint;
+};
+
+/**
+ * The epoch a stake account was created in, from the slot of its oldest signature.
+ *
+ * This is what bounds the reward sweep from below, because `delegation.activationEpoch` does not:
+ * re-delegating resets it to the epoch of the *latest* delegation, discarding the account's earlier
+ * earning history. An account cannot be paid a reward before it exists, so its first signature is a
+ * correct floor — and a far tighter one than the cluster's first reward epoch, which no long-lived
+ * account can sweep inside the route's budget.
+ *
+ * Anchors on the current epoch rather than dividing the slot by the epoch length, so no cluster's
+ * epoch length has to be hardcoded. It assumes every epoch since the account's first is the same
+ * length, which holds once a cluster is past its warmup epochs. An account older than that gets an
+ * epoch that is too low, which only widens the sweep — the caller floors it at the cluster's first
+ * reward epoch anyway.
+ */
+export function getCreationEpoch({ epochInfo, oldestSlot }: { epochInfo: EpochInfo; oldestSlot: bigint }): number {
+    const { absoluteSlot, epoch, slotIndex, slotsInEpoch } = epochInfo;
+
+    const currentEpochFirstSlot = absoluteSlot - slotIndex;
+    if (oldestSlot >= currentEpochFirstSlot) {
+        return Number(epoch);
+    }
+
+    // Rounded up, because a slot anywhere inside an epoch belongs to that whole epoch.
+    const epochsBack = (currentEpochFirstSlot - oldestSlot + slotsInEpoch - 1n) / slotsInEpoch;
+    return Number(epoch - epochsBack);
+}

--- a/app/entities/stake-rewards/lib/epoch-range.ts
+++ b/app/entities/stake-rewards/lib/epoch-range.ts
@@ -1,0 +1,59 @@
+import { Cluster } from '@utils/cluster';
+
+export type RewardEpochRange = {
+    fromEpoch: number;
+    toEpoch: number;
+};
+
+/**
+ * Inflation rewards began in these epochs, so no earlier epoch can hold a reward.
+ * Clusters absent from the map have no floor.
+ */
+const FIRST_REWARD_EPOCH = new Map<Cluster, number>([
+    [Cluster.MainnetBeta, 132],
+    [Cluster.Testnet, 43],
+]);
+
+/**
+ * The epochs whose inflation rewards make up a stake account's lifetime total.
+ *
+ * Returns `undefined` when the account has no completed reward epochs yet — a stake account
+ * delegated this epoch, or one that deactivated before its first reward. That is a total of
+ * zero, not a failure; callers must not treat it as an error.
+ *
+ * `deactivationEpoch` is `undefined` when the account is still delegated. Callers normalise
+ * the `u64::MAX` sentinel away, as `DelegationCard` already does.
+ *
+ * The range starts at `creationEpoch` and never at `delegation.activationEpoch`. Re-delegating
+ * resets the activation epoch to the epoch of the latest delegation, so it is not the account's
+ * first earning epoch — measured at 81% of one account's total left out. There is no fallback: a
+ * caller that cannot date the account must fail rather than pass a later epoch, because a later
+ * start yields a total short by an unknown amount that reads as a correct one.
+ */
+export function getRewardEpochRange({
+    cluster,
+    creationEpoch,
+    currentEpoch,
+    deactivationEpoch,
+}: {
+    cluster: Cluster;
+    creationEpoch: number;
+    currentEpoch: number;
+    deactivationEpoch?: number;
+}): RewardEpochRange | undefined {
+    const fromEpoch = Math.max(creationEpoch, FIRST_REWARD_EPOCH.get(cluster) ?? 0);
+
+    // The current epoch has not finished, so it has paid nothing yet.
+    const lastCompletedEpoch = currentEpoch - 1;
+
+    // A caller that forgets to strip the u64::MAX sentinel would otherwise pass a number far
+    // beyond any real epoch. Treat anything past the safe integer range as "still delegated".
+    const isDeactivated = deactivationEpoch !== undefined && deactivationEpoch < Number.MAX_SAFE_INTEGER;
+    const toEpoch = isDeactivated ? Math.min(lastCompletedEpoch, deactivationEpoch) : lastCompletedEpoch;
+
+    if (fromEpoch > toEpoch) {
+        return undefined;
+    }
+
+    return { fromEpoch, toEpoch };
+}

--- a/app/entities/stake-rewards/server.ts
+++ b/app/entities/stake-rewards/server.ts
@@ -1,0 +1,4 @@
+export { getCreationEpoch } from './lib/creation-epoch';
+export { getRewardEpochRange, type RewardEpochRange } from './lib/epoch-range';
+export { getOldestSignatureSlot, SignatureHistoryUnavailableError } from './api/oldest-signature-slot';
+export { sumInflationRewards } from './api/sum-inflation-rewards';

--- a/app/features/stake/__fixtures__/stake-account.ts
+++ b/app/features/stake/__fixtures__/stake-account.ts
@@ -1,0 +1,150 @@
+import { gen } from '@__fixtures__/gen';
+import {
+    type AccountInfoBase,
+    type AccountInfoWithJsonData,
+    address,
+    type Base64EncodedBytes,
+    lamports,
+} from '@solana/kit';
+import { STAKE_PROGRAM_ADDRESS } from '@solana-program/stake';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+
+import { type StakeAccountInfo } from '../lib/validators';
+
+/**
+ * What kit's `getAccountInfo(…, { encoding: 'jsonParsed' })` returns in `value`, which is the shape
+ * `parseStakeDelegation` reads. Integers are bigints and the epochs strings, matching kit's upcast
+ * of the RPC response — see `StakeDelegationAccount`.
+ */
+type ParsedAccount = AccountInfoBase & AccountInfoWithJsonData;
+
+const ACCOUNT_ENVELOPE = {
+    executable: false,
+    lamports: lamports(214_211_410n),
+    owner: STAKE_PROGRAM_ADDRESS,
+    space: 200n,
+} as const;
+
+export const STAKE_ACCOUNT_ADDRESS = gen.vanityAddress('STAKE');
+
+/** On-chain, a still-delegated account carries `u64::MAX` rather than a real deactivation epoch. */
+export const EPOCH_NEVER_SET = '18446744073709551615';
+
+/** A stake account delegated in epoch 943 and still delegated, as jsonParsed returns it. */
+export function makeStakeAccount({
+    activationEpoch = '943',
+    deactivationEpoch = EPOCH_NEVER_SET,
+}: { activationEpoch?: string; deactivationEpoch?: string } = {}): ParsedAccount {
+    return {
+        ...ACCOUNT_ENVELOPE,
+        data: {
+            parsed: {
+                info: {
+                    meta: makeMeta(),
+                    stake: {
+                        creditsObserved: 959135070n,
+                        delegation: {
+                            activationEpoch,
+                            deactivationEpoch,
+                            stake: '211917944',
+                            voter: STAKE_ACCOUNT_ADDRESS,
+                        },
+                    },
+                },
+                type: 'delegated',
+            },
+            program: 'stake',
+            space: 200n,
+        },
+    };
+}
+
+/** An initialized stake account that was never delegated: jsonParsed emits `stake: null`. */
+export function makeUndelegatedStakeAccount(): ParsedAccount {
+    return {
+        ...ACCOUNT_ENVELOPE,
+        data: {
+            parsed: { info: { meta: makeMeta(), stake: null }, type: 'initialized' },
+            program: 'stake',
+            space: 200n,
+        },
+    };
+}
+
+/**
+ * A nonce account. jsonParsed reports it as `type: 'initialized'` too, so it is the case that
+ * proves the type alone does not identify a stake account — only the `stake` key does.
+ */
+export function makeNonceAccount(): ParsedAccount {
+    return {
+        ...ACCOUNT_ENVELOPE,
+        data: {
+            parsed: {
+                info: {
+                    authority: STAKE_ACCOUNT_ADDRESS,
+                    blockhash: gen.address(2),
+                    feeCalculator: { lamportsPerSignature: '5000' },
+                },
+                type: 'initialized',
+            },
+            program: 'nonce',
+            space: 80n,
+        },
+        owner: SYSTEM_PROGRAM_ADDRESS,
+        space: 80n,
+    };
+}
+
+/** An account belonging to some other program, so the stake validator rejects it. */
+export function makeOtherProgramAccount(): ParsedAccount {
+    return {
+        ...ACCOUNT_ENVELOPE,
+        data: {
+            parsed: { info: { mint: gen.address(1) }, type: 'account' },
+            program: 'spl-token',
+            space: 165n,
+        },
+    };
+}
+
+/** The `[base64, 'base64']` tuple the RPC returns for a program it cannot parse. */
+export function makeUnparsedAccount(): ParsedAccount {
+    // Cast: `Base64EncodedBytes` is a branded string with no constructor to call.
+    return { ...ACCOUNT_ENVELOPE, data: ['3q2+7w==' as Base64EncodedBytes, 'base64'] };
+}
+
+function makeMeta() {
+    return {
+        authorized: { staker: STAKE_ACCOUNT_ADDRESS, withdrawer: STAKE_ACCOUNT_ADDRESS },
+        // Bigints, not numbers: kit upcasts both, and the epoch fields below stay strings.
+        lockup: { custodian: STAKE_ACCOUNT_ADDRESS, epoch: 0n, unixTimestamp: 0n },
+        rentExemptReserve: '2282880',
+    };
+}
+
+/**
+ * The validated domain shape (`StakeAccountInfo`), as the card receives it — bigints and branded
+ * addresses, not the strings the RPC sends. Use `makeStakeAccount` for the parser's input instead.
+ */
+export function makeStakeAccountInfo({
+    activationEpoch = 100n,
+    deactivationEpoch = BigInt(EPOCH_NEVER_SET),
+}: { activationEpoch?: bigint; deactivationEpoch?: bigint } = {}): StakeAccountInfo {
+    return {
+        meta: {
+            authorized: { staker: address(STAKE_ACCOUNT_ADDRESS), withdrawer: address(STAKE_ACCOUNT_ADDRESS) },
+            lockup: { custodian: address(SYSTEM_PROGRAM_ADDRESS), epoch: 0, unixTimestamp: 0 },
+            rentExemptReserve: 2_282_880n,
+        },
+        stake: {
+            creditsObserved: 12_345,
+            delegation: {
+                activationEpoch,
+                deactivationEpoch,
+                stake: 1_000_000_000n,
+                voter: address(STAKE_ACCOUNT_ADDRESS),
+                warmupCooldownRate: 0.09,
+            },
+        },
+    };
+}

--- a/app/features/stake/lib/__tests__/parse-stake-delegation.spec.ts
+++ b/app/features/stake/lib/__tests__/parse-stake-delegation.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    makeNonceAccount,
+    makeOtherProgramAccount,
+    makeStakeAccount,
+    makeUndelegatedStakeAccount,
+    makeUnparsedAccount,
+} from '../../__fixtures__/stake-account';
+import { parseStakeDelegation } from '../parse-stake-delegation';
+
+describe('parseStakeDelegation', () => {
+    it('should read both epochs from a deactivated stake account', () => {
+        expect(parseStakeDelegation(makeStakeAccount({ deactivationEpoch: '1000' }))).toEqual({
+            activationEpoch: 943,
+            deactivationEpoch: 1000,
+            kind: 'delegated',
+        });
+    });
+
+    it('should report no deactivation epoch while the account is still delegated', () => {
+        expect(parseStakeDelegation(makeStakeAccount())).toEqual({
+            activationEpoch: 943,
+            deactivationEpoch: undefined,
+            kind: 'delegated',
+        });
+    });
+
+    it('should report a missing account as not found', () => {
+        expect(parseStakeDelegation(null)).toEqual({ kind: 'not-found' });
+        expect(parseStakeDelegation(undefined)).toEqual({ kind: 'not-found' });
+    });
+
+    it('should report an account the RPC could not parse as not a stake account', () => {
+        expect(parseStakeDelegation(makeUnparsedAccount())).toEqual({ kind: 'not-a-stake-account' });
+    });
+
+    it('should report a parsed account of another program as not a stake account', () => {
+        expect(parseStakeDelegation(makeOtherProgramAccount())).toEqual({ kind: 'not-a-stake-account' });
+    });
+
+    it('should report a nonce account as not a stake account, though jsonParsed also calls it initialized', () => {
+        expect(parseStakeDelegation(makeNonceAccount())).toEqual({ kind: 'not-a-stake-account' });
+    });
+
+    it('should report an initialized stake account with no delegation as undelegated', () => {
+        expect(parseStakeDelegation(makeUndelegatedStakeAccount())).toEqual({ kind: 'undelegated' });
+    });
+});

--- a/app/features/stake/lib/parse-stake-delegation.ts
+++ b/app/features/stake/lib/parse-stake-delegation.ts
@@ -1,0 +1,67 @@
+import { type AccountInfoWithJsonData } from '@solana/kit';
+import { create } from 'superstruct';
+
+import { EPOCH_NEVER_SET } from './constants';
+import { StakeDelegationAccount } from './validators';
+
+/**
+ * Why an address has no delegation, kept apart so callers can tell the cases apart. Collapsing
+ * them would report a missing account and an undelegated stake account the same way.
+ */
+export type StakeDelegation =
+    | {
+          kind: 'delegated';
+          activationEpoch: number;
+          /** Absent while still delegated — on-chain that is the `u64::MAX` sentinel. */
+          deactivationEpoch?: number;
+      }
+    | { kind: 'not-found' }
+    | { kind: 'not-a-stake-account' }
+    | { kind: 'undelegated' };
+
+/**
+ * Reads the activation and deactivation epochs from a delegated stake account.
+ *
+ * Takes kit's `getAccountInfo(…, { encoding: 'jsonParsed' })` value. The parameter is structural
+ * rather than kit's full `AccountInfoBase & AccountInfoWithJsonData` so a caller can hand over the
+ * response value as-is and a test can build one without the account envelope.
+ *
+ * `create` rather than `is`: `activationEpoch` and `deactivationEpoch` arrive as strings and the
+ * validator coerces them to bigint, which `is` would reject. A failed parse is a caller error to
+ * report, not something to propagate, so the throw is caught.
+ */
+export function parseStakeDelegation(
+    account: { data: AccountInfoWithJsonData['data'] } | null | undefined,
+): StakeDelegation {
+    if (!account) {
+        return { kind: 'not-found' };
+    }
+
+    // A `[base64, 'base64']` tuple means the RPC could not parse the account, so it is not a stake
+    // account as far as we can tell.
+    const { data } = account;
+    if (Array.isArray(data)) {
+        return { kind: 'not-a-stake-account' };
+    }
+
+    let stake;
+    try {
+        stake = create(data.parsed, StakeDelegationAccount).info.stake;
+    } catch {
+        return { kind: 'not-a-stake-account' };
+    }
+
+    // An initialized stake account that was never delegated has no activation epoch, so there is
+    // no range to sum. Reporting zero would be a claim about the account we cannot support.
+    if (!stake) {
+        return { kind: 'undelegated' };
+    }
+
+    const { activationEpoch, deactivationEpoch } = stake.delegation;
+
+    return {
+        activationEpoch: Number(activationEpoch),
+        deactivationEpoch: deactivationEpoch === EPOCH_NEVER_SET ? undefined : Number(deactivationEpoch),
+        kind: 'delegated',
+    };
+}

--- a/app/features/stake/lib/validators.ts
+++ b/app/features/stake/lib/validators.ts
@@ -44,3 +44,31 @@ export const StakeAccount = type({
     info: StakeAccountInfo,
     type: StakeAccountType,
 });
+
+/**
+ * The delegation epochs alone, validated against **kit's** jsonParsed output.
+ *
+ * Separate from `StakeAccount` because kit upcasts every JSON integer to bigint except an
+ * allowlist (`jsonParsedAccountsConfigs` in `@solana/rpc-transformers`, which for a stake account
+ * holds only `warmupCooldownRate`). That makes `lockup.epoch`, `lockup.unixTimestamp`, and
+ * `creditsObserved` bigints, which `StakeAccount`'s `number()` fields reject — so a real stake
+ * account would fail validation. `type()` ignores the fields absent here, and a caller that needs
+ * only the epochs never reads those three.
+ *
+ * `stake: nullable` also rejects a nonce account, which jsonParsed likewise reports as
+ * `type: 'initialized'` but with no `stake` key at all.
+ */
+export type StakeDelegationAccount = Infer<typeof StakeDelegationAccount>;
+export const StakeDelegationAccount = type({
+    info: type({
+        stake: nullable(
+            type({
+                delegation: type({
+                    activationEpoch: BigIntFromString,
+                    deactivationEpoch: BigIntFromString,
+                }),
+            }),
+        ),
+    }),
+    type: StakeAccountType,
+});

--- a/app/features/stake/model/__tests__/use-total-reward.test.tsx
+++ b/app/features/stake/model/__tests__/use-total-reward.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { Cluster } from '@utils/cluster';
+import { type ReactNode } from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { STAKE_ACCOUNT_ADDRESS } from '../../__fixtures__/stake-account';
+import { useTotalReward } from '../use-total-reward';
+
+const mocks = vi.hoisted(() => ({ cluster: { cluster: 0, url: '' } }));
+
+vi.mock('@/app/providers/cluster', () => ({ useCluster: () => mocks.cluster }));
+
+describe('useTotalReward', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.cluster = { cluster: Cluster.MainnetBeta, url: 'https://rpc.example' };
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('should report loading before the request resolves', () => {
+        vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}));
+
+        expect(renderTotalReward().result.current).toEqual({ status: 'loading' });
+    });
+
+    it('should report the total once the request resolves', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeTotalResponse(4200824));
+
+        const { result } = renderTotalReward();
+
+        await waitFor(() => expect(result.current).toEqual({ lamports: 4200824, status: 'ready' }));
+    });
+
+    it('should request the route with the current cluster', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeTotalResponse(1));
+
+        renderTotalReward();
+
+        await waitFor(() =>
+            expect(global.fetch).toHaveBeenCalledWith(
+                `/api/stake-rewards/${STAKE_ACCOUNT_ADDRESS}?cluster=${Cluster.MainnetBeta}`,
+            ),
+        );
+    });
+
+    it('should report unavailable when the route fails', async () => {
+        vi.mocked(global.fetch).mockResolvedValue({ ok: false, status: 502 } as Response);
+
+        const { result } = renderTotalReward();
+
+        await waitFor(() => expect(result.current).toEqual({ status: 'unavailable' }));
+    });
+
+    it('should report a zero total as ready, not unavailable', async () => {
+        vi.mocked(global.fetch).mockResolvedValue(makeTotalResponse(0));
+
+        const { result } = renderTotalReward();
+
+        await waitFor(() => expect(result.current).toEqual({ lamports: 0, status: 'ready' }));
+    });
+
+    it('should not call the route on a custom cluster the server cannot reach', () => {
+        mocks.cluster = { cluster: Cluster.Custom, url: 'http://localhost:8899' };
+
+        expect(renderTotalReward().result.current).toEqual({ status: 'unavailable' });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * A fresh SWR cache per test. `useSWRImmutable` never revalidates, so a shared cache would let one
+ * test's result — including a pending promise — satisfy the next test's identical key.
+ */
+function renderTotalReward() {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <SWRConfig value={{ provider: () => new Map() }}>{children}</SWRConfig>
+    );
+    return renderHook(() => useTotalReward(STAKE_ACCOUNT_ADDRESS), { wrapper });
+}
+
+function makeTotalResponse(totalReward: number): Response {
+    return { json: () => Promise.resolve({ totalReward }), ok: true } as Response;
+}

--- a/app/features/stake/model/use-total-reward.ts
+++ b/app/features/stake/model/use-total-reward.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { shouldUseDirectRpc } from '@entities/cluster';
+import useSWRImmutable from 'swr/immutable';
+
+import { useCluster } from '@/app/providers/cluster';
+import { type Cluster } from '@/app/utils/cluster';
+
+/**
+ * `unavailable` covers every reason there is no figure to show — a failed request, an address the
+ * route rejects, or a custom cluster the server cannot reach. The row renders the same quiet
+ * message for all of them, and never a zero, which would be a claim about the account.
+ */
+export type TotalRewardState =
+    | { status: 'loading' }
+    | { status: 'ready'; lamports: number }
+    | { status: 'unavailable' };
+
+/**
+ * A stake account's lifetime inflation-reward total, in lamports.
+ *
+ * The sweep costs one RPC call per epoch, so it runs on the server behind `/api/stake-rewards`,
+ * which caches the response at the CDN and each epoch underneath. Custom and localhost clusters
+ * have no server endpoint, so they skip the request rather than fail it.
+ */
+export function useTotalReward(stakeAccountAddress: string): TotalRewardState {
+    const { cluster, url } = useCluster();
+    const isCustom = shouldUseDirectRpc(cluster, url);
+
+    const { data, error, isLoading } = useSWRImmutable(
+        !isCustom && (['stake-total-reward', stakeAccountAddress, cluster] as const),
+        () => fetchTotalReward(stakeAccountAddress, cluster),
+        // fetchTotalReward throws rather than returning undefined, so cap the retries.
+        { errorRetryCount: 3 },
+    );
+
+    if (isCustom || error) {
+        return { status: 'unavailable' };
+    }
+    if (isLoading || data === undefined) {
+        return { status: 'loading' };
+    }
+    return { lamports: data, status: 'ready' };
+}
+
+async function fetchTotalReward(stakeAccountAddress: string, cluster: Cluster): Promise<number> {
+    const response = await fetch(`/api/stake-rewards/${stakeAccountAddress}?cluster=${cluster}`);
+    if (!response.ok) {
+        // Throw rather than return: a transient 502 should be retried, not cached as a successful
+        // "no total" under useSWRImmutable, which never revalidates.
+        throw new Error(`/api/stake-rewards returned ${response.status}`);
+    }
+    const { totalReward } = await response.json();
+    return totalReward;
+}

--- a/app/features/stake/server.ts
+++ b/app/features/stake/server.ts
@@ -1,0 +1,1 @@
+export { parseStakeDelegation, type StakeDelegation } from './lib/parse-stake-delegation';

--- a/app/features/stake/ui/StakeAccountSection.tsx
+++ b/app/features/stake/ui/StakeAccountSection.tsx
@@ -12,6 +12,7 @@ import { displayTimestampUtc, unixTimestampToMs } from '@utils/date';
 import { capitalizeFirstLetter, lamportsToSol } from '@utils/index';
 import React from 'react';
 
+import { Skeleton } from '@/app/components/shared/ui/skeleton';
 import { toKitAddress } from '@/app/shared/lib/web3js-compat';
 import { Alert } from '@/app/shared/ui/Alert';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
@@ -20,6 +21,7 @@ import { BaseTable } from '@/app/shared/ui/Table';
 import type { StakeActivationStatus } from '../api/stake-activation';
 import { EPOCH_NEVER_SET } from '../lib/constants';
 import type { StakeAccountInfo, StakeAccountType, StakeMeta } from '../lib/validators';
+import { type TotalRewardState, useTotalReward } from '../model/use-total-reward';
 
 type StakeActivationData = {
     state: StakeActivationStatus;
@@ -49,6 +51,8 @@ export function StakeAccountSection({
     // simply don't render on other clusters.
     const priceResult = useTokenPrice(NATIVE_MINT.toBase58());
     const solPrice = priceResult?.status === PriceStatus.Success ? priceResult.price : null;
+    // Fetched here, alongside the price, so `DelegationCard` stays a presentational card.
+    const totalReward = useTotalReward(account.pubkey.toBase58());
     return (
         <>
             <LockupCard stakeAccount={stakeAccount} />
@@ -60,7 +64,12 @@ export function StakeAccountSection({
                 solPrice={solPrice}
             />
             {stakeAccount.stake && (
-                <DelegationCard stakeAccount={stakeAccount} activation={activation} solPrice={solPrice} />
+                <DelegationCard
+                    stakeAccount={stakeAccount}
+                    activation={activation}
+                    solPrice={solPrice}
+                    totalReward={totalReward}
+                />
             )}
             <AuthoritiesCard meta={stakeAccount.meta} />
         </>
@@ -163,14 +172,20 @@ function OverviewCard({
     );
 }
 
-function DelegationCard({
+/**
+ * Exported for Storybook: the card is presentational, so its three total-reward states are covered
+ * by passing `totalReward` directly rather than by mocking the hook the section calls.
+ */
+export function DelegationCard({
     stakeAccount,
     activation,
     solPrice,
+    totalReward,
 }: {
     stakeAccount: StakeAccountInfo;
     activation?: StakeActivationData;
     solPrice: number | null;
+    totalReward: TotalRewardState;
 }) {
     const { stake } = stakeAccount;
     if (!stake) {
@@ -214,6 +229,13 @@ function DelegationCard({
                 )}
 
                 <BaseTable.Row>
+                    <BaseTable.Cell>Total Reward (SOL)</BaseTable.Cell>
+                    <BaseTable.Cell className="md:text-right">
+                        <TotalReward state={totalReward} solPrice={solPrice} />
+                    </BaseTable.Cell>
+                </BaseTable.Row>
+
+                <BaseTable.Row>
                     <BaseTable.Cell>Delegated Vote Address</BaseTable.Cell>
                     <BaseTable.Cell className="md:text-right">
                         <KitAddress address={delegation.voter} alignRight link />
@@ -235,6 +257,19 @@ function DelegationCard({
             </TableCardBody>
         </Card>
     );
+}
+
+// Lifetime rewards load separately from the account, so the row carries its own state. A failure
+// shows a quiet message rather than 0 — zero is a claim about the account, not about the request.
+function TotalReward({ state, solPrice }: { state: TotalRewardState; solPrice: number | null }) {
+    switch (state.status) {
+        case 'loading':
+            return <Skeleton className="ml-auto h-4 w-24" />;
+        case 'ready':
+            return <SolWithUsd lamports={state.lamports} solPrice={solPrice} />;
+        case 'unavailable':
+            return <span className="text-dk-gray-700">Unavailable</span>;
+    }
 }
 
 function AuthoritiesCard({ meta }: { meta: StakeMeta }) {

--- a/app/features/stake/ui/__stories__/DelegationCard.stories.tsx
+++ b/app/features/stake/ui/__stories__/DelegationCard.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook-config/types';
+import { expect, within } from 'storybook/test';
+
+import { nextjsParameters, withClusterAndAccounts, withTokenInfoBatch } from '../../../../../.storybook/decorators';
+import { makeStakeAccountInfo } from '../../__fixtures__/stake-account';
+import { DelegationCard } from '../StakeAccountSection';
+
+const DELEGATED_STAKE = 1_000_000_000; // 1 SOL
+
+const meta = {
+    component: DelegationCard,
+    decorators: [withClusterAndAccounts, withTokenInfoBatch],
+    parameters: nextjsParameters,
+    tags: ['autodocs', 'test'],
+    title: 'Features/Stake/DelegationCard',
+} satisfies Meta<typeof DelegationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const args = {
+    activation: { active: DELEGATED_STAKE, inactive: 0, state: 'active' as const },
+    solPrice: null,
+    stakeAccount: makeStakeAccountInfo(),
+};
+
+export const TotalRewardLoading: Story = {
+    // The total is fetched separately from the account, so the row shows its own placeholder
+    // while the rest of the card is already populated.
+    args: { ...args, totalReward: { status: 'loading' } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('Total Reward (SOL)')).toBeInTheDocument();
+        expect(canvas.getByText('Delegated Stake (SOL)')).toBeInTheDocument();
+        expect(canvas.queryByText('Unavailable')).not.toBeInTheDocument();
+    },
+};
+
+export const TotalRewardReady: Story = {
+    args: { ...args, totalReward: { lamports: 4_200_824, status: 'ready' } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        expect(canvas.getByText('◎0.004200824')).toBeInTheDocument();
+        expect(canvas.queryByText('Unavailable')).not.toBeInTheDocument();
+    },
+};
+
+export const TotalRewardUnavailable: Story = {
+    // A failed lookup must not read as "this account earned nothing", so the row shows a quiet
+    // message rather than a zero, and the other rows keep working.
+    args: { ...args, totalReward: { status: 'unavailable' } },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        // The row renders exactly one branch, so showing the message proves it is not showing a
+        // number. The neighbouring rows keep working — a missing total is not a broken card.
+        expect(canvas.getByText('Unavailable')).toBeInTheDocument();
+        expect(canvas.getByText('Delegated Vote Address')).toBeInTheDocument();
+        expect(canvas.getByText('Delegated Stake (SOL)')).toBeInTheDocument();
+    },
+};

--- a/app/utils/__tests__/with-backoff.spec.ts
+++ b/app/utils/__tests__/with-backoff.spec.ts
@@ -65,6 +65,42 @@ describe('withBackoff', () => {
         expect(fn).toHaveBeenCalledTimes(6);
     });
 
+    it('should not retry when the signal is already aborted', async () => {
+        const fn = vi.fn().mockRejectedValue(new Error('boom'));
+
+        await expect(withBackoff(fn, { signal: AbortSignal.abort() })).rejects.toThrow('boom');
+        // The rejection is the caller's error, not an abort error: the abort only ends the loop.
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop retrying when the signal aborts while an attempt sleeps', async () => {
+        const controller = new AbortController();
+        const fn = vi.fn().mockRejectedValue(new Error('boom'));
+
+        const promise = withBackoff(fn, { initialDelay: 100, maxRetries: 5, signal: controller.signal });
+        const assertion = expect(promise).rejects.toThrow('boom');
+
+        // Let the first attempt fail and schedule its retry, then abort mid-sleep.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fn).toHaveBeenCalledTimes(1);
+        controller.abort();
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        // The abort landed during the first delay, so the queued retry never ran.
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry as usual while the signal stays unaborted', async () => {
+        const fn = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue('ok');
+
+        const promise = withBackoff(fn, { signal: new AbortController().signal });
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
     it('should wait initialDelay and multiply it by factor between retries', async () => {
         const fn = vi.fn().mockRejectedValue(new Error('x'));
 

--- a/app/utils/with-backoff.ts
+++ b/app/utils/with-backoff.ts
@@ -4,18 +4,27 @@ type BackoffOptions = {
     maxRetries?: number;
     initialDelay?: number;
     factor?: number;
+    /**
+     * Ends the retry loop once aborted. A caller that has already given up cannot use a later
+     * result, and every remaining attempt would otherwise sleep for an escalating delay first —
+     * which would let the loop outlive the deadline it is meant to respect.
+     */
+    signal?: AbortSignal;
 };
 
 export function withBackoff<T>(fn: () => Promise<T>, options?: BackoffOptions): Promise<T> {
-    const { maxRetries = 5, initialDelay = 300, factor = 2 } = options ?? {};
+    const { maxRetries = 5, initialDelay = 300, factor = 2, signal } = options ?? {};
 
     async function attempt(retries: number, delay: number): Promise<T> {
         try {
             return await fn();
         } catch (error) {
-            if (retries <= 0) throw error;
+            if (retries <= 0 || signal?.aborted) throw error;
             Logger.debug('[utils:with-backoff] Retrying after failure', { delay, error, retriesLeft: retries });
             await new Promise(resolve => setTimeout(resolve, delay));
+            // The signal can abort while this attempt sleeps. Re-check rather than spend a retry,
+            // so an abort costs at most the delay already in flight.
+            if (signal?.aborted) throw error;
             return attempt(retries - 1, delay * factor);
         }
     }

--- a/bench/BUILD.md
+++ b/bench/BUILD.md
@@ -39,6 +39,7 @@
 | Dynamic | `/api/search` | — | — |
 | Dynamic | `/api/security-txt` | — | — |
 | Dynamic | `/api/sns-domains/[address]` | — | — |
+| Dynamic | `/api/stake-rewards/[address]` | — | — |
 | Dynamic | `/api/token-image/[mintAddress]` | — | — |
 | Dynamic | `/api/token-info` | — | — |
 | Dynamic | `/api/token-market-data/[address]` | — | — |
@@ -48,7 +49,7 @@
 | Dynamic | `/api/verification/jupiter/[mintAddress]` | — | — |
 | Dynamic | `/api/verification/rugcheck/[mintAddress]` | — | — |
 | Dynamic | `/block/[slot]` | 220 kB | 1.25 MB |
-| Dynamic | `/block/[slot]/accounts` | 220 kB | 1.24 MB |
+| Dynamic | `/block/[slot]/accounts` | 210 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/programs` | 210 kB | 1.24 MB |
 | Dynamic | `/block/[slot]/rewards` | 210 kB | 1.24 MB |
 | Dynamic | `/epoch/[epoch]` | 10 kB | 1.04 MB |

--- a/openspec/changes/add-stake-total-reward/proposal.md
+++ b/openspec/changes/add-stake-total-reward/proposal.md
@@ -1,0 +1,118 @@
+# Proposal: Define the lifetime total reward for stake accounts
+
+## Context
+
+The Stake Delegation card (`DelegationCard` in `app/features/stake/ui/StakeAccountSection.tsx`) shows delegated, active, and inactive stake. It shows the vote address. It shows the activation and deactivation epochs. It does not show what the stake has earned.
+
+Other explorers show a lifetime total. We do not.
+
+We measured the number first. For `116vkzEjoTpFEd3x12XL9HbYJ5EpoC4cZ9a1N5A5mUt`, the rewards for epochs 943 to 1011 add up to **4,200,824 lamports**. Of those 69 epochs, 67 paid a reward. Epoch 979 paid nothing.
+
+That figure is fixed for that epoch range, because past epoch rewards never change. The account keeps earning about 62,000 lamports per epoch, so its total today is higher. Read the number as evidence from one measurement, not as the account's current total.
+
+## Why
+
+Two simpler formulas look correct and are wrong. Each epoch adds the reward to `delegation.stake`. So the current account state cannot give you the total.
+
+- `lamports − rentExemptReserve − delegation.stake` gives 10,586. That is the inactive stake, not the reward.
+- `lamports − initial_deposit` gives 4,211,407. That is 10,583 lamports too high. The extra comes from Jito tip claims and dust.
+
+Both errors are small. A reviewer will not catch either one. So we fix the definition before we write code.
+
+### Why the range starts at creation, not at `activationEpoch`
+
+`activationEpoch` looks like the account's first earning epoch. It is not. Re-delegating resets it to
+the epoch of the latest delegation (`process_delegate` calls `new_stake(…, clock.epoch)`), and the
+earlier delegation's rewards are still paid to the same address. A range that starts there drops
+them. On `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs` that is 55,208,535 lamports earned against
+10,482,997 reported — **81% missing**, under a label that reads "Total Reward". Five of 100 sampled
+accounts sharing an activation epoch were already earning more than 100 epochs before it.
+
+Three ways to fix it, and why this one:
+
+- **Start at the cluster's first reward epoch (132).** Correct for every account, and it needs no
+  extra call. It is ruled out by the sweep budget, not by cost — see below.
+- **Rename the row to "Reward since epoch N".** Free, and honest, but gives up the figure we set out
+  to show.
+- **Start at the account's creation epoch.** An account cannot be paid before it exists, so this is a
+  correct floor, and a tight one. `getSignaturesForAddress` finds it — stake accounts hold few
+  signatures, because epoch rewards are credited by the runtime and never appear as transactions.
+  It returns 55,208,535 for the account above, identical to the sweep from epoch 132.
+
+**What decides it is the sweep budget, not the call count.** Measured at concurrency 2 against a
+mainnet provider:
+
+| Sweep | Calls | Wall clock | Retries |
+| --- | --- | --- | --- |
+| From creation, 169 epochs | 172 | 33 s | 37 |
+| From the cluster floor, 881 epochs | 883 | 188 s | 221 |
+
+`SWEEP_BUDGET_MS` is 40 s and `maxDuration` is 60. The 881-epoch sweep is 4.7× over budget, so it
+answers 504 every time. Each attempt does leave its settled epochs cached, so it would warm across
+roughly five timed-out requests, driven by whichever visitors happen to load the page — and until
+then nobody sees a total. The cluster floor is not more expensive, it does not work. Its second cost
+is cache footprint: 881 entries per account against 169, against a Data Cache shared team-wide.
+
+**The honest cost is the warm path.** Once the per-epoch cache is full only the newest epoch is an
+uncached call, so the sweep amortises to nearly nothing while the signature walk is paid on every
+request: 4 network calls per request against the cluster floor's 3. We accept a permanent +1 to keep
+the cold path inside the budget. On latency it is cheap — the walk needs only the address, so it runs
+alongside the two calls already there, at 126 ms against `getAccountInfo`'s 112 ms.
+
+The 33 s figure is worth watching. It leaves 7 s of headroom, so an account a few hundred epochs old
+sits near the limit even with this floor.
+
+**There is no fallback.** A page that comes back full means older signatures may sit behind it, so
+the walk pages back until a page arrives short. If it still cannot date the account — more than five
+pages, or no signatures at all — the request fails. Substituting `activationEpoch` there would answer
+200 with a total short by an unknown amount, which is the same failure this change exists to fix, and
+it would hit exactly the accounts with the longest histories. The card already renders `unavailable`
+rather than a zero.
+
+### Why we compute the total on the server
+
+- **The cost is one RPC call per epoch.** That is 69 calls for the example account, and about 880 for one delegated near epoch 132. No RPC method returns the total.
+- **On the client, every visitor pays that cost again.** On the server we pay it once and share the result.
+- **The result is the same for everyone, and it changes once per epoch.** An epoch lasts about 2.1 days, so a cached result stays correct for a long time.
+- **We already cache route responses.** Routes under `app/api/**` set `Cache-Control` headers. There is no new infrastructure to add.
+- **The cost is paid once, not per visitor.** Fan-out stays low either way — `d5ee71e72` (#854) cut client fan-out to two calls at a time after 429s, and the sweep uses the same ceiling. Moving it server-side does not make it faster; it makes it happen once and be shared.
+
+`GET /api/idl-latest` already has this shape. The route parses params, sets cache headers, and maps errors. The entity does the work.
+
+The trade-off: the first request for an account still pays for the whole sweep.
+
+### Why we cache each epoch, not the total
+
+- **A settled epoch's reward never changes.** So each epoch response can be cached forever. There is no cache lifetime to choose and no staleness window.
+- **After an epoch boundary only one epoch is a miss.** The rest are hits, so the sweep runs once per account and then grows by one call every 2.1 days.
+- **The cache survives deploys.** We measured it: entries written with `next: { revalidate: false }` survived a rebuild with a new build ID. The fetch cache key does not include the build ID.
+- **It is the mechanism we already use.** `app/entities/digital-asset/api.ts` caches its POST fetches the same way. No new concept and no config change.
+
+We use `fetch` with `cache: 'force-cache'`. We do not use `use cache: remote`, which would require turning on `cacheComponents` for the whole app.
+
+## What Changes
+
+- **Define the total.** It is the sum of the per-epoch inflation staking rewards, over the account's own epoch range. Do not derive it from the current account state. Exclude MEV and transfers.
+- **Bound the epoch range with the account.** Start at the epoch the account was created in. End at `deactivationEpoch`. Floor the start at the first epoch that paid inflation rewards (mainnet-beta 132, testnet 43). Inflation began in that epoch, so no earlier epoch can hold a reward. For the example account this gives 69 epochs, not 1012.
+
+- **Compute the total on the server**, behind a cached route handler. The client makes one request.
+- **Cache each epoch's RPC response on its own**, with `cache: 'force-cache'` and `next: { revalidate: false }`. One entry per account per epoch. The request body differs per epoch, and the body is part of the cache key, so each epoch gets its own entry.
+- **Do not cache the newest epoch.** The last epoch in the range may not have settled yet, so it is fetched with `cache: 'no-store'`. Every earlier epoch is cached forever.
+
+- **Show the total as a row in the Stake Delegation card, with three states.** Loading shows a placeholder in the row itself, not a spinner over the whole card. Success shows the SOL amount. Failure shows a short, quiet message in the same place. The other rows keep working either way.
+- **Run the sweep with `fetchAll` at concurrency 2**, matching the client paths. 8 was measured to rate-limit a cold sweep partway through. After warm-up only the newest epoch is an uncached call, so the ceiling costs nothing in the steady state.
+
+- **Cache the route response at the CDN for 4 hours**, using the shared `CACHE_HEADERS` in `app/shared/lib/http-utils.ts` (`max-age` and `s-maxage` of 14400, `stale-while-revalidate` of 3600). This sits on top of the per-epoch cache: without it, every request re-runs the sweep as cache reads even when no epoch has changed. Only successful responses carry it.
+
+- **Fail the whole request when part of the sweep fails.** An RPC error that survives `withBackoff` returns an uncached 502, following `app/api/idl-latest/route.ts`. A null result is not a failure — it means no reward was paid and counts as zero. We never return a partial total, because it is wrong by an unknown amount and still looks authoritative. Every epoch that did succeed stays in the per-epoch cache, so a retry re-fetches only what failed.
+
+## Impact
+
+- **Files:** a `stake-rewards` entity (creation epoch, epoch range, sweep), the stake feature's delegation parser, hook and card row, and `GET /api/stake-rewards/[address]`.
+- **What the number leaves out.** It counts inflation staking rewards only. It excludes MEV paid into the stake account. A fully deactivated account stops earning, so the range ends at `deactivationEpoch`. That last bound is a small known gap: cooldown can span several epochs when a lot of stake deactivates at once, and a partially effective stake still earns during them.
+- **One extra RPC call per request**, for the signature walk that dates the account — more if the account has over 1000 signatures. It runs in parallel with the two calls already there, so it adds about 14 ms rather than a round trip. Sampled on mainnet-beta: 25 accounts delegated in epoch 1005 held a median of 8 signatures and at most 139; 25 delegated in epoch 300 held a median of 270 and at most 615. None needed a second page.
+- **Accounts we will refuse to answer for.** An account with more than 5000 signatures returns 502 and the card shows `unavailable`. None were found in sampling, and the alternative is a total that is short by an unknown amount.
+- **A long-idle account now costs more.** One created long ago but delegated only recently sweeps from creation and finds zeros for most of that span. It cannot be told apart from a re-delegated account without sweeping, so it pays. If it exceeds the budget the card shows `unavailable` rather than a short total.
+- **Open cost problem.** No RPC method returns the total. It costs one call per epoch on a cold cache.
+- **Cache size to watch.** One entry per account per epoch, about 133 bytes each. The cache evicts least-recently-used entries, so "forever" is best effort. An evicted epoch costs one re-fetch, not a wrong answer. On Pro the Data Cache is shared by every project in the team, so heavy writing evicts other projects' entries. Check Observability → Runtime Cache after release. If we are evicting other projects, move the aggregation to the CDN cache on our own route: one entry per account instead of one per epoch.
+- **Cost of not caching the newest epoch:** one uncached RPC call per sweep. That is the price of never storing an unsettled epoch forever, and it is cheap next to the alternative — a permanently short total that survives deploys and needs a team-wide cache purge to clear.

--- a/openspec/changes/add-stake-total-reward/specs/stake-reward-total/spec.md
+++ b/openspec/changes/add-stake-total-reward/specs/stake-reward-total/spec.md
@@ -1,0 +1,193 @@
+## ADDED Requirements
+
+### Requirement: The lifetime total SHALL be the sum of per-epoch inflation rewards over the account's own epoch range
+
+The total SHALL be the sum of the `getInflationReward` amounts for the stake account, across every epoch in the range. It MUST NOT be derived from the current account state.
+
+The range SHALL start at the later of two values: the epoch the account was created in, or the first epoch that paid inflation rewards on the cluster (mainnet-beta 132, testnet 43). The range SHALL end at the earlier of two values: the previous epoch, or the account's `delegation.deactivationEpoch`.
+
+An epoch may return no reward. This happens when the validator was delinquent, or when the RPC does not serve that epoch. Such an epoch SHALL count as zero. It MUST NOT stop the sum.
+
+The total SHALL count inflation staking rewards only. It SHALL exclude lamports from any other source, such as MEV tip claims and plain transfers. Those stay loose in the account and never enter `delegation.stake`.
+
+#### Scenario: Range covers the account's own epochs and stops before the current one
+
+- **WHEN** a stake account created and activated in epoch 943 is queried during epoch 1012, with no deactivation set
+- **THEN** the range SHALL be epochs 943 through 1011
+- **AND** the total SHALL NOT include the current epoch
+
+#### Scenario: Rewards are summed and a non-paying epoch counts zero
+
+- **WHEN** the range covers four epochs, three paying 10, 20, and 30 lamports and one paying nothing
+- **THEN** the total SHALL be 60 lamports
+
+#### Scenario: Deactivated stake account
+
+- **WHEN** the account's `delegation.deactivationEpoch` is set and is earlier than the current epoch
+- **THEN** the range SHALL end at `deactivationEpoch`, not at the current epoch
+
+#### Scenario: Account credited with MEV or transfers
+
+- **WHEN** the stake account has received lamports from tip claims or transfers
+- **THEN** the total SHALL NOT include those lamports
+
+### Requirement: The range SHALL start at the account's creation epoch, not its activation epoch
+
+The endpoint SHALL derive the start of the range from the epoch the stake account was created in, read from the slot of the account's oldest signature. It MUST NOT use `delegation.activationEpoch` as the start, under any condition.
+
+Re-delegating a stake account resets `delegation.activationEpoch` to the epoch of the latest delegation. The earlier delegation's rewards are still paid to the same address and still returned by `getInflationReward`, so a range that starts at `activationEpoch` drops them. Measured on `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs`: 55,208,535 lamports earned, 10,482,997 reported, 81% missing. Five of 100 sampled accounts sharing an activation epoch were already earning more than 100 epochs before it.
+
+An account cannot be paid a reward before it exists, so the creation epoch is a correct start. The cluster's first reward epoch is also correct, but a sweep that long does not fit the route's budget: measured at 188 seconds for 881 epochs, against a 40-second sweep budget.
+
+The endpoint SHALL page `getSignaturesForAddress` backwards until a page arrives shorter than the page limit, which is the end of the account's history. A full page MUST NOT end the walk, because older signatures may sit behind it.
+
+When the account still cannot be dated — more pages than the walk will follow, or no signatures at all — the endpoint SHALL return an error. It MUST NOT substitute `delegation.activationEpoch` or any other epoch. Every substitute is a start later than the truth, which yields a total short by an unknown amount that cannot be told apart from a correct one. This is the same failure the sweep's own error policy prevents, and it would strike exactly the accounts with the longest histories.
+
+#### Scenario: Re-delegated account is swept from creation
+
+- **WHEN** an account reports `activationEpoch` 1005 but its oldest signature falls in epoch 844
+- **THEN** the range SHALL start at epoch 844
+
+#### Scenario: Signature page comes back full
+
+- **WHEN** a page of signatures returns the maximum number of entries
+- **THEN** the endpoint SHALL request the next page back
+- **AND** SHALL NOT treat the oldest entry of that page as the account's first
+
+#### Scenario: Account has more history than the walk will follow
+
+- **WHEN** the walk reaches its page limit with every page still full
+- **THEN** the endpoint SHALL return an error
+- **AND** SHALL NOT return a total
+- **AND** SHALL NOT sweep any epoch
+
+#### Scenario: Older account delegated this epoch
+
+- **WHEN** an account was created in an earlier epoch but `activationEpoch` is the current epoch
+- **THEN** the endpoint SHALL still sweep from the creation epoch
+- **AND** SHALL NOT report zero on the strength of `activationEpoch` alone
+
+#### Scenario: Signature lookup fails
+
+- **WHEN** the request for the account's signatures fails
+- **THEN** the endpoint SHALL return an error
+- **AND** SHALL NOT sweep a range bounded by `delegation.activationEpoch`
+
+### Requirement: Only settled epochs SHALL be cached permanently
+
+The last epoch in the range MAY still be unsettled, so its response SHALL NOT be stored in a permanent cache entry. Every earlier epoch SHALL be cached with no expiry.
+
+Rewards for epoch N become effective inside epoch N+1, not at the boundary. Measured across 67 consecutive epochs, they landed 2 to 297 slots after the boundary, and never before it. So the last epoch in the range can return no reward simply because it has not settled yet. Storing that as a permanent zero would keep the total short for as long as the entry survives, which is across deployments.
+
+Every epoch before the last one settled at least a full epoch earlier. Those are safe to cache with no expiry.
+
+#### Scenario: Newest epoch has not settled
+
+- **WHEN** the last epoch in the range returns no reward because it has not settled
+- **THEN** that response SHALL NOT be stored in a permanent cache entry
+- **AND** a later request SHALL fetch that epoch again
+
+#### Scenario: Older epochs are cached
+
+- **WHEN** an epoch other than the last in the range is fetched
+- **THEN** its response SHALL be cached with no expiry
+
+### Requirement: The endpoint SHALL say why an address has no total
+
+The endpoint SHALL tell apart the reasons an address cannot produce a total, and MUST NOT report them all the same way. Each reason points the caller at a different fix, and collapsing them hides which one applies.
+
+An address that does not exist SHALL return `404`. An address that exists but is not a stake account SHALL return `400`. A stake account that has never been delegated SHALL return `400` with a message distinct from the previous case.
+
+None of these SHALL report a total of zero. A never-delegated account has no activation epoch, so there is no range to sum, and zero would be a claim about the account rather than about the request. None of these responses SHALL be cached: an account can be created or delegated at any time, and a cached answer would outlive the fact.
+
+#### Scenario: Account does not exist
+
+- **WHEN** the address has no account
+- **THEN** the endpoint SHALL respond `404`
+- **AND** SHALL NOT sweep any epoch
+
+#### Scenario: Address is not a stake account
+
+- **WHEN** the account exists but is not a parsable stake account
+- **THEN** the endpoint SHALL respond `400`
+
+#### Scenario: Stake account has never been delegated
+
+- **WHEN** the account is a stake account with no delegation
+- **THEN** the endpoint SHALL respond `400` with a message distinct from a missing or non-stake account
+- **AND** SHALL NOT report a total of zero
+
+#### Scenario: None of these are cached
+
+- **WHEN** the endpoint rejects an address for any of the reasons above
+- **THEN** the response SHALL NOT carry cache headers
+
+### Requirement: A failed sweep SHALL return an error, never a partial total
+
+The endpoint SHALL fail the whole request when any epoch in the range cannot be fetched. It MUST NOT return a total computed from only the epochs that succeeded.
+
+A partial total cannot be told apart from a correct one, so returning one would present a wrong figure as if it were right.
+
+An epoch that returns no reward is not a failure. It counts as zero, as described above. A failure is an RPC error that remains after the configured retries.
+
+The error response SHALL NOT be cached, so a passing failure cannot be held for the length of the success cache window.
+
+#### Scenario: An epoch fails after retries
+
+- **WHEN** an epoch's request still fails after the configured retries
+- **THEN** the endpoint SHALL respond with an error
+- **AND** the response SHALL NOT carry a total
+- **AND** the response SHALL NOT be cached
+
+#### Scenario: No reward is not a failure
+
+- **WHEN** an epoch returns a successful response that carries no reward
+- **THEN** it SHALL count as zero and the sweep SHALL continue
+
+#### Scenario: Retry after a failure
+
+- **WHEN** a request is retried after a failed sweep
+- **THEN** the epochs that already succeeded SHALL be served from the cache
+- **AND** only the failed epochs SHALL be fetched again
+
+### Requirement: Successful responses SHALL be cached at the CDN for four hours
+
+A successful response SHALL carry the shared cache headers used by the other route handlers: `max-age` and `s-maxage` of 14400 seconds, with `stale-while-revalidate` of 3600.
+
+This sits on top of the per-epoch cache. Without it, every request repeats the whole sweep as cache reads even when no epoch has changed.
+
+An epoch lasts about 50 hours, so a four-hour entry means the total can lag a new epoch by up to four hours. That is accepted: the figure is a lifetime total, and being one epoch behind for part of a day does not mislead.
+
+#### Scenario: Repeat request inside the cache window
+
+- **WHEN** a second request for the same address and cluster arrives inside the four-hour window
+- **THEN** it SHALL be served from the CDN
+- **AND** the sweep SHALL NOT run again
+
+### Requirement: The card SHALL show the total with separate loading, value, and error states
+
+The Stake Delegation card SHALL always render the total reward row, and the row SHALL show its own state rather than putting the whole card into a loading or error state.
+
+While the total is being fetched, the row SHALL show a loading placeholder. When it resolves, the row SHALL show the amount in SOL. When it fails, the row SHALL show a short message in place of the amount.
+
+The failure message SHALL be visually quiet. It SHALL NOT use the styling reserved for destructive or blocking errors, because a missing total does not stop the rest of the card being useful. The row SHALL NOT show `0` when the total is unavailable, because zero is a claim about the account rather than a claim about the request.
+
+A failure to load the total SHALL NOT affect the other rows in the card.
+
+#### Scenario: Total is loading
+
+- **WHEN** the total has been requested and has not resolved
+- **THEN** the row SHALL show a loading placeholder
+- **AND** the other rows in the card SHALL render normally
+
+#### Scenario: Total resolves
+
+- **WHEN** the total resolves
+- **THEN** the row SHALL show the amount in SOL
+
+#### Scenario: Total fails to load
+
+- **WHEN** the request for the total fails
+- **THEN** the row SHALL show a short, quiet message instead of the amount
+- **AND** the row SHALL NOT show `0`
+- **AND** the other rows in the card SHALL render normally


### PR DESCRIPTION
> [!CAUTION]
> # 🚧 DO NOT MERGE — DEMO ONLY 🚧
>
> ## This PR is open for **testing and demonstration purposes only**. It is **not** ready to merge.
>
> Known blockers:
>
> - **Cold-cache sweeps time out.** A 169-epoch account returns **504** on the preview deployment at 41.2 s, against a 40 s sweep budget. That is the re-delegated case this change exists to fix.
> - **The measurements in this description came from a Helius endpoint**, not the Triton endpoint production uses. They should not be relied on for capacity planning.
> - **Open design question.** A per-request RPC sweep is doing an indexer's job. See Additional Notes.

---

## Description

Adds a **Total Reward** row to the Stake Delegation card, showing a stake account's lifetime inflation rewards in SOL.

The figure cannot come from the account state. Each epoch's reward is added to both the lamport balance and `delegation.stake`, and the principal at delegation time is never stored, so the two are indistinguishable on chain. `credits_observed` is vote credits, not lamports. The only source is `getInflationReward`, which serves one epoch per call.

So the sum runs server-side behind `GET /api/stake-rewards/[address]`:

- **Each settled epoch's RPC response is cached with no expiry.** A past epoch's reward never changes, so there is no staleness window to choose. Only the newest epoch in the range is fetched uncached, since it may not have settled yet.
- **The route response is cached at the CDN for four hours**, so a warm request does not re-read the whole range.
- **A failed sweep returns an uncached error, never a partial total.** A partial total is wrong by an unknown amount and still looks authoritative. Every epoch that did succeed stays cached, so a retry re-fetches only what failed.

### The epoch range starts at account creation, not activation

`delegation.activationEpoch` looks like the account's first earning epoch. It is not — re-delegating resets it to the epoch of the latest delegation (`process_delegate` calls `new_stake(…, clock.epoch)`), and the earlier delegation's rewards are still paid to the same address.

Measured on `MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs`: **55,208,535 lamports earned, 10,482,997 reported — 81% missing.** Five of 100 sampled accounts sharing an activation epoch were already earning more than 100 epochs before it.

The range therefore starts at the epoch of the account's oldest signature. An account cannot be paid before it exists, so this is a correct floor and a tight one. Flooring at the cluster's first reward epoch (132) is also correct but does not fit the route's budget — measured at 188 s for 881 epochs against a 40 s sweep budget, versus 33 s for 169 epochs from the creation epoch. Both return the same total.

There is no fallback. The signature walk pages back until a page arrives short; if the account still cannot be dated it returns an error and the card shows `unavailable`, because substituting any later epoch reproduces exactly the short-total failure above.

Rationale and the alternatives considered are in [`openspec/changes/add-stake-total-reward/proposal.md`](openspec/changes/add-stake-total-reward/proposal.md).

### Known limitations

- Counts inflation staking rewards only — MEV tip claims and transfers are excluded by design.
- `toEpoch` stops at `deactivationEpoch`. Cooldown can span several epochs when a lot of stake deactivates at once, and a partially effective stake still earns during them.
- A long-idle account — created long ago, delegated only recently, never delegated in between — sweeps from creation and finds zeros for most of that span. It cannot be told apart from a re-delegated account without sweeping.

## Type of change

-   [x] New feature

## Testing

Manual testing on the preview deployment:

- [Stake account, 70 epochs](https://explorer-8t8lkg6na-solana-foundation.vercel.app/address/116vkzEjoTpFEd3x12XL9HbYJ5EpoC4cZ9a1N5A5mUt) — creation epoch equals activation epoch. Total Reward reads **0.004263041 SOL** (epochs 943–1012), matching a direct mainnet sweep.
- [Stake account, re-delegated, 169 epochs](https://explorer-8t8lkg6na-solana-foundation.vercel.app/address/MCrWxQJgT3VogbgM5sy78K4uCEmwPQiKeXG2Bna51zs) — expected **0.055208535 SOL** (epochs 844–1012), against the 0.010482997 SOL that `activationEpoch` alone would give. **On a cold cache this currently returns 504** — see Additional Notes.
- [Not a stake account](https://explorer-8t8lkg6na-solana-foundation.vercel.app/address/So11111111111111111111111111111111111111112) — the card must not render a Total Reward row.

Both totals grow by roughly one epoch's reward per 2.1 days, so expect them to exceed these figures over time — the second should stay about 13× the first.

## Related Issues

Closes [HOO-898](https://linear.app/solana-fndn/issue/HOO-898/add-total-reward-field-to-stake-account-overview)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have updated documentation as needed
-   [x] I have run `build:info` script to update build information

## Additional Notes

**Cold-cache sweeps are slower on Vercel than measured locally, and the 169-epoch account currently times out.** Measured against this preview: the 70-epoch account returned 200 with the correct total in 24.2 s, and the 169-epoch account returned 504 at 41.2 s, hitting `SWEEP_BUDGET_MS` (40 s). Locally the same sweeps took 13.7 s and 33.0 s. Each attempt does leave its settled epochs cached, so a repeat request resumes rather than starting over — but the first visitor to a long-range account sees `unavailable`. Needs either a higher budget with `maxDuration` raised to match, or the indexer path below. Flagging rather than hiding it.


The measurements quoted above were taken against a **Helius** endpoint, which is what `.env` configures locally — not against Triton, which production uses. Rate-limit and latency figures should be re-checked against Triton before they are used for capacity planning.

Longer term this is an indexer's job, not an RPC's. Epoch rewards are published once per epoch across ~274 blocks (~4,000 entries each, ~1.1M per epoch), so ~274 `getBlock` calls capture the whole cluster — against one call per account per epoch here. Triton's Old Faithful archive carries that reward metadata and is already routed into the subscription. Worth a separate proposal.



