### PR TITLE
fix(token): build uiAmountString with the exact bigint formatter

### DIFF
--- a/app/features/decode-instruction-token-2022/lib/__tests__/token-2022-parser.spec.ts
+++ b/app/features/decode-instruction-token-2022/lib/__tests__/token-2022-parser.spec.ts
@@ -5,6 +5,7 @@ import {
     getInitializeTokenGroupInstructionDataEncoder,
     getInitializeTokenMetadataInstructionDataEncoder,
     getRemoveTokenMetadataKeyInstructionDataEncoder,
+    getTransferCheckedInstructionDataEncoder,
     getUpdateTokenGroupMaxSizeInstructionDataEncoder,
     getUpdateTokenGroupUpdateAuthorityInstructionDataEncoder,
     getUpdateTokenMetadataFieldInstructionDataDecoder,
@@ -151,5 +152,16 @@ describe('parseToken2022Instruction — SPL interface instructions', () => {
             value: 'X',
         });
         expect(() => getUpdateTokenMetadataFieldInstructionDataDecoder().decode(data)).toThrow();
+    });
+
+    test('should build uiAmountString as an exact decimal for transferChecked', () => {
+        // 1 base unit of a 9-decimal mint. The buggy float path produced "1e-9"
+        // (and lost precision for amounts above 2^53); uiAmountString must be the
+        // exact plain decimal, matching Solana RPC jsonParsed output.
+        const data = getTransferCheckedInstructionDataEncoder().encode({ amount: 1n, decimals: 9 });
+        const parsed = parse(data, [MINT_AUTHORITY, MINT, METADATA, AUTHORITY]);
+        expect(parsed?.type).toBe('transferChecked');
+        const info = parsed?.info as { tokenAmount: { uiAmountString: string } };
+        expect(info.tokenAmount.uiAmountString).toBe('0.000000001');
     });
 });

--- a/app/features/decode-instruction-token-2022/lib/token-2022-parser.ts
+++ b/app/features/decode-instruction-token-2022/lib/token-2022-parser.ts
@@ -1,4 +1,5 @@
 import { getTokenIxValidator } from '@components/instruction/token/types';
+import { formatTokenAmount } from '@entities/token-amount';
 import { isParsedInstructionProgram, type ParserProgramLabel } from '@explorer/parsers';
 import { unwrapOption } from '@solana/kit';
 import { type ParsedInstruction, PublicKey } from '@solana/web3.js';
@@ -18,7 +19,6 @@ import {
     parseUpdateMetadataPointerInstruction,
     Token2022Instruction,
 } from '@solana-program/token-2022';
-import { normalizeTokenAmount } from '@utils/index';
 import { create } from 'superstruct';
 
 import type { KitInstruction } from '@/app/shared/lib/web3js-compat';
@@ -112,7 +112,7 @@ export function parseToken2022Instruction(ix: KitInstruction): Token2022Parsed |
                         tokenAmount: {
                             amount,
                             decimals,
-                            uiAmountString: normalizeTokenAmount(amount, decimals).toString(),
+                            uiAmountString: formatTokenAmount({ amount: BigInt(amount), decimals }),
                         },
                     },
                     type: 'transferChecked',

--- a/app/features/decode-instruction-token/lib/token-parser.ts
+++ b/app/features/decode-instruction-token/lib/token-parser.ts
@@ -1,4 +1,5 @@
 import { getTokenIxValidator } from '@components/instruction/token/types';
+import { formatTokenAmount } from '@entities/token-amount';
 import { isParsedInstructionProgram, type ParserProgramLabel } from '@explorer/parsers';
 import { type ParsedInstruction, PublicKey } from '@solana/web3.js';
 import {
@@ -10,7 +11,6 @@ import {
     parseTransferInstruction,
     TokenInstruction,
 } from '@solana-program/token';
-import { normalizeTokenAmount } from '@utils/index';
 import { create } from 'superstruct';
 
 import type { KitInstruction } from '@/app/shared/lib/web3js-compat';
@@ -88,7 +88,7 @@ export function parseTokenInstruction(ix: KitInstruction): TokenParsed | undefin
                         tokenAmount: {
                             amount,
                             decimals,
-                            uiAmountString: normalizeTokenAmount(amount, decimals).toString(),
+                            uiAmountString: formatTokenAmount({ amount: BigInt(amount), decimals }),
                         },
                     },
                     type: 'transferChecked',


### PR DESCRIPTION
## Summary

The TransferChecked parsers build `uiAmountString` with `normalizeTokenAmount(amount, decimals).toString()`, and `normalizeTokenAmount` is `parseInt(raw) / Math.pow(10, decimals)`, so the value is routed through a JS `double`:

```ts
uiAmountString: normalizeTokenAmount(amount, decimals).toString(),
```

`uiAmountString` is meant to be the exact, lossless plain decimal of `amount / 10^decimals` (the precise counterpart to the numeric `uiAmount`, and what Solana RPC jsonParsed always emits, never in exponent form). The float path breaks that in two ways for valid `u64` inputs:

```
amount, decimals | current           | correct
1, 9             | "1e-9"            | "0.000000001"
9007199254740993, 6 | "9007199254.740992" | "9007199254.740993"
1000000000000000000000, 0 | "1e+21"     | "1000000000000000000000"
```

So any UI amount below 1e-6 renders in exponent notation, and amounts at/above 2^53 base units lose precision. This field is passed through to MCP clients via `decodeInstructionFallback`, so consumers receive the wrong string.

## Fix

Use the repo's own `formatTokenAmount` (the exact bigint path, already used by `token-batch` and `instruction-simulation`) in both the token and token-2022 parsers:

```ts
uiAmountString: formatTokenAmount({ amount: BigInt(amount), decimals }),
```

## Test

Added a `transferChecked` case to `token-2022-parser.spec.ts` asserting `uiAmountString === "0.000000001"` for a 1-base-unit, 9-decimal transfer. It fails on the old float path (`"1e-9"`) and passes with the fix. `vitest --project specs`, `eslint`, and `prettier` all pass.
