### PR TITLE
fix(transaction): show UTC alongside local timestamp

### DIFF
--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -21,7 +21,7 @@ import {
 } from '@providers/transactions';
 import { ParsedTransaction, SystemInstruction, SystemProgram } from '@solana/web3.js';
 import { Cluster, ClusterStatus } from '@utils/cluster';
-import { displayTimestamp } from '@utils/date';
+import { displayTimestamp, displayTimestampUtc } from '@utils/date';
 import { SignatureProps } from '@utils/index';
 import { getTransactionInstructionError } from '@utils/program-err';
 import { intoTransactionInstruction } from '@utils/tx';
@@ -349,18 +349,31 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
                 )}
 
                 {/* Timestamp */}
-                <Row>
-                    <Label>Timestamp</Label>
-                    <Value>
-                        {info.timestamp !== 'unavailable' ? (
-                            <span className="font-mono">{displayTimestamp(info.timestamp * 1000)}</span>
-                        ) : (
+                {info.timestamp !== 'unavailable' ? (
+                    <>
+                        <Row divider>
+                            <Label>Timestamp (Local)</Label>
+                            <Value>
+                                <span className="font-mono">{displayTimestamp(info.timestamp * 1000, true)}</span>
+                            </Value>
+                        </Row>
+                        <Row>
+                            <Label>Timestamp (UTC)</Label>
+                            <Value>
+                                <span className="font-mono">{displayTimestampUtc(info.timestamp * 1000, true)}</span>
+                            </Value>
+                        </Row>
+                    </>
+                ) : (
+                    <Row>
+                        <Label>Timestamp</Label>
+                        <Value>
                             <InfoTooltip bottom text="Timestamps are only available for confirmed blocks">
                                 Unavailable
                             </InfoTooltip>
-                        )}
-                    </Value>
-                </Row>
+                        </Value>
+                    </Row>
+                )}
             </Card>
         </section>
     );


### PR DESCRIPTION
## Description

The transaction summary card rendered the block time only in the viewer's local timezone. That makes it awkward to correlate a transaction against validator logs, RPC responses, and other tooling, which all report UTC — the reader has to do the offset conversion in their head.

This splits the single `Timestamp` row into two rows, `Timestamp (Local)` and `Timestamp (UTC)`, reusing the existing `displayTimestampUtc` helper from `@utils/date`. The layout mirrors how the block page (`app/block/[slot]/layout.tsx`) already presents block time, so the two pages now read consistently. Both rows pass the short timezone name, again matching the block page.

When the timestamp is unavailable the card still renders a single `Timestamp` row with the existing tooltip — that path is unchanged apart from the conditional moving from inside the value cell out to the row level.

This is a stop-gap until the reusable timestamp component lands.

## Type of change

-   [x] Bug fix

## Screenshots
<img width="1117" height="751" alt="Screenshot 2026-08-12 at 16 47 47" src="https://github.com/user-attachments/assets/378660a4-43aa-4b9f-aa70-df127ca5653d" />

<!-- to be added -->

## Testing

Manual testing on the preview deployment:

- [Transaction page — both `Timestamp (Local)` and `Timestamp (UTC)` render, and the UTC value reads `Aug 12, 2026 at 09:27:59 UTC`](https://explorer-git-fix-utc-time-transaction-page-solana-foundation.vercel.app/tx/2u4yBeREPdCo1GAK2CZFU9QKRAvjnbDtBB28Cpfe9Cj36Y8AR3Fmgb7c4XK7GAd54JGsoN3YoaQfTQY6T6Nm2d42)
- [Another transaction in the same block — same two rows, same UTC value](https://explorer-git-fix-utc-time-transaction-page-solana-foundation.vercel.app/tx/3iZ7CHX1eYU6Knr5waaVQ2sCFPCAkce4B8GA8yRw5D6LMN711dprJJp1FmXJWTzVALFiQReyngMJZRNGaQz8M5cV)
- [Block 438785999 — the block page this layout mirrors; its Local/UTC rows should read identically to the two above](https://explorer-git-fix-utc-time-transaction-page-solana-foundation.vercel.app/block/438785999)
- [Devnet transaction — confirms the rows are cluster-independent; UTC reads `Aug 12, 2026 at 09:45:15 UTC`](https://explorer-git-fix-utc-time-transaction-page-solana-foundation.vercel.app/tx/66ZHvVUm2wbastA5vzxEWGohYE1giuG7ouApXX5QQBsw43cvDpEf23JBA7cLMco28QCczGnYiSXGwXeEE3E3R7rU?cluster=devnet)

## Related Issues

Closes [HOO-1046](https://linear.app/solana-fndn/issue/HOO-1046/add-utc-time-to-transaction-page)

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] I have run `build:info` script to update build information

## Additional Notes

`bench/BUILD.md` was regenerated by `build:info` and came back unchanged, so there is no diff for it in this PR.

The existing `SummaryCard` Storybook stories cover both branches of this change — `NoTimestamp` exercises the `unavailable` path, and the default stories cover the two new rows. No new tests were added, since the change is presentational and those stories already assert the card renders.


