### PR TITLE
feat(tx): read transaction details with kit so v1 renders

### DIFF
--- a/app/components/common/BaseInstructionCard.tsx
+++ b/app/components/common/BaseInstructionCard.tsx
@@ -11,7 +11,7 @@ import { Code } from 'react-feather';
 
 import { BaseTable } from '@/app/shared/ui/Table';
 
-import { BaseRawDetails } from './BaseRawDetails';
+import { BaseRawDetails, RawDetailsUnavailable } from './BaseRawDetails';
 import { BaseRawParsedDetails } from './BaseRawParsedDetails';
 
 type InstructionProps = {
@@ -28,6 +28,8 @@ type InstructionProps = {
     raw?: TransactionInstruction;
     // will be triggered on requesting raw data for instruction, if present
     onRequestRaw?: () => void;
+    // set when no request can produce `raw`, so the Raw view says so instead of omitting its rows
+    rawUnavailable?: boolean;
     // Extra buttons rendered in the card header next to Raw
     headerButtons?: React.ReactNode;
     // Show a Collapse/Expand button that hides all card content
@@ -46,6 +48,7 @@ export function BaseInstructionCard({
     childIndex,
     raw,
     onRequestRaw,
+    rawUnavailable,
     headerButtons,
     collapsible = false,
 }: InstructionProps) {
@@ -108,7 +111,11 @@ export function BaseInstructionCard({
                             </BaseTable.Row>
                             {'parsed' in ix ? (
                                 <BaseRawParsedDetails ix={ix}>
-                                    {raw ? <BaseRawDetails ix={raw} /> : null}
+                                    {raw ? (
+                                        <BaseRawDetails ix={raw} />
+                                    ) : rawUnavailable ? (
+                                        <RawDetailsUnavailable />
+                                    ) : null}
                                 </BaseRawParsedDetails>
                             ) : (
                                 <BaseRawDetails ix={ix} />

--- a/app/components/common/BaseRawDetails.tsx
+++ b/app/components/common/BaseRawDetails.tsx
@@ -19,6 +19,21 @@ function RawDetailsLoader() {
 }
 
 /**
+ *  Stands in for the account and hex data rows when the transaction's instructions cannot be
+ *  reconstructed from its wire bytes — web3.js builds them from a `VersionedMessage`, which tops
+ *  out at v0.
+ */
+export function RawDetailsUnavailable() {
+    return (
+        <BaseTable.Row>
+            <BaseTable.Cell colSpan={2} className="text-center text-dark-muted-foreground">
+                Account list and hex data are not available for this transaction version
+            </BaseTable.Cell>
+        </BaseTable.Row>
+    );
+}
+
+/**
  *  Component that displays accounts from any Instruction.
  *
  *  VersionedMessage is optional as it will be present at inspector page only.

--- a/app/components/common/__tests__/BaseInstructionCard.spec.tsx
+++ b/app/components/common/__tests__/BaseInstructionCard.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax -- test assertions use RegExp for pattern matching */
 import { ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { TransactionMessage } from '@solana/web3.js';
+import { SystemProgram, TransactionMessage } from '@solana/web3.js';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import { resolveAddressLookupTables } from '@/app/__tests__/mock-resolvers';
@@ -63,5 +63,32 @@ describe('BaseInstructionCard', () => {
         expect(await screen.findAllByText(/Associated Token Program/)).toHaveLength(1);
         // we expect specific internal component to be rendered with "defaultRaw"
         expect(screen.getByText('Instruction Data')).toBeInTheDocument();
+    });
+
+    test('should say so when the accounts and hex data cannot be reconstructed', async () => {
+        const parsedIx = {
+            parsed: { info: { lamports: 1 }, type: 'transfer' },
+            program: 'system',
+            programId: SystemProgram.programId,
+        };
+
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <BaseInstructionCard
+                        ix={parsedIx}
+                        index={0}
+                        title="System: Transfer"
+                        result={{ err: null }}
+                        defaultRaw
+                        rawUnavailable
+                    />
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(
+            await screen.findByText(/Account list and hex data are not available for this transaction version/),
+        ).toBeInTheDocument();
     });
 });

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -488,12 +488,23 @@ export function PermalinkView({
         return <ErrorCard text="Transaction was not found" retry={reset} retryText="Reset" />;
     }
 
-    const { message, signatures, meta } = transaction;
+    const { message, messageBytes, signatures, meta } = transaction;
+    // The inspector renders a web3.js `VersionedMessage`, which cannot represent a v1 message.
+    if (!message) {
+        return (
+            <ErrorCard
+                text={`The inspector does not yet support v${transaction.version} transactions`}
+                retry={reset}
+                retryText="Reset"
+            />
+        );
+    }
+
     const tx = {
         accountBalances: meta,
         compiledInnerInstructions: meta?.innerInstructions,
         message,
-        rawMessage: message.serialize(),
+        rawMessage: messageBytes,
         signatures,
     };
     return <LoadedView transaction={tx} onClear={reset} showTokenBalanceChanges={showTokenBalanceChanges} />;

--- a/app/components/instruction/InstructionCard.tsx
+++ b/app/components/instruction/InstructionCard.tsx
@@ -41,7 +41,7 @@ export function InstructionCard({
     // Use provided raw prop, or fetch from transaction details
     let raw: TransactionInstruction | undefined = rawProp;
     if (!raw && rawDetails && childIndex === undefined) {
-        raw = rawDetails?.data?.raw?.transaction.instructions[index];
+        raw = rawDetails?.data?.raw?.transaction?.instructions[index];
     }
 
     const fetchRaw = useFetchRawTransaction();

--- a/app/components/instruction/InstructionCard.tsx
+++ b/app/components/instruction/InstructionCard.tsx
@@ -1,4 +1,5 @@
 import { BaseInstructionCard } from '@components/common/BaseInstructionCard';
+import { FetchStatus } from '@providers/cache';
 import { useFetchRawTransaction, useRawTransactionDetails } from '@providers/transactions/raw';
 import { ParsedInstruction, SignatureResult, TransactionInstruction } from '@solana/web3.js';
 import React, { useCallback, useContext } from 'react';
@@ -47,8 +48,11 @@ export function InstructionCard({
     const fetchRaw = useFetchRawTransaction();
     const fetchRawTrigger = useCallback(() => fetchRaw(signature), [signature, fetchRaw]);
 
-    // Only allow fetching raw data if we have a valid signature (not in inspector mode)
-    const canFetchRaw = signature && !raw;
+    // Only allow fetching raw data if we have a valid signature (not in inspector mode), and only
+    // while a fetch could still produce it: a v1 transaction has no web3.js instruction view, so
+    // once its raw data has arrived, asking again would refetch on every open of the Raw view.
+    const rawUnavailable = rawDetails?.status === FetchStatus.Fetched && raw === undefined;
+    const canFetchRaw = signature && !raw && !rawUnavailable;
 
     return (
         <BaseInstructionCard

--- a/app/components/instruction/InstructionCard.tsx
+++ b/app/components/instruction/InstructionCard.tsx
@@ -51,8 +51,11 @@ export function InstructionCard({
     // Only allow fetching raw data if we have a valid signature (not in inspector mode), and only
     // while a fetch could still produce it: a v1 transaction has no web3.js instruction view, so
     // once its raw data has arrived, asking again would refetch on every open of the Raw view.
-    const rawUnavailable = rawDetails?.status === FetchStatus.Fetched && raw === undefined;
-    const canFetchRaw = signature && !raw && !rawUnavailable;
+    const rawFetched = rawDetails?.status === FetchStatus.Fetched;
+    const canFetchRaw = signature && !raw && !rawFetched;
+    // Inner instructions never carry raw wire data, so their Raw view is the same with or without
+    // it; only the top-level list has rows to lose.
+    const rawUnavailable = rawFetched && raw === undefined && childIndex === undefined;
 
     return (
         <BaseInstructionCard
@@ -66,6 +69,7 @@ export function InstructionCard({
             childIndex={childIndex}
             raw={raw}
             onRequestRaw={canFetchRaw ? fetchRawTrigger : undefined}
+            rawUnavailable={rawUnavailable}
             headerButtons={headerButtons}
             collapsible={collapsible}
         >

--- a/app/components/instruction/__tests__/InstructionCard.spec.tsx
+++ b/app/components/instruction/__tests__/InstructionCard.spec.tsx
@@ -1,0 +1,108 @@
+import { gen } from '@__fixtures__/gen';
+import { FetchStatus } from '@providers/cache';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InstructionCard } from '../InstructionCard';
+import { SignatureContext } from '../SignatureContext';
+
+const SIGNATURE = gen.signature(1);
+const PROGRAM_ID = new PublicKey(gen.address(1));
+
+const fetchRaw = vi.fn();
+let rawDetails: { data?: { raw?: unknown }; status: FetchStatus } | undefined;
+
+vi.mock('@providers/transactions/raw', () => ({
+    useFetchRawTransaction: () => fetchRaw,
+    useRawTransactionDetails: () => rawDetails,
+}));
+
+// The real card renders a table of decoded accounts; only the Raw button's request behavior is
+// under test here, so stand in a button that reports what it was handed.
+vi.mock('@components/common/BaseInstructionCard', () => ({
+    BaseInstructionCard: ({ onRequestRaw }: { onRequestRaw?: () => void }) => (
+        <button data-can-request={onRequestRaw !== undefined} onClick={() => onRequestRaw?.()}>
+            Raw
+        </button>
+    ),
+}));
+
+function renderCard(props: Partial<React.ComponentProps<typeof InstructionCard>> = {}) {
+    const instruction = new TransactionInstruction({ data: Buffer.from([1]), keys: [], programId: PROGRAM_ID });
+
+    return render(
+        <SignatureContext.Provider value={SIGNATURE}>
+            <InstructionCard title="Transfer" result={{ err: null }} index={0} ix={instruction} {...props} />
+        </SignatureContext.Provider>,
+    );
+}
+
+function legacyRawDetails() {
+    const instruction = new TransactionInstruction({ data: Buffer.from([1]), keys: [], programId: PROGRAM_ID });
+
+    return {
+        data: { raw: { transaction: { instructions: [instruction] } } },
+        status: FetchStatus.Fetched,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    rawDetails = undefined;
+});
+
+describe('InstructionCard', () => {
+    it('should request raw data the first time the Raw view is opened', async () => {
+        renderCard();
+
+        await userEvent.click(screen.getByRole('button'));
+
+        expect(fetchRaw).toHaveBeenCalledWith(SIGNATURE);
+    });
+
+    it('should stop requesting raw data once a fetch has arrived without an instruction to show', async () => {
+        rawDetails = { data: { raw: { transaction: undefined } }, status: FetchStatus.Fetched };
+
+        renderCard();
+        await userEvent.click(screen.getByRole('button'));
+
+        expect(screen.getByRole('button').dataset.canRequest).toBe('false');
+        expect(fetchRaw).not.toHaveBeenCalled();
+    });
+
+    it('should stop requesting raw data once the instruction is available', () => {
+        rawDetails = legacyRawDetails();
+
+        renderCard();
+
+        expect(screen.getByRole('button').dataset.canRequest).toBe('false');
+    });
+
+    it('should allow a retry after a failed fetch', async () => {
+        rawDetails = { status: FetchStatus.FetchFailed };
+
+        renderCard();
+        await userEvent.click(screen.getByRole('button'));
+
+        expect(fetchRaw).toHaveBeenCalledWith(SIGNATURE);
+    });
+
+    it('should not request raw data for an instruction supplied by the inspector', () => {
+        const raw = new TransactionInstruction({ data: Buffer.from([1]), keys: [], programId: PROGRAM_ID });
+
+        renderCard({ raw });
+
+        expect(screen.getByRole('button').dataset.canRequest).toBe('false');
+    });
+
+    it('should stop requesting raw data for an inner instruction once a fetch has arrived', () => {
+        rawDetails = legacyRawDetails();
+
+        renderCard({ childIndex: 0 });
+
+        expect(screen.getByRole('button').dataset.canRequest).toBe('false');
+    });
+});

--- a/app/components/instruction/__tests__/InstructionCard.spec.tsx
+++ b/app/components/instruction/__tests__/InstructionCard.spec.tsx
@@ -23,8 +23,18 @@ vi.mock('@providers/transactions/raw', () => ({
 // The real card renders a table of decoded accounts; only the Raw button's request behavior is
 // under test here, so stand in a button that reports what it was handed.
 vi.mock('@components/common/BaseInstructionCard', () => ({
-    BaseInstructionCard: ({ onRequestRaw }: { onRequestRaw?: () => void }) => (
-        <button data-can-request={onRequestRaw !== undefined} onClick={() => onRequestRaw?.()}>
+    BaseInstructionCard: ({
+        onRequestRaw,
+        rawUnavailable,
+    }: {
+        onRequestRaw?: () => void;
+        rawUnavailable?: boolean;
+    }) => (
+        <button
+            data-can-request={onRequestRaw !== undefined}
+            data-raw-unavailable={rawUnavailable === true}
+            onClick={() => onRequestRaw?.()}
+        >
             Raw
         </button>
     ),
@@ -71,6 +81,22 @@ describe('InstructionCard', () => {
 
         expect(screen.getByRole('button').dataset.canRequest).toBe('false');
         expect(fetchRaw).not.toHaveBeenCalled();
+    });
+
+    it('should mark raw data unavailable when a fetch has arrived without an instruction to show', () => {
+        rawDetails = { data: { raw: { transaction: undefined } }, status: FetchStatus.Fetched };
+
+        renderCard();
+
+        expect(screen.getByRole('button').dataset.rawUnavailable).toBe('true');
+    });
+
+    it('should not mark raw data unavailable for an inner instruction, which never carries it', () => {
+        rawDetails = legacyRawDetails();
+
+        renderCard({ childIndex: 0 });
+
+        expect(screen.getByRole('button').dataset.rawUnavailable).toBe('false');
     });
 
     it('should stop requesting raw data once the instruction is available', () => {

--- a/app/entities/transaction-data/__fixtures__/wire-transactions.ts
+++ b/app/entities/transaction-data/__fixtures__/wire-transactions.ts
@@ -1,0 +1,89 @@
+import {
+    type Address,
+    appendTransactionMessageInstruction,
+    type Blockhash,
+    compileTransaction,
+    createTransactionMessage,
+    getAddressDecoder,
+    getTransactionEncoder,
+    pipe,
+    setTransactionMessageComputeUnitLimit,
+    setTransactionMessageFeePayer,
+    setTransactionMessageHeapSize,
+    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
+    setTransactionMessagePriorityFeeLamports,
+} from '@solana/kit';
+import { PublicKey, SystemProgram, TransactionMessage } from '@solana/web3.js';
+
+const testAddress = (seed: number) => getAddressDecoder().decode(new Uint8Array(32).fill(seed));
+
+export const FEE_PAYER = testAddress(1);
+export const RECIPIENT = testAddress(2);
+export const PROGRAM = testAddress(3);
+export const BLOCKHASH = testAddress(9) as string as Blockhash;
+
+export type V1ConfigOverrides = {
+    computeUnitLimit?: number;
+    heapSize?: number;
+    loadedAccountsDataSizeLimit?: number;
+    priorityFeeLamports?: bigint;
+};
+
+/** Wire bytes of an unsigned v1 transaction carrying whichever resource limits are passed. */
+export function createV1TransactionBytes(config: V1ConfigOverrides): Uint8Array {
+    const message = pipe(
+        // @ts-expect-error `createTransactionMessage` constrains its version parameter to
+        // `Exclude<TransactionVersion, 1>`. The runtime path is complete, so v1 messages compile and
+        // encode correctly; only the type gate is missing. Remove once kit lifts the exclusion.
+        createTransactionMessage({ version: 1 }),
+        m => setTransactionMessageFeePayer(FEE_PAYER, m),
+        m => setTransactionMessageLifetimeUsingBlockhash({ blockhash: BLOCKHASH, lastValidBlockHeight: 100n }, m),
+        m =>
+            appendTransactionMessageInstruction(
+                { accounts: [{ address: RECIPIENT, role: 1 }], data: new Uint8Array([1]), programAddress: PROGRAM },
+                m,
+            ),
+        // Every setter treats `undefined` as "leave unset", so omitted limits need no branching.
+        m => setTransactionMessageComputeUnitLimit(config.computeUnitLimit, m),
+        m => setTransactionMessageHeapSize(config.heapSize, m),
+        m => setTransactionMessageLoadedAccountsDataSizeLimit(config.loadedAccountsDataSizeLimit, m),
+        // The cast is needed only because the `@ts-expect-error` above leaves the message typed as
+        // `legacy | 0`; this setter is constrained to `{ version: 1 }`.
+        m => setTransactionMessagePriorityFeeLamports(config.priorityFeeLamports, m as typeof m & { version: 1 }),
+    );
+
+    return new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
+}
+
+/** A single-transfer web3.js message, for the versions web3.js can build. */
+export function createWeb3TransactionMessage(feePayer: Address = FEE_PAYER): TransactionMessage {
+    return new TransactionMessage({
+        instructions: [
+            SystemProgram.transfer({
+                fromPubkey: new PublicKey(feePayer),
+                lamports: 1n,
+                toPubkey: new PublicKey(RECIPIENT),
+            }),
+        ],
+        payerKey: new PublicKey(feePayer),
+        recentBlockhash: PublicKey.default.toBase58(),
+    });
+}
+
+/**
+ * Wire bytes of an unsigned legacy or v0 transaction.
+ *
+ * Signatures on the wire are fixed-count and zero-filled until signed, so an unsigned transaction
+ * carries one all-zero signature for its fee payer.
+ */
+export function createWeb3TransactionBytes(version: 'legacy' | 0): Uint8Array {
+    const message = createWeb3TransactionMessage();
+    const compiled = version === 'legacy' ? message.compileToLegacyMessage() : message.compileToV0Message();
+    const messageBytes = compiled.serialize();
+    const bytes = new Uint8Array(1 + 64 + messageBytes.length);
+    bytes[0] = 1;
+    bytes.set(messageBytes, 1 + 64);
+
+    return bytes;
+}

--- a/app/entities/transaction-data/__fixtures__/wire-transactions.ts
+++ b/app/entities/transaction-data/__fixtures__/wire-transactions.ts
@@ -1,10 +1,10 @@
+import { gen } from '@__fixtures__/gen';
 import {
-    type Address,
+    address,
     appendTransactionMessageInstruction,
-    type Blockhash,
+    blockhash,
     compileTransaction,
     createTransactionMessage,
-    getAddressDecoder,
     getTransactionEncoder,
     pipe,
     setTransactionMessageComputeUnitLimit,
@@ -16,12 +16,10 @@ import {
 } from '@solana/kit';
 import { PublicKey, SystemProgram, TransactionMessage } from '@solana/web3.js';
 
-const testAddress = (seed: number) => getAddressDecoder().decode(new Uint8Array(32).fill(seed));
-
-export const FEE_PAYER = testAddress(1);
-export const RECIPIENT = testAddress(2);
-export const PROGRAM = testAddress(3);
-export const BLOCKHASH = testAddress(9) as string as Blockhash;
+export const FEE_PAYER = address(gen.address(1));
+export const RECIPIENT = address(gen.address(2));
+const PROGRAM = address(gen.address(3));
+const BLOCKHASH = blockhash(gen.blockhash());
 
 export type V1ConfigOverrides = {
     computeUnitLimit?: number;
@@ -57,16 +55,16 @@ export function createV1TransactionBytes(config: V1ConfigOverrides): Uint8Array 
 }
 
 /** A single-transfer web3.js message, for the versions web3.js can build. */
-export function createWeb3TransactionMessage(feePayer: Address = FEE_PAYER): TransactionMessage {
+export function createWeb3TransactionMessage(): TransactionMessage {
     return new TransactionMessage({
         instructions: [
             SystemProgram.transfer({
-                fromPubkey: new PublicKey(feePayer),
+                fromPubkey: new PublicKey(FEE_PAYER),
                 lamports: 1n,
                 toPubkey: new PublicKey(RECIPIENT),
             }),
         ],
-        payerKey: new PublicKey(feePayer),
+        payerKey: new PublicKey(FEE_PAYER),
         recentBlockhash: PublicKey.default.toBase58(),
     });
 }

--- a/app/entities/transaction-data/api/__tests__/fetch-raw-transaction.spec.ts
+++ b/app/entities/transaction-data/api/__tests__/fetch-raw-transaction.spec.ts
@@ -1,0 +1,137 @@
+import { gen } from '@__fixtures__/gen';
+import type * as SolanaKit from '@solana/kit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toBase64 } from '@/app/shared/lib/bytes';
+
+import {
+    createV1TransactionBytes,
+    createWeb3TransactionBytes,
+    FEE_PAYER,
+    RECIPIENT,
+} from '../../__fixtures__/wire-transactions';
+import { fetchRawTransaction } from '../fetch-raw-transaction';
+
+// The global setup stubs `createSolanaRpc` so no test reaches the network; these tests exercise the
+// real client against a stubbed `fetch` instead.
+vi.mock('@solana/kit', async () => await vi.importActual<typeof SolanaKit>('@solana/kit'));
+
+const URL = 'https://mock.rpc';
+const SIGNATURE = gen.signature(1);
+
+const fetchMock = vi.fn();
+
+function respondWith(result: unknown) {
+    const body = JSON.stringify({ id: 1, jsonrpc: '2.0', result });
+    // kit reads the body as text so it can upcast integers to bigints as it parses.
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, text: async () => body });
+}
+
+function transactionResult(bytes: Uint8Array, meta: unknown = null, version: unknown = 1) {
+    return { blockTime: 1_778_761_079, meta, slot: 372_654_321, transaction: [toBase64(bytes), 'base64'], version };
+}
+
+function requestBody() {
+    return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('fetchRawTransaction', () => {
+    it('should ask for base64 bytes at the newest version Explorer renders', async () => {
+        respondWith(transactionResult(createV1TransactionBytes({})));
+
+        await fetchRawTransaction(URL, SIGNATURE, 'confirmed');
+
+        expect(requestBody().params).toEqual([
+            SIGNATURE,
+            { commitment: 'confirmed', encoding: 'base64', maxSupportedTransactionVersion: 1 },
+        ]);
+    });
+
+    it('should return null when the RPC does not hold the transaction', async () => {
+        respondWith(null);
+
+        await expect(fetchRawTransaction(URL, SIGNATURE)).resolves.toBeNull();
+    });
+
+    it('should expose a v1 transaction as bytes and resource limits, without a web3.js view', async () => {
+        const bytes = createV1TransactionBytes({ computeUnitLimit: 8442, priorityFeeLamports: 10_000n });
+        respondWith(transactionResult(bytes));
+
+        const raw = await fetchRawTransaction(URL, SIGNATURE);
+
+        expect(raw?.version).toBe(1);
+        expect(raw?.transactionConfig).toEqual({
+            computeUnitLimit: 8442,
+            heapSize: undefined,
+            loadedAccountsDataSizeLimit: undefined,
+            priorityFeeLamports: 10_000n,
+        });
+        expect(raw?.message).toBeUndefined();
+        expect(raw?.transaction).toBeUndefined();
+        expect(bytes.subarray(0, raw?.messageBytes.length)).toEqual(raw?.messageBytes);
+    });
+
+    it.each(['legacy' as const, 0 as const])(
+        'should decode a %s transaction into the web3.js views the inspector renders',
+        async version => {
+            respondWith(transactionResult(createWeb3TransactionBytes(version), null, version));
+
+            const raw = await fetchRawTransaction(URL, SIGNATURE);
+
+            expect(raw?.version).toBe(version);
+            expect(raw?.message?.staticAccountKeys[0].toBase58()).toBe(FEE_PAYER);
+            expect(raw?.transaction?.instructions).toHaveLength(1);
+            // Only v1 carries message-level limits.
+            expect(raw?.transactionConfig).toBeUndefined();
+        },
+    );
+
+    it('should leave an unsigned signer slot undefined so it is not reported as an invalid signature', async () => {
+        respondWith(transactionResult(createV1TransactionBytes({})));
+
+        const raw = await fetchRawTransaction(URL, SIGNATURE);
+
+        expect(raw?.signatures).toEqual([undefined]);
+    });
+
+    it('should narrow the balances and inner instructions the inspector reads', async () => {
+        respondWith(
+            transactionResult(createWeb3TransactionBytes('legacy'), {
+                innerInstructions: [
+                    { index: 0, instructions: [{ accounts: [1, 2], data: '3Bxs4', programIdIndex: 3 }] },
+                ],
+                loadedAddresses: { readonly: [RECIPIENT], writable: [FEE_PAYER] },
+                postBalances: [900_000_000, 100_000_000],
+                preBalances: [1_000_000_000, 0],
+            }),
+        );
+
+        const raw = await fetchRawTransaction(URL, SIGNATURE);
+
+        expect(raw?.meta?.preBalances).toEqual([1_000_000_000, 0]);
+        expect(raw?.meta?.postBalances).toEqual([900_000_000, 100_000_000]);
+        expect(raw?.meta?.innerInstructions).toEqual([
+            { index: 0, instructions: [{ accounts: [1, 2], data: '3Bxs4', programIdIndex: 3 }] },
+        ]);
+    });
+
+    it('should reject when the RPC call fails, so the provider can report the failure', async () => {
+        fetchMock.mockResolvedValueOnce({
+            headers: new Headers(),
+            ok: false,
+            status: 429,
+            statusText: 'Too Many Requests',
+        });
+
+        await expect(fetchRawTransaction(URL, SIGNATURE)).rejects.toThrow();
+    });
+});

--- a/app/entities/transaction-data/api/__tests__/fetch-transaction-details.spec.ts
+++ b/app/entities/transaction-data/api/__tests__/fetch-transaction-details.spec.ts
@@ -1,0 +1,118 @@
+import { gen } from '@__fixtures__/gen';
+import type * as SolanaKit from '@solana/kit';
+import { SystemProgram } from '@solana/web3.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchTransactionDetails } from '../fetch-transaction-details';
+
+// The global setup stubs `createSolanaRpc` so no test reaches the network; these tests exercise the
+// real client against a stubbed `fetch` instead.
+vi.mock('@solana/kit', async () => await vi.importActual<typeof SolanaKit>('@solana/kit'));
+
+const URL = 'https://mock.rpc';
+const SIGNATURE = gen.signature(1);
+const FEE_PAYER = gen.address(1);
+const SYSTEM_PROGRAM = SystemProgram.programId.toBase58();
+
+const fetchMock = vi.fn();
+
+function respondWith(result: unknown) {
+    const body = JSON.stringify({ id: 1, jsonrpc: '2.0', result });
+    // kit reads the body as text so it can upcast integers to bigints as it parses.
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, text: async () => body });
+}
+
+function parsedTransactionResult(version: 'legacy' | 0 | 1) {
+    return {
+        blockTime: 1_778_761_079,
+        meta: {
+            computeUnitsConsumed: 8442,
+            err: null,
+            fee: 5000,
+            logMessages: [`Program ${SYSTEM_PROGRAM} invoke [1]`],
+            postBalances: [900_000_000],
+            preBalances: [1_000_000_000],
+        },
+        slot: 372_654_321,
+        transaction: {
+            message: {
+                accountKeys: [{ pubkey: FEE_PAYER, signer: true, source: 'transaction', writable: true }],
+                instructions: [
+                    {
+                        parsed: { info: { lamports: 100_000_000 }, type: 'transfer' },
+                        program: 'system',
+                        programId: SYSTEM_PROGRAM,
+                    },
+                ],
+                recentBlockhash: gen.blockhash(),
+            },
+            signatures: [SIGNATURE],
+        },
+        version,
+    };
+}
+
+function requestBody() {
+    return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('fetchTransactionDetails', () => {
+    it('should ask for parsed data at the newest version Explorer renders', async () => {
+        respondWith(parsedTransactionResult(0));
+
+        await fetchTransactionDetails(URL, SIGNATURE);
+
+        expect(requestBody().params).toEqual([
+            SIGNATURE,
+            { commitment: 'confirmed', encoding: 'jsonParsed', maxSupportedTransactionVersion: 1 },
+        ]);
+    });
+
+    it('should return null when the RPC does not hold the transaction', async () => {
+        respondWith(null);
+
+        await expect(fetchTransactionDetails(URL, SIGNATURE)).resolves.toBeNull();
+    });
+
+    it.each(['legacy' as const, 0 as const, 1 as const])(
+        'should adapt a %s transaction into the web3.js shape consumers read',
+        async version => {
+            respondWith(parsedTransactionResult(version));
+
+            const result = await fetchTransactionDetails(URL, SIGNATURE);
+
+            expect(result?.version).toBe(version);
+            expect(result?.slot).toBe(372_654_321);
+            expect(result?.meta?.fee).toBe(5000);
+            expect(result?.transaction.message.accountKeys[0].pubkey.toBase58()).toBe(FEE_PAYER);
+        },
+    );
+
+    it('should read a v1 transaction in a single round trip', async () => {
+        respondWith(parsedTransactionResult(1));
+
+        await fetchTransactionDetails(URL, SIGNATURE);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject when the RPC call fails, so the provider can report the failure', async () => {
+        fetchMock.mockResolvedValueOnce({
+            headers: new Headers(),
+            ok: false,
+            status: 429,
+            statusText: 'Too Many Requests',
+        });
+
+        await expect(fetchTransactionDetails(URL, SIGNATURE)).rejects.toThrow();
+    });
+});

--- a/app/entities/transaction-data/api/fetch-raw-transaction.ts
+++ b/app/entities/transaction-data/api/fetch-raw-transaction.ts
@@ -2,9 +2,11 @@ import { createSolanaRpc, signature as createSignature } from '@solana/kit';
 import { type DecompileArgs, type Finality, PublicKey, TransactionMessage, VersionedMessage } from '@solana/web3.js';
 
 import { fromBase64 } from '@/app/shared/lib/bytes';
+import { Logger } from '@/app/shared/lib/logger';
 
-import { decodeWireTransaction } from '../lib/decode-wire-transaction';
-import type { RawTransaction, TransactionVersion } from '../model/types';
+import { decodeTransactionConfig } from '../lib/decode-transaction-config';
+import { decodeWireTransaction, type WireTransaction } from '../lib/decode-wire-transaction';
+import type { RawTransaction, TransactionConfig } from '../model/types';
 import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
 
 /**
@@ -36,10 +38,9 @@ export async function fetchRawTransaction(
 
     const [base64Transaction] = response.transaction;
     const { compiledMessage, messageBytes, signatures } = decodeWireTransaction(fromBase64(base64Transaction));
-    const version = compiledMessage.version as TransactionVersion;
     const meta = response.meta;
 
-    return {
+    const base = {
         messageBytes,
         meta: meta
             ? {
@@ -57,9 +58,32 @@ export async function fetchRawTransaction(
               }
             : undefined,
         signatures,
-        version,
-        ...(version === 1 ? undefined : decodeWithWeb3(messageBytes, meta?.loadedAddresses)),
+        transactionConfig: readTransactionConfig(compiledMessage, signature),
     };
+
+    if (compiledMessage.version === 1) {
+        return { ...base, version: 1 };
+    }
+
+    return {
+        ...base,
+        ...decodeWithWeb3(messageBytes, meta?.loadedAddresses),
+        version: compiledMessage.version,
+    };
+}
+
+// The resource-limit rows are supplemental; the wire bytes still render, download, and inspect
+// without them.
+function readTransactionConfig(
+    compiledMessage: WireTransaction['compiledMessage'],
+    signature: string,
+): TransactionConfig | undefined {
+    try {
+        return decodeTransactionConfig(compiledMessage);
+    } catch (error) {
+        Logger.error(error, { module: '[transaction-data]', signature });
+        return undefined;
+    }
 }
 
 type RpcLoadedAddresses = Readonly<{ readonly: readonly string[]; writable: readonly string[] }>;
@@ -67,7 +91,7 @@ type RpcLoadedAddresses = Readonly<{ readonly: readonly string[]; writable: read
 function decodeWithWeb3(
     messageBytes: Uint8Array,
     loadedAddresses: RpcLoadedAddresses | undefined,
-): Pick<RawTransaction, 'message' | 'transaction'> {
+): { message: VersionedMessage; transaction: TransactionMessage } {
     const message = VersionedMessage.deserialize(messageBytes);
     const accountKeysFromLookups = loadedAddresses && {
         readonly: loadedAddresses.readonly.map(address => new PublicKey(address)),

--- a/app/entities/transaction-data/api/fetch-raw-transaction.ts
+++ b/app/entities/transaction-data/api/fetch-raw-transaction.ts
@@ -1,4 +1,4 @@
-import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+import { createSolanaRpc, MAX_SUPPORTED_TRANSACTION_VERSION, signature as createSignature } from '@solana/kit';
 import { type DecompileArgs, type Finality, PublicKey, TransactionMessage, VersionedMessage } from '@solana/web3.js';
 
 import { fromBase64 } from '@/app/shared/lib/bytes';
@@ -7,7 +7,6 @@ import { Logger } from '@/app/shared/lib/logger';
 import { decodeTransactionConfig } from '../lib/decode-transaction-config';
 import { decodeWireTransaction, type WireTransaction } from '../lib/decode-wire-transaction';
 import type { RawTransaction, TransactionConfig } from '../model/types';
-import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
 
 /**
  * Fetches a transaction's wire bytes and metadata for the inspector and the download button.

--- a/app/entities/transaction-data/api/fetch-raw-transaction.ts
+++ b/app/entities/transaction-data/api/fetch-raw-transaction.ts
@@ -1,0 +1,79 @@
+import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+import { type DecompileArgs, type Finality, PublicKey, TransactionMessage, VersionedMessage } from '@solana/web3.js';
+
+import { fromBase64 } from '@/app/shared/lib/bytes';
+
+import { decodeWireTransaction } from '../lib/decode-wire-transaction';
+import type { RawTransaction, TransactionVersion } from '../model/types';
+import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
+
+/**
+ * Fetches a transaction's wire bytes and metadata for the inspector and the download button.
+ *
+ * `base64` encoding rather than `json` so the bytes are the ones the network holds: they are what
+ * the download button writes, and the only representation a v1 transaction has here — web3.js
+ * `VersionedMessage` tops out at v0, so `message` and `transaction` are populated for legacy and
+ * v0 only.
+ */
+export async function fetchRawTransaction(
+    url: string,
+    signature: string,
+    commitment?: Finality,
+): Promise<RawTransaction | null> {
+    const response = await createSolanaRpc(url)
+        .getTransaction(createSignature(signature), {
+            commitment,
+            encoding: 'base64',
+            maxSupportedTransactionVersion: MAX_SUPPORTED_TRANSACTION_VERSION,
+        })
+        .send();
+
+    if (response === null) {
+        // The cache providers distinguish "fetched, not found" from "not fetched yet" by null vs undefined.
+        // eslint-disable-next-line unicorn/no-null
+        return null;
+    }
+
+    const [base64Transaction] = response.transaction;
+    const { compiledMessage, messageBytes, signatures } = decodeWireTransaction(fromBase64(base64Transaction));
+    const version = compiledMessage.version as TransactionVersion;
+    const meta = response.meta;
+
+    return {
+        messageBytes,
+        meta: meta
+            ? {
+                  innerInstructions:
+                      meta.innerInstructions?.map(({ index, instructions }) => ({
+                          index,
+                          instructions: instructions.map(({ accounts, data, programIdIndex }) => ({
+                              accounts: [...accounts],
+                              data,
+                              programIdIndex,
+                          })),
+                      })) ?? undefined,
+                  postBalances: meta.postBalances.map(Number),
+                  preBalances: meta.preBalances.map(Number),
+              }
+            : undefined,
+        signatures,
+        version,
+        ...(version === 1 ? undefined : decodeWithWeb3(messageBytes, meta?.loadedAddresses)),
+    };
+}
+
+type RpcLoadedAddresses = Readonly<{ readonly: readonly string[]; writable: readonly string[] }>;
+
+function decodeWithWeb3(
+    messageBytes: Uint8Array,
+    loadedAddresses: RpcLoadedAddresses | undefined,
+): Pick<RawTransaction, 'message' | 'transaction'> {
+    const message = VersionedMessage.deserialize(messageBytes);
+    const accountKeysFromLookups = loadedAddresses && {
+        readonly: loadedAddresses.readonly.map(address => new PublicKey(address)),
+        writable: loadedAddresses.writable.map(address => new PublicKey(address)),
+    };
+    const decompileArgs: DecompileArgs | undefined = accountKeysFromLookups && { accountKeysFromLookups };
+
+    return { message, transaction: TransactionMessage.decompile(message, decompileArgs) };
+}

--- a/app/entities/transaction-data/api/fetch-raw-transaction.ts
+++ b/app/entities/transaction-data/api/fetch-raw-transaction.ts
@@ -57,11 +57,10 @@ export async function fetchRawTransaction(
               }
             : undefined,
         signatures,
-        transactionConfig: readTransactionConfig(compiledMessage, signature),
     };
 
     if (compiledMessage.version === 1) {
-        return { ...base, version: 1 };
+        return { ...base, transactionConfig: readTransactionConfig(compiledMessage, signature), version: 1 };
     }
 
     return {

--- a/app/entities/transaction-data/api/fetch-transaction-details.ts
+++ b/app/entities/transaction-data/api/fetch-transaction-details.ts
@@ -53,5 +53,10 @@ async function fetchTransactionConfig(url: string, signature: string): Promise<T
     }
 
     const [base64Transaction] = response.transaction;
-    return decodeTransactionConfig(decodeWireTransaction(fromBase64(base64Transaction)).compiledMessage);
+    try {
+        return decodeTransactionConfig(decodeWireTransaction(fromBase64(base64Transaction)).compiledMessage);
+    } catch {
+        // The resource-limit rows are supplemental; the rest of the page renders without them.
+        return undefined;
+    }
 }

--- a/app/entities/transaction-data/api/fetch-transaction-details.ts
+++ b/app/entities/transaction-data/api/fetch-transaction-details.ts
@@ -1,23 +1,18 @@
 import { createSolanaRpc, signature as createSignature } from '@solana/kit';
 
-import { fromBase64 } from '@/app/shared/lib/bytes';
-
 import { adaptParsedTransaction } from '../lib/adapt-parsed-transaction';
-import { decodeTransactionConfig } from '../lib/decode-transaction-config';
-import { decodeWireTransaction } from '../lib/decode-wire-transaction';
-import type { TransactionConfig, TransactionWithMeta } from '../model/types';
+import type { TransactionWithMeta } from '../model/types';
 import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
 
 /**
  * Fetches a transaction for the detail page.
  *
- * v1 carries its resource limits in the message rather than in Compute Budget instructions, and
- * the `jsonParsed` encoding drops them, so v1 costs a second round trip to read the wire bytes.
- * Legacy and v0 make one call.
+ * The v1 resource limits are not part of this response — the `jsonParsed` encoding drops them.
+ * They are read from the wire bytes {@link fetchRawTransaction} already fetches for the download
+ * button and the inspector.
  */
 export async function fetchTransactionDetails(url: string, signature: string): Promise<TransactionWithMeta | null> {
-    const rpc = createSolanaRpc(url);
-    const response = await rpc
+    const response = await createSolanaRpc(url)
         .getTransaction(createSignature(signature), {
             commitment: 'confirmed',
             encoding: 'jsonParsed',
@@ -31,32 +26,5 @@ export async function fetchTransactionDetails(url: string, signature: string): P
         return null;
     }
 
-    const transactionWithMeta = adaptParsedTransaction(response);
-    if (transactionWithMeta.version !== 1) {
-        return transactionWithMeta;
-    }
-
-    return { ...transactionWithMeta, transactionConfig: await fetchTransactionConfig(url, signature) };
-}
-
-async function fetchTransactionConfig(url: string, signature: string): Promise<TransactionConfig | undefined> {
-    const response = await createSolanaRpc(url)
-        .getTransaction(createSignature(signature), {
-            commitment: 'confirmed',
-            encoding: 'base64',
-            maxSupportedTransactionVersion: MAX_SUPPORTED_TRANSACTION_VERSION,
-        })
-        .send();
-
-    if (response === null) {
-        return undefined;
-    }
-
-    const [base64Transaction] = response.transaction;
-    try {
-        return decodeTransactionConfig(decodeWireTransaction(fromBase64(base64Transaction)).compiledMessage);
-    } catch {
-        // The resource-limit rows are supplemental; the rest of the page renders without them.
-        return undefined;
-    }
+    return adaptParsedTransaction(response);
 }

--- a/app/entities/transaction-data/api/fetch-transaction-details.ts
+++ b/app/entities/transaction-data/api/fetch-transaction-details.ts
@@ -1,8 +1,7 @@
-import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+import { createSolanaRpc, MAX_SUPPORTED_TRANSACTION_VERSION, signature as createSignature } from '@solana/kit';
 
 import { adaptParsedTransaction } from '../lib/adapt-parsed-transaction';
 import type { TransactionWithMeta } from '../model/types';
-import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
 
 /**
  * Fetches a transaction for the detail page.

--- a/app/entities/transaction-data/api/fetch-transaction-details.ts
+++ b/app/entities/transaction-data/api/fetch-transaction-details.ts
@@ -1,0 +1,57 @@
+import { createSolanaRpc, signature as createSignature } from '@solana/kit';
+
+import { fromBase64 } from '@/app/shared/lib/bytes';
+
+import { adaptParsedTransaction } from '../lib/adapt-parsed-transaction';
+import { decodeTransactionConfig } from '../lib/decode-transaction-config';
+import { decodeWireTransaction } from '../lib/decode-wire-transaction';
+import type { TransactionConfig, TransactionWithMeta } from '../model/types';
+import { MAX_SUPPORTED_TRANSACTION_VERSION } from './max-supported-transaction-version';
+
+/**
+ * Fetches a transaction for the detail page.
+ *
+ * v1 carries its resource limits in the message rather than in Compute Budget instructions, and
+ * the `jsonParsed` encoding drops them, so v1 costs a second round trip to read the wire bytes.
+ * Legacy and v0 make one call.
+ */
+export async function fetchTransactionDetails(url: string, signature: string): Promise<TransactionWithMeta | null> {
+    const rpc = createSolanaRpc(url);
+    const response = await rpc
+        .getTransaction(createSignature(signature), {
+            commitment: 'confirmed',
+            encoding: 'jsonParsed',
+            maxSupportedTransactionVersion: MAX_SUPPORTED_TRANSACTION_VERSION,
+        })
+        .send();
+
+    if (response === null) {
+        // The cache providers distinguish "fetched, not found" from "not fetched yet" by null vs undefined.
+        // eslint-disable-next-line unicorn/no-null
+        return null;
+    }
+
+    const transactionWithMeta = adaptParsedTransaction(response);
+    if (transactionWithMeta.version !== 1) {
+        return transactionWithMeta;
+    }
+
+    return { ...transactionWithMeta, transactionConfig: await fetchTransactionConfig(url, signature) };
+}
+
+async function fetchTransactionConfig(url: string, signature: string): Promise<TransactionConfig | undefined> {
+    const response = await createSolanaRpc(url)
+        .getTransaction(createSignature(signature), {
+            commitment: 'confirmed',
+            encoding: 'base64',
+            maxSupportedTransactionVersion: MAX_SUPPORTED_TRANSACTION_VERSION,
+        })
+        .send();
+
+    if (response === null) {
+        return undefined;
+    }
+
+    const [base64Transaction] = response.transaction;
+    return decodeTransactionConfig(decodeWireTransaction(fromBase64(base64Transaction)).compiledMessage);
+}

--- a/app/entities/transaction-data/api/max-supported-transaction-version.ts
+++ b/app/entities/transaction-data/api/max-supported-transaction-version.ts
@@ -1,8 +1,0 @@
-/**
- * The newest transaction version Explorer asks the RPC for.
- *
- * Without it the RPC answers `-32015` for anything newer than legacy and the transaction fails to
- * load at all. Nodes that predate v1 compare this ceiling against the versions they actually hold,
- * so requesting 1 is safe against them.
- */
-export const MAX_SUPPORTED_TRANSACTION_VERSION = 1;

--- a/app/entities/transaction-data/api/max-supported-transaction-version.ts
+++ b/app/entities/transaction-data/api/max-supported-transaction-version.ts
@@ -1,0 +1,8 @@
+/**
+ * The newest transaction version Explorer asks the RPC for.
+ *
+ * Without it the RPC answers `-32015` for anything newer than legacy and the transaction fails to
+ * load at all. Nodes that predate v1 compare this ceiling against the versions they actually hold,
+ * so requesting 1 is safe against them.
+ */
+export const MAX_SUPPORTED_TRANSACTION_VERSION = 1;

--- a/app/entities/transaction-data/index.ts
+++ b/app/entities/transaction-data/index.ts
@@ -13,4 +13,4 @@ export {
     type InstructionSummary,
 } from './lib/instruction-summary';
 export { mergeTransactionMap } from './lib/merge-transaction-map';
-export type { RawTransaction, TransactionConfig, TransactionVersion, TransactionWithMeta } from './model/types';
+export type { RawTransaction, TransactionConfig, TransactionWithMeta } from './model/types';

--- a/app/entities/transaction-data/index.ts
+++ b/app/entities/transaction-data/index.ts
@@ -1,4 +1,10 @@
 export { type ByteArray } from '@/app/shared/lib/bytes';
+export { fetchRawTransaction } from './api/fetch-raw-transaction';
+export { fetchTransactionDetails } from './api/fetch-transaction-details';
+export { MAX_SUPPORTED_TRANSACTION_VERSION } from './api/max-supported-transaction-version';
+export { adaptParsedTransaction } from './lib/adapt-parsed-transaction';
+export { decodeTransactionConfig } from './lib/decode-transaction-config';
+export { decodeWireTransaction } from './lib/decode-wire-transaction';
 export { encodeTransactionData, type EncodingFormat } from './lib/encoding';
 export { getProgramName } from './lib/get-program-name';
 export {
@@ -7,3 +13,4 @@ export {
     type InstructionSummary,
 } from './lib/instruction-summary';
 export { mergeTransactionMap } from './lib/merge-transaction-map';
+export type { RawTransaction, TransactionConfig, TransactionVersion, TransactionWithMeta } from './model/types';

--- a/app/entities/transaction-data/index.ts
+++ b/app/entities/transaction-data/index.ts
@@ -1,7 +1,6 @@
 export { type ByteArray } from '@/app/shared/lib/bytes';
 export { fetchRawTransaction } from './api/fetch-raw-transaction';
 export { fetchTransactionDetails } from './api/fetch-transaction-details';
-export { MAX_SUPPORTED_TRANSACTION_VERSION } from './api/max-supported-transaction-version';
 export { adaptParsedTransaction } from './lib/adapt-parsed-transaction';
 export { decodeTransactionConfig } from './lib/decode-transaction-config';
 export { decodeWireTransaction } from './lib/decode-wire-transaction';

--- a/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
@@ -8,34 +8,42 @@ const SYSTEM_PROGRAM = '11111111111111111111111111111111';
 const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const BLOCKHASH = '9vHo1dQ6H2XZ1g6TbsbT1T1zuHz39qrkAPGe2f4tXU5V';
 
+type RpcMeta = NonNullable<RpcParsedTransaction['meta']>;
+
+function createMeta(overrides: Partial<RpcMeta> = {}): RpcMeta {
+    return {
+        computeUnitsConsumed: 8442n,
+        costUnits: 3234,
+        err: null,
+        fee: 5000n,
+        innerInstructions: [
+            {
+                index: 0,
+                instructions: [{ accounts: [FEE_PAYER], data: '3Bxs4', programId: SYSTEM_PROGRAM }],
+            },
+        ],
+        loadedAddresses: { readonly: [RECIPIENT], writable: [FEE_PAYER] },
+        logMessages: ['Program 11111111111111111111111111111111 invoke [1]'],
+        postBalances: [900_000_000n, 100_000_000n],
+        postTokenBalances: [
+            {
+                accountIndex: 1,
+                mint: MINT,
+                owner: RECIPIENT,
+                programId: SYSTEM_PROGRAM,
+                // `uiAmount` is not on kit's allow-list, so a whole-number balance is a bigint.
+                uiTokenAmount: { amount: '15000000', decimals: 6, uiAmount: 15n, uiAmountString: '15' },
+            },
+        ],
+        preBalances: [1_000_000_000n, 0n],
+        ...overrides,
+    };
+}
+
 function createResponse(overrides: Partial<RpcParsedTransaction> = {}): RpcParsedTransaction {
     return {
         blockTime: 1_778_761_079n,
-        meta: {
-            computeUnitsConsumed: 8442n,
-            costUnits: 3234,
-            err: null,
-            fee: 5000n,
-            innerInstructions: [
-                {
-                    index: 0,
-                    instructions: [{ accounts: [FEE_PAYER], data: '3Bxs4', programId: SYSTEM_PROGRAM }],
-                },
-            ],
-            loadedAddresses: { readonly: [RECIPIENT], writable: [FEE_PAYER] },
-            logMessages: ['Program 11111111111111111111111111111111 invoke [1]'],
-            postBalances: [900_000_000n, 100_000_000n],
-            postTokenBalances: [
-                {
-                    accountIndex: 1,
-                    mint: MINT,
-                    owner: RECIPIENT,
-                    programId: SYSTEM_PROGRAM,
-                    uiTokenAmount: { amount: '15000000', decimals: 6, uiAmount: 15, uiAmountString: '15' },
-                },
-            ],
-            preBalances: [1_000_000_000n, 0n],
-        },
+        meta: createMeta(),
         slot: 372_654_321n,
         transaction: {
             message: {
@@ -45,7 +53,12 @@ function createResponse(overrides: Partial<RpcParsedTransaction> = {}): RpcParse
                 ],
                 instructions: [
                     {
-                        parsed: { info: { lamports: 100_000_000 }, type: 'transfer' },
+                        // Nothing inside a parsed instruction is on kit's allow-list, so every
+                        // integral value in here arrives as a bigint.
+                        parsed: {
+                            info: { destination: RECIPIENT, lamports: 100_000_000n, source: FEE_PAYER },
+                            type: 'transfer',
+                        },
                         program: 'system',
                         programId: SYSTEM_PROGRAM,
                     },
@@ -108,6 +121,32 @@ describe('adaptParsedTransaction', () => {
             programId: SYSTEM_PROGRAM,
             uiTokenAmount: { amount: '15000000', decimals: 6, uiAmount: 15, uiAmountString: '15' },
         });
+        expect(typeof postTokenBalance.uiTokenAmount.uiAmount).toBe('number');
+    });
+
+    // Cards render these payloads with JSON.stringify, which throws on a bigint, and the receipt
+    // model validates them against superstruct `number()` schemas.
+    it('should leave no bigint anywhere in the adapted transaction', () => {
+        const result = adaptParsedTransaction(
+            createResponse({ meta: createMeta({ err: { InstructionError: [1n, { Custom: 6001n }] } }) }),
+        );
+
+        expect(() => JSON.stringify(result)).not.toThrow();
+        expect(findBigIntPath(result)).toBeUndefined();
+    });
+
+    it('should convert instruction error indices and codes so the error formatters can do arithmetic', () => {
+        const response = createResponse({
+            meta: createMeta({ err: { InstructionError: [1n, { Custom: 6001n }] } }),
+        });
+
+        expect(adaptParsedTransaction(response).meta?.err).toEqual({ InstructionError: [1, { Custom: 6001 }] });
+    });
+
+    it('should convert numbers nested inside a parsed instruction', () => {
+        const [instruction] = adaptParsedTransaction(createResponse()).transaction.message.instructions;
+
+        expect('parsed' in instruction && instruction.parsed.info.lamports).toBe(100_000_000);
     });
 
     it.each(['legacy' as const, 0 as const, 1 as const])('should carry version %s through', version => {
@@ -135,3 +174,14 @@ describe('adaptParsedTransaction', () => {
         expect(result.meta?.costUnits).toBeUndefined();
     });
 });
+
+// Returns the dotted path of the first bigint found, so a failure names the offending field.
+function findBigIntPath(value: unknown, path = ''): string | undefined {
+    if (typeof value === 'bigint') return path || '<root>';
+    if (value === null || typeof value !== 'object') return undefined;
+    for (const [key, item] of Object.entries(value)) {
+        const found = findBigIntPath(item, path ? `${path}.${key}` : key);
+        if (found) return found;
+    }
+    return undefined;
+}

--- a/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
@@ -1,12 +1,14 @@
+import { gen } from '@__fixtures__/gen';
+import { SystemProgram } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
 import { adaptParsedTransaction, type RpcParsedTransaction } from '../adapt-parsed-transaction';
 
-const FEE_PAYER = '11111111111111111111111111111112';
-const RECIPIENT = '11111111111111111111111111111113';
-const SYSTEM_PROGRAM = '11111111111111111111111111111111';
-const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
-const BLOCKHASH = '9vHo1dQ6H2XZ1g6TbsbT1T1zuHz39qrkAPGe2f4tXU5V';
+const FEE_PAYER = gen.address(1);
+const RECIPIENT = gen.address(2);
+const SYSTEM_PROGRAM = SystemProgram.programId.toBase58();
+const MINT = gen.address(3);
+const BLOCKHASH = gen.blockhash();
 
 type RpcMeta = NonNullable<RpcParsedTransaction['meta']>;
 
@@ -23,7 +25,7 @@ function createMeta(overrides: Partial<RpcMeta> = {}): RpcMeta {
             },
         ],
         loadedAddresses: { readonly: [RECIPIENT], writable: [FEE_PAYER] },
-        logMessages: ['Program 11111111111111111111111111111111 invoke [1]'],
+        logMessages: [`Program ${SYSTEM_PROGRAM} invoke [1]`],
         postBalances: [900_000_000n, 100_000_000n],
         postTokenBalances: [
             {
@@ -65,7 +67,7 @@ function createResponse(overrides: Partial<RpcParsedTransaction> = {}): RpcParse
                 ],
                 recentBlockhash: BLOCKHASH,
             },
-            signatures: ['5xyz'],
+            signatures: [gen.signature(1)],
         },
         version: 0n,
         ...overrides,

--- a/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
@@ -67,7 +67,7 @@ function createResponse(overrides: Partial<RpcParsedTransaction> = {}): RpcParse
             },
             signatures: ['5xyz'],
         },
-        version: 0,
+        version: 0n,
         ...overrides,
     };
 }
@@ -149,8 +149,12 @@ describe('adaptParsedTransaction', () => {
         expect('parsed' in instruction && instruction.parsed.info.lamports).toBe(100_000_000);
     });
 
-    it.each(['legacy' as const, 0 as const, 1 as const])('should carry version %s through', version => {
-        expect(adaptParsedTransaction(createResponse({ version })).version).toBe(version);
+    it.each([
+        ['legacy' as const, 'legacy'],
+        [0n, 0],
+        [1n, 1],
+    ])('should narrow version %s to %s', (version, expected) => {
+        expect(adaptParsedTransaction(createResponse({ version })).version).toBe(expected);
     });
 
     it('should tolerate a response with no optional metadata', () => {

--- a/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/adapt-parsed-transaction.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { adaptParsedTransaction, type RpcParsedTransaction } from '../adapt-parsed-transaction';
+
+const FEE_PAYER = '11111111111111111111111111111112';
+const RECIPIENT = '11111111111111111111111111111113';
+const SYSTEM_PROGRAM = '11111111111111111111111111111111';
+const MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const BLOCKHASH = '9vHo1dQ6H2XZ1g6TbsbT1T1zuHz39qrkAPGe2f4tXU5V';
+
+function createResponse(overrides: Partial<RpcParsedTransaction> = {}): RpcParsedTransaction {
+    return {
+        blockTime: 1_778_761_079n,
+        meta: {
+            computeUnitsConsumed: 8442n,
+            costUnits: 3234,
+            err: null,
+            fee: 5000n,
+            innerInstructions: [
+                {
+                    index: 0,
+                    instructions: [{ accounts: [FEE_PAYER], data: '3Bxs4', programId: SYSTEM_PROGRAM }],
+                },
+            ],
+            loadedAddresses: { readonly: [RECIPIENT], writable: [FEE_PAYER] },
+            logMessages: ['Program 11111111111111111111111111111111 invoke [1]'],
+            postBalances: [900_000_000n, 100_000_000n],
+            postTokenBalances: [
+                {
+                    accountIndex: 1,
+                    mint: MINT,
+                    owner: RECIPIENT,
+                    programId: SYSTEM_PROGRAM,
+                    uiTokenAmount: { amount: '15000000', decimals: 6, uiAmount: 15, uiAmountString: '15' },
+                },
+            ],
+            preBalances: [1_000_000_000n, 0n],
+        },
+        slot: 372_654_321n,
+        transaction: {
+            message: {
+                accountKeys: [
+                    { pubkey: FEE_PAYER, signer: true, source: 'transaction', writable: true },
+                    { pubkey: RECIPIENT, signer: false, source: 'lookupTable', writable: true },
+                ],
+                instructions: [
+                    {
+                        parsed: { info: { lamports: 100_000_000 }, type: 'transfer' },
+                        program: 'system',
+                        programId: SYSTEM_PROGRAM,
+                    },
+                ],
+                recentBlockhash: BLOCKHASH,
+            },
+            signatures: ['5xyz'],
+        },
+        version: 0,
+        ...overrides,
+    };
+}
+
+describe('adaptParsedTransaction', () => {
+    it('should narrow the RPC bigints web3.js consumers expect as numbers', () => {
+        const result = adaptParsedTransaction(createResponse());
+
+        expect(result.slot).toBe(372_654_321);
+        expect(result.blockTime).toBe(1_778_761_079);
+        expect(result.meta?.fee).toBe(5000);
+        expect(result.meta?.computeUnitsConsumed).toBe(8442);
+        expect(result.meta?.preBalances).toEqual([1_000_000_000, 0]);
+        expect(result.meta?.postBalances).toEqual([900_000_000, 100_000_000]);
+    });
+
+    it('should keep costUnits, which kit does not type but the RPC serves', () => {
+        expect(adaptParsedTransaction(createResponse()).meta?.costUnits).toBe(3234);
+        expect(adaptParsedTransaction(createResponse({ meta: null })).meta).toBeNull();
+    });
+
+    it('should wrap every address in a PublicKey', () => {
+        const result = adaptParsedTransaction(createResponse());
+        const [feePayer, recipient] = result.transaction.message.accountKeys;
+
+        expect(feePayer.pubkey.toBase58()).toBe(FEE_PAYER);
+        expect(feePayer.source).toBe('transaction');
+        expect(recipient.source).toBe('lookupTable');
+        expect(result.meta?.loadedAddresses?.writable[0].toBase58()).toBe(FEE_PAYER);
+        expect(result.meta?.loadedAddresses?.readonly[0].toBase58()).toBe(RECIPIENT);
+    });
+
+    it('should adapt parsed and partially decoded instructions, including inner ones', () => {
+        const result = adaptParsedTransaction(createResponse());
+        const [instruction] = result.transaction.message.instructions;
+        const [innerInstruction] = result.meta?.innerInstructions?.[0].instructions ?? [];
+
+        expect(instruction).toMatchObject({ parsed: { type: 'transfer' }, program: 'system' });
+        expect(instruction.programId.toBase58()).toBe(SYSTEM_PROGRAM);
+        expect(innerInstruction).toMatchObject({ data: '3Bxs4' });
+        expect('accounts' in innerInstruction && innerInstruction.accounts[0].toBase58()).toBe(FEE_PAYER);
+    });
+
+    it('should pass token balances through with their stringified amounts intact', () => {
+        const [postTokenBalance] = adaptParsedTransaction(createResponse()).meta?.postTokenBalances ?? [];
+
+        expect(postTokenBalance).toEqual({
+            accountIndex: 1,
+            mint: MINT,
+            owner: RECIPIENT,
+            programId: SYSTEM_PROGRAM,
+            uiTokenAmount: { amount: '15000000', decimals: 6, uiAmount: 15, uiAmountString: '15' },
+        });
+    });
+
+    it.each(['legacy' as const, 0 as const, 1 as const])('should carry version %s through', version => {
+        expect(adaptParsedTransaction(createResponse({ version })).version).toBe(version);
+    });
+
+    it('should tolerate a response with no optional metadata', () => {
+        const response = createResponse({
+            meta: {
+                err: 'InvalidProgramForExecution',
+                fee: 5000n,
+                logMessages: null,
+                postBalances: [],
+                preBalances: [],
+            },
+        });
+
+        const result = adaptParsedTransaction(response);
+
+        expect(result.meta?.err).toBe('InvalidProgramForExecution');
+        expect(result.meta?.logMessages).toBeNull();
+        expect(result.meta?.innerInstructions).toBeUndefined();
+        expect(result.meta?.loadedAddresses).toBeUndefined();
+        expect(result.meta?.computeUnitsConsumed).toBeUndefined();
+        expect(result.meta?.costUnits).toBeUndefined();
+    });
+});

--- a/app/entities/transaction-data/lib/__tests__/decode-transaction-config.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/decode-transaction-config.spec.ts
@@ -1,63 +1,9 @@
-import {
-    appendTransactionMessageInstruction,
-    type Blockhash,
-    compileTransaction,
-    createTransactionMessage,
-    getAddressDecoder,
-    getCompiledTransactionMessageDecoder,
-    getTransactionEncoder,
-    pipe,
-    setTransactionMessageComputeUnitLimit,
-    setTransactionMessageFeePayer,
-    setTransactionMessageHeapSize,
-    setTransactionMessageLifetimeUsingBlockhash,
-    setTransactionMessageLoadedAccountsDataSizeLimit,
-    setTransactionMessagePriorityFeeLamports,
-} from '@solana/kit';
-import { PublicKey, SystemProgram, TransactionMessage } from '@solana/web3.js';
+import { getCompiledTransactionMessageDecoder } from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 
+import { createV1TransactionBytes, createWeb3TransactionMessage } from '../../__fixtures__/wire-transactions';
 import { decodeTransactionConfig } from '../decode-transaction-config';
 import { decodeWireTransaction } from '../decode-wire-transaction';
-
-const testAddress = (seed: number) => getAddressDecoder().decode(new Uint8Array(32).fill(seed));
-
-const FEE_PAYER = testAddress(1);
-const RECIPIENT = testAddress(2);
-const PROGRAM = testAddress(3);
-const BLOCKHASH = testAddress(9) as string as Blockhash;
-
-type ConfigOverrides = {
-    computeUnitLimit?: number;
-    heapSize?: number;
-    loadedAccountsDataSizeLimit?: number;
-    priorityFeeLamports?: bigint;
-};
-
-function createV1TransactionBytes(config: ConfigOverrides): Uint8Array {
-    const message = pipe(
-        // @ts-expect-error `createTransactionMessage` constrains its version parameter to
-        // `Exclude<TransactionVersion, 1>`. The runtime path is complete, so v1 messages compile and
-        // encode correctly; only the type gate is missing. Remove once kit lifts the exclusion.
-        createTransactionMessage({ version: 1 }),
-        m => setTransactionMessageFeePayer(FEE_PAYER, m),
-        m => setTransactionMessageLifetimeUsingBlockhash({ blockhash: BLOCKHASH, lastValidBlockHeight: 100n }, m),
-        m =>
-            appendTransactionMessageInstruction(
-                { accounts: [{ address: RECIPIENT, role: 1 }], data: new Uint8Array([1]), programAddress: PROGRAM },
-                m,
-            ),
-        // Every setter treats `undefined` as "leave unset", so omitted limits need no branching.
-        m => setTransactionMessageComputeUnitLimit(config.computeUnitLimit, m),
-        m => setTransactionMessageHeapSize(config.heapSize, m),
-        m => setTransactionMessageLoadedAccountsDataSizeLimit(config.loadedAccountsDataSizeLimit, m),
-        // The cast is needed only because the `@ts-expect-error` above leaves the message typed as
-        // `legacy | 0`; this setter is constrained to `{ version: 1 }`.
-        m => setTransactionMessagePriorityFeeLamports(config.priorityFeeLamports, m as typeof m & { version: 1 }),
-    );
-
-    return new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
-}
 
 function decodeConfigFromWire(bytes: Uint8Array) {
     return decodeTransactionConfig(decodeWireTransaction(bytes).compiledMessage);
@@ -96,23 +42,11 @@ describe('decodeTransactionConfig', () => {
     });
 
     it.each([
-        ['legacy', (message: TransactionMessage) => message.compileToLegacyMessage()],
-        ['v0', (message: TransactionMessage) => message.compileToV0Message()],
+        ['legacy', (message: ReturnType<typeof createWeb3TransactionMessage>) => message.compileToLegacyMessage()],
+        ['v0', (message: ReturnType<typeof createWeb3TransactionMessage>) => message.compileToV0Message()],
     ])('should return undefined for a %s message, which carries no config', (_name, compile) => {
         const compiledMessage = getCompiledTransactionMessageDecoder().decode(
-            compile(
-                new TransactionMessage({
-                    instructions: [
-                        SystemProgram.transfer({
-                            fromPubkey: new PublicKey(FEE_PAYER),
-                            lamports: 1n,
-                            toPubkey: new PublicKey(RECIPIENT),
-                        }),
-                    ],
-                    payerKey: new PublicKey(FEE_PAYER),
-                    recentBlockhash: PublicKey.default.toBase58(),
-                }),
-            ).serialize(),
+            compile(createWeb3TransactionMessage()).serialize(),
         );
 
         expect(decodeTransactionConfig(compiledMessage)).toBeUndefined();
@@ -130,5 +64,11 @@ describe('decodeWireTransaction', () => {
         // v1 puts the message first in the envelope, followed by the signature array.
         expect(messageBytes.length).toBeLessThan(bytes.length);
         expect(bytes.subarray(0, messageBytes.length)).toEqual(messageBytes);
+    });
+
+    it('should leave an unsigned signer slot undefined rather than reporting a zero signature', () => {
+        const { signatures } = decodeWireTransaction(createV1TransactionBytes({}));
+
+        expect(signatures).toEqual([undefined]);
     });
 });

--- a/app/entities/transaction-data/lib/__tests__/decode-transaction-config.spec.ts
+++ b/app/entities/transaction-data/lib/__tests__/decode-transaction-config.spec.ts
@@ -1,0 +1,134 @@
+import {
+    appendTransactionMessageInstruction,
+    type Blockhash,
+    compileTransaction,
+    createTransactionMessage,
+    getAddressDecoder,
+    getCompiledTransactionMessageDecoder,
+    getTransactionEncoder,
+    pipe,
+    setTransactionMessageComputeUnitLimit,
+    setTransactionMessageFeePayer,
+    setTransactionMessageHeapSize,
+    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
+    setTransactionMessagePriorityFeeLamports,
+} from '@solana/kit';
+import { PublicKey, SystemProgram, TransactionMessage } from '@solana/web3.js';
+import { describe, expect, it } from 'vitest';
+
+import { decodeTransactionConfig } from '../decode-transaction-config';
+import { decodeWireTransaction } from '../decode-wire-transaction';
+
+const testAddress = (seed: number) => getAddressDecoder().decode(new Uint8Array(32).fill(seed));
+
+const FEE_PAYER = testAddress(1);
+const RECIPIENT = testAddress(2);
+const PROGRAM = testAddress(3);
+const BLOCKHASH = testAddress(9) as string as Blockhash;
+
+type ConfigOverrides = {
+    computeUnitLimit?: number;
+    heapSize?: number;
+    loadedAccountsDataSizeLimit?: number;
+    priorityFeeLamports?: bigint;
+};
+
+function createV1TransactionBytes(config: ConfigOverrides): Uint8Array {
+    const message = pipe(
+        // @ts-expect-error `createTransactionMessage` constrains its version parameter to
+        // `Exclude<TransactionVersion, 1>`. The runtime path is complete, so v1 messages compile and
+        // encode correctly; only the type gate is missing. Remove once kit lifts the exclusion.
+        createTransactionMessage({ version: 1 }),
+        m => setTransactionMessageFeePayer(FEE_PAYER, m),
+        m => setTransactionMessageLifetimeUsingBlockhash({ blockhash: BLOCKHASH, lastValidBlockHeight: 100n }, m),
+        m =>
+            appendTransactionMessageInstruction(
+                { accounts: [{ address: RECIPIENT, role: 1 }], data: new Uint8Array([1]), programAddress: PROGRAM },
+                m,
+            ),
+        // Every setter treats `undefined` as "leave unset", so omitted limits need no branching.
+        m => setTransactionMessageComputeUnitLimit(config.computeUnitLimit, m),
+        m => setTransactionMessageHeapSize(config.heapSize, m),
+        m => setTransactionMessageLoadedAccountsDataSizeLimit(config.loadedAccountsDataSizeLimit, m),
+        // The cast is needed only because the `@ts-expect-error` above leaves the message typed as
+        // `legacy | 0`; this setter is constrained to `{ version: 1 }`.
+        m => setTransactionMessagePriorityFeeLamports(config.priorityFeeLamports, m as typeof m & { version: 1 }),
+    );
+
+    return new Uint8Array(getTransactionEncoder().encode(compileTransaction(message)));
+}
+
+function decodeConfigFromWire(bytes: Uint8Array) {
+    return decodeTransactionConfig(decodeWireTransaction(bytes).compiledMessage);
+}
+
+describe('decodeTransactionConfig', () => {
+    it('should read every resource limit a v1 message carries', () => {
+        const bytes = createV1TransactionBytes({
+            computeUnitLimit: 8442,
+            heapSize: 262_144,
+            loadedAccountsDataSizeLimit: 75_013,
+            priorityFeeLamports: 10_000n,
+        });
+
+        expect(decodeConfigFromWire(bytes)).toEqual({
+            computeUnitLimit: 8442,
+            heapSize: 262_144,
+            loadedAccountsDataSizeLimit: 75_013,
+            priorityFeeLamports: 10_000n,
+        });
+    });
+
+    it('should leave limits the message omits undefined', () => {
+        const bytes = createV1TransactionBytes({ computeUnitLimit: 8442 });
+
+        expect(decodeConfigFromWire(bytes)).toEqual({
+            computeUnitLimit: 8442,
+            heapSize: undefined,
+            loadedAccountsDataSizeLimit: undefined,
+            priorityFeeLamports: undefined,
+        });
+    });
+
+    it('should return undefined for a v1 message that sets no limits', () => {
+        expect(decodeConfigFromWire(createV1TransactionBytes({}))).toBeUndefined();
+    });
+
+    it.each([
+        ['legacy', (message: TransactionMessage) => message.compileToLegacyMessage()],
+        ['v0', (message: TransactionMessage) => message.compileToV0Message()],
+    ])('should return undefined for a %s message, which carries no config', (_name, compile) => {
+        const compiledMessage = getCompiledTransactionMessageDecoder().decode(
+            compile(
+                new TransactionMessage({
+                    instructions: [
+                        SystemProgram.transfer({
+                            fromPubkey: new PublicKey(FEE_PAYER),
+                            lamports: 1n,
+                            toPubkey: new PublicKey(RECIPIENT),
+                        }),
+                    ],
+                    payerKey: new PublicKey(FEE_PAYER),
+                    recentBlockhash: PublicKey.default.toBase58(),
+                }),
+            ).serialize(),
+        );
+
+        expect(decodeTransactionConfig(compiledMessage)).toBeUndefined();
+    });
+});
+
+describe('decodeWireTransaction', () => {
+    it('should round-trip the message bytes and expose the compiled v1 message', () => {
+        const bytes = createV1TransactionBytes({ computeUnitLimit: 8442 });
+
+        const { compiledMessage, messageBytes, signatures } = decodeWireTransaction(bytes);
+
+        expect(compiledMessage.version).toBe(1);
+        expect(signatures).toHaveLength(1);
+        // v1 puts the message first in the envelope, followed by the signature array.
+        expect(messageBytes.length).toBeLessThan(bytes.length);
+        expect(bytes.subarray(0, messageBytes.length)).toEqual(messageBytes);
+    });
+});

--- a/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
+++ b/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
@@ -1,0 +1,172 @@
+import {
+    type ParsedInstruction,
+    type ParsedMessageAccount,
+    type PartiallyDecodedInstruction,
+    PublicKey,
+    type TokenBalance,
+    type TransactionError,
+} from '@solana/web3.js';
+
+import type { TransactionVersion, TransactionWithMeta } from '../model/types';
+
+type RpcAccountKey = Readonly<{
+    pubkey: string;
+    signer: boolean;
+    /** Whether the address was declared in the message or resolved from an address lookup table. */
+    source: 'lookupTable' | 'transaction';
+    writable: boolean;
+}>;
+
+type RpcInstruction =
+    | Readonly<{ parsed: unknown; program: string; programId: string }>
+    | Readonly<{ accounts: readonly string[]; data: string; programId: string }>;
+
+type RpcTokenBalance = Readonly<{
+    accountIndex: number;
+    mint: string;
+    owner?: string;
+    programId?: string;
+    uiTokenAmount: Readonly<{
+        amount: string;
+        decimals: number;
+        uiAmount: number | null;
+        uiAmountString: string;
+    }>;
+}>;
+
+type RpcMeta = Readonly<{
+    computeUnitsConsumed?: bigint;
+    /**
+     * Served by the RPC but absent from kit's meta type, and it drives the "Transaction cost"
+     * row. Numeric fields arrive as bigint only where kit declares them, so an undeclared field
+     * can be either.
+     */
+    costUnits?: number | bigint;
+    err: TransactionError | null;
+    fee: bigint;
+    innerInstructions?: readonly Readonly<{ index: number; instructions: readonly RpcInstruction[] }>[] | null;
+    loadedAddresses?: Readonly<{ readonly: readonly string[]; writable: readonly string[] }>;
+    logMessages: readonly string[] | null;
+    postBalances: readonly bigint[];
+    postTokenBalances?: readonly RpcTokenBalance[];
+    preBalances: readonly bigint[];
+    preTokenBalances?: readonly RpcTokenBalance[];
+}>;
+
+/**
+ * A `getTransaction` response under `jsonParsed` encoding, as delivered by kit.
+ *
+ * Declared structurally rather than derived from kit's overloaded `GetTransactionApi`, which
+ * resolves to whichever overload is declared last regardless of the encoding requested.
+ */
+export type RpcParsedTransaction = Readonly<{
+    blockTime: bigint | null;
+    meta: RpcMeta | null;
+    slot: bigint;
+    transaction: Readonly<{
+        message: Readonly<{
+            accountKeys: readonly RpcAccountKey[];
+            instructions: readonly RpcInstruction[];
+            recentBlockhash: string;
+        }>;
+        signatures: readonly string[];
+    }>;
+    version?: TransactionVersion;
+}>;
+
+/**
+ * Converts a kit `getTransaction` response into the web3.js-shaped transaction the detail page
+ * renders.
+ *
+ * kit is the only client that can read v1 — web3.js validates the version against a
+ * `'legacy' | 0` union and throws on anything newer — but every consumer downstream of the
+ * transaction providers is written against web3.js types, so the response is adapted rather
+ * than propagated.
+ */
+// web3.js types `blockTime` and `meta` as required `T | null`, so null is the contract here,
+// not a stylistic choice.
+/* eslint-disable unicorn/no-null */
+export function adaptParsedTransaction(response: RpcParsedTransaction): TransactionWithMeta {
+    const { message, signatures } = response.transaction;
+
+    return {
+        blockTime: response.blockTime === null ? null : Number(response.blockTime),
+        meta: adaptMeta(response.meta),
+        slot: Number(response.slot),
+        transaction: {
+            message: {
+                accountKeys: message.accountKeys.map(adaptAccountKey),
+                instructions: message.instructions.map(adaptInstruction),
+                recentBlockhash: message.recentBlockhash,
+            },
+            signatures: [...signatures],
+        },
+        version: response.version,
+    };
+}
+
+function adaptMeta(meta: RpcMeta | null): TransactionWithMeta['meta'] {
+    if (meta === null) {
+        return null;
+    }
+
+    return {
+        computeUnitsConsumed: toOptionalNumber(meta.computeUnitsConsumed),
+        costUnits: toOptionalNumber(meta.costUnits),
+        err: meta.err,
+        fee: Number(meta.fee),
+        innerInstructions: meta.innerInstructions?.map(({ index, instructions }) => ({
+            index,
+            instructions: instructions.map(adaptInstruction),
+        })),
+        loadedAddresses: meta.loadedAddresses && {
+            readonly: meta.loadedAddresses.readonly.map(address => new PublicKey(address)),
+            writable: meta.loadedAddresses.writable.map(address => new PublicKey(address)),
+        },
+        logMessages: meta.logMessages && [...meta.logMessages],
+        postBalances: meta.postBalances.map(Number),
+        postTokenBalances: meta.postTokenBalances?.map(adaptTokenBalance),
+        preBalances: meta.preBalances.map(Number),
+        preTokenBalances: meta.preTokenBalances?.map(adaptTokenBalance),
+    };
+}
+/* eslint-enable unicorn/no-null */
+
+function adaptAccountKey(accountKey: RpcAccountKey): ParsedMessageAccount {
+    return {
+        pubkey: new PublicKey(accountKey.pubkey),
+        signer: accountKey.signer,
+        source: accountKey.source,
+        writable: accountKey.writable,
+    };
+}
+
+function adaptInstruction(instruction: RpcInstruction): ParsedInstruction | PartiallyDecodedInstruction {
+    if ('parsed' in instruction) {
+        return {
+            parsed: instruction.parsed,
+            program: instruction.program,
+            programId: new PublicKey(instruction.programId),
+        };
+    }
+
+    return {
+        accounts: instruction.accounts.map(account => new PublicKey(account)),
+        data: instruction.data,
+        programId: new PublicKey(instruction.programId),
+    };
+}
+
+function adaptTokenBalance(tokenBalance: RpcTokenBalance): TokenBalance {
+    return {
+        accountIndex: tokenBalance.accountIndex,
+        mint: tokenBalance.mint,
+        owner: tokenBalance.owner,
+        programId: tokenBalance.programId,
+        uiTokenAmount: { ...tokenBalance.uiTokenAmount },
+    };
+}
+
+function toOptionalNumber(value: number | bigint | undefined): number | undefined {
+    return value === undefined ? undefined : Number(value);
+}

--- a/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
+++ b/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
@@ -1,3 +1,4 @@
+import type { TransactionVersion } from '@solana/kit';
 import {
     type ParsedInstruction,
     type ParsedMessageAccount,
@@ -7,7 +8,7 @@ import {
     type TransactionError,
 } from '@solana/web3.js';
 
-import type { TransactionVersion, TransactionWithMeta } from '../model/types';
+import type { TransactionWithMeta } from '../model/types';
 
 type RpcAccountKey = Readonly<{
     pubkey: string;

--- a/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
+++ b/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
@@ -72,7 +72,11 @@ export type RpcParsedTransaction = Readonly<{
         }>;
         signatures: readonly string[];
     }>;
-    version?: TransactionVersion;
+    /**
+     * kit types the numeric versions as numbers, but `version` is absent from its integer
+     * allow-list, so they arrive as bigints at runtime.
+     */
+    version?: TransactionVersion | bigint;
 }>;
 
 /**
@@ -102,8 +106,12 @@ export function adaptParsedTransaction(response: RpcParsedTransaction): Transact
             },
             signatures: [...signatures],
         },
-        version: response.version,
+        version: adaptVersion(response.version),
     };
+}
+
+function adaptVersion(version: RpcParsedTransaction['version']): TransactionVersion | undefined {
+    return typeof version === 'bigint' ? (Number(version) as TransactionVersion) : version;
 }
 
 function adaptMeta(meta: RpcMeta | null): TransactionWithMeta['meta'] {

--- a/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
+++ b/app/entities/transaction-data/lib/adapt-parsed-transaction.ts
@@ -29,7 +29,8 @@ type RpcTokenBalance = Readonly<{
     uiTokenAmount: Readonly<{
         amount: string;
         decimals: number;
-        uiAmount: number | null;
+        /** kit declares this `number`, but delivers a bigint whenever the balance is a whole number. */
+        uiAmount: number | bigint | null;
         uiAmountString: string;
     }>;
 }>;
@@ -113,7 +114,9 @@ function adaptMeta(meta: RpcMeta | null): TransactionWithMeta['meta'] {
     return {
         computeUnitsConsumed: toOptionalNumber(meta.computeUnitsConsumed),
         costUnits: toOptionalNumber(meta.costUnits),
-        err: meta.err,
+        // Instruction indices and custom program error codes arrive as bigints; the error
+        // formatters do arithmetic on them and would throw on a mixed-type operation.
+        err: withNumbersInsteadOfBigInts(meta.err),
         fee: Number(meta.fee),
         innerInstructions: meta.innerInstructions?.map(({ index, instructions }) => ({
             index,
@@ -144,7 +147,7 @@ function adaptAccountKey(accountKey: RpcAccountKey): ParsedMessageAccount {
 function adaptInstruction(instruction: RpcInstruction): ParsedInstruction | PartiallyDecodedInstruction {
     if ('parsed' in instruction) {
         return {
-            parsed: instruction.parsed,
+            parsed: withNumbersInsteadOfBigInts(instruction.parsed),
             program: instruction.program,
             programId: new PublicKey(instruction.programId),
         };
@@ -163,10 +166,48 @@ function adaptTokenBalance(tokenBalance: RpcTokenBalance): TokenBalance {
         mint: tokenBalance.mint,
         owner: tokenBalance.owner,
         programId: tokenBalance.programId,
-        uiTokenAmount: { ...tokenBalance.uiTokenAmount },
+        uiTokenAmount: {
+            amount: tokenBalance.uiTokenAmount.amount,
+            decimals: tokenBalance.uiTokenAmount.decimals,
+            // `uiAmount` is not on kit's allow-list, so a whole-number balance arrives as a
+            // bigint while a fractional one stays a number.
+            uiAmount: toNullableNumber(tokenBalance.uiTokenAmount.uiAmount),
+            uiAmountString: tokenBalance.uiTokenAmount.uiAmountString,
+        },
     };
 }
 
 function toOptionalNumber(value: number | bigint | undefined): number | undefined {
     return value === undefined ? undefined : Number(value);
+}
+
+function toNullableNumber(value: number | bigint | null): number | null {
+    // web3.js types `uiAmount` as `number | null`, so null is the contract here.
+    // eslint-disable-next-line unicorn/no-null
+    return value === null ? null : Number(value);
+}
+
+/**
+ * Recursively replaces bigints with numbers.
+ *
+ * kit upcasts every integral value in an RPC response to a bigint unless its key path is on an
+ * allow-list, and that list covers nothing inside a parsed instruction or a transaction error.
+ * web3.js delivered plain numbers throughout, and consumers `JSON.stringify` these payloads —
+ * which throws on a bigint — and validate them against superstruct `number()` schemas.
+ *
+ * Precision above 2^53 is lost, exactly as it was when web3.js parsed the same response.
+ */
+function withNumbersInsteadOfBigInts<T>(value: T): T {
+    if (typeof value === 'bigint') {
+        return Number(value) as T;
+    }
+    if (Array.isArray(value)) {
+        return value.map(withNumbersInsteadOfBigInts) as T;
+    }
+    if (typeof value === 'object' && value !== null) {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, item]) => [key, withNumbersInsteadOfBigInts(item)]),
+        ) as T;
+    }
+    return value;
 }

--- a/app/entities/transaction-data/lib/decode-transaction-config.ts
+++ b/app/entities/transaction-data/lib/decode-transaction-config.ts
@@ -1,0 +1,37 @@
+import {
+    type CompiledTransactionMessage,
+    type CompiledTransactionMessageWithLifetime,
+    decompileTransactionMessage,
+    getTransactionMessageComputeUnitLimit,
+    getTransactionMessageHeapSize,
+    getTransactionMessageLoadedAccountsDataSizeLimit,
+    getTransactionMessagePriorityFeeLamports,
+} from '@solana/kit';
+
+import type { TransactionConfig } from '../model/types';
+
+/**
+ * Reads the message-level resource limits out of a compiled transaction message.
+ *
+ * v1 carries these in the message rather than in Compute Budget instructions, and the RPC's
+ * `jsonParsed` encoding does not surface them, so they have to come from the wire bytes.
+ *
+ * Returns `undefined` when the message is not v1, or when it sets no limits at all.
+ */
+export function decodeTransactionConfig(
+    compiledMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime,
+): TransactionConfig | undefined {
+    if (compiledMessage.version !== 1) {
+        return undefined;
+    }
+
+    const message = decompileTransactionMessage(compiledMessage);
+    const config: TransactionConfig = {
+        computeUnitLimit: getTransactionMessageComputeUnitLimit(message),
+        heapSize: getTransactionMessageHeapSize(message),
+        loadedAccountsDataSizeLimit: getTransactionMessageLoadedAccountsDataSizeLimit(message),
+        priorityFeeLamports: getTransactionMessagePriorityFeeLamports(message),
+    };
+
+    return Object.values(config).every(value => value === undefined) ? undefined : config;
+}

--- a/app/entities/transaction-data/lib/decode-wire-transaction.ts
+++ b/app/entities/transaction-data/lib/decode-wire-transaction.ts
@@ -6,6 +6,8 @@ import {
     getTransactionDecoder,
 } from '@solana/kit';
 
+const SIGNATURE_BYTES = 64;
+
 export type WireTransaction = {
     compiledMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime;
     /** The message portion of the wire bytes, exactly as served by the RPC. */
@@ -29,9 +31,10 @@ export function decodeWireTransaction(bytes: Uint8Array): WireTransaction {
         compiledMessage: getCompiledTransactionMessageDecoder().decode(transaction.messageBytes),
         // The decoded message bytes are a view over `bytes`; copy so callers own their buffer.
         messageBytes: new Uint8Array(transaction.messageBytes),
-        // SignaturesMap is insertion-ordered, matching the message's signer order.
+        // SignaturesMap is insertion-ordered, matching the message's signer order. A signer that has
+        // not signed yet gets the all-zero signature, which renders as a placeholder rather than a gap.
         signatures: Object.values(transaction.signatures).map(signature =>
-            signature ? base58Decoder.decode(signature) : '',
+            base58Decoder.decode(signature ?? new Uint8Array(SIGNATURE_BYTES)),
         ),
     };
 }

--- a/app/entities/transaction-data/lib/decode-wire-transaction.ts
+++ b/app/entities/transaction-data/lib/decode-wire-transaction.ts
@@ -1,0 +1,37 @@
+import {
+    type CompiledTransactionMessage,
+    type CompiledTransactionMessageWithLifetime,
+    getBase58Decoder,
+    getCompiledTransactionMessageDecoder,
+    getTransactionDecoder,
+} from '@solana/kit';
+
+export type WireTransaction = {
+    compiledMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime;
+    /** The message portion of the wire bytes, exactly as served by the RPC. */
+    messageBytes: Uint8Array;
+    /** Base58-encoded, in signer order. */
+    signatures: string[];
+};
+
+/**
+ * Splits base64-encoded transaction wire bytes into their message and signatures.
+ *
+ * kit is used rather than web3.js `VersionedTransaction` because v1 reorders the wire envelope —
+ * message bytes first, then a fixed-count signature array with no length prefix — which web3.js
+ * cannot parse.
+ */
+export function decodeWireTransaction(bytes: Uint8Array): WireTransaction {
+    const transaction = getTransactionDecoder().decode(bytes);
+    const base58Decoder = getBase58Decoder();
+
+    return {
+        compiledMessage: getCompiledTransactionMessageDecoder().decode(transaction.messageBytes),
+        // The decoded message bytes are a view over `bytes`; copy so callers own their buffer.
+        messageBytes: new Uint8Array(transaction.messageBytes),
+        // SignaturesMap is insertion-ordered, matching the message's signer order.
+        signatures: Object.values(transaction.signatures).map(signature =>
+            signature ? base58Decoder.decode(signature) : '',
+        ),
+    };
+}

--- a/app/entities/transaction-data/lib/decode-wire-transaction.ts
+++ b/app/entities/transaction-data/lib/decode-wire-transaction.ts
@@ -6,14 +6,12 @@ import {
     getTransactionDecoder,
 } from '@solana/kit';
 
-const SIGNATURE_BYTES = 64;
-
 export type WireTransaction = {
     compiledMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime;
     /** The message portion of the wire bytes, exactly as served by the RPC. */
     messageBytes: Uint8Array;
-    /** Base58-encoded, in signer order. */
-    signatures: string[];
+    /** Base58-encoded in signer order; a signer slot that has not been signed is `undefined`. */
+    signatures: (string | undefined)[];
 };
 
 /**
@@ -31,10 +29,11 @@ export function decodeWireTransaction(bytes: Uint8Array): WireTransaction {
         compiledMessage: getCompiledTransactionMessageDecoder().decode(transaction.messageBytes),
         // The decoded message bytes are a view over `bytes`; copy so callers own their buffer.
         messageBytes: new Uint8Array(transaction.messageBytes),
-        // SignaturesMap is insertion-ordered, matching the message's signer order. A signer that has
-        // not signed yet gets the all-zero signature, which renders as a placeholder rather than a gap.
+        // SignaturesMap is insertion-ordered, matching the message's signer order. A signer slot
+        // that has not been signed holds no bytes at all, which consumers render as missing rather
+        // than as a signature that fails to verify.
         signatures: Object.values(transaction.signatures).map(signature =>
-            base58Decoder.decode(signature ?? new Uint8Array(SIGNATURE_BYTES)),
+            signature ? base58Decoder.decode(signature) : undefined,
         ),
     };
 }

--- a/app/entities/transaction-data/model/types.ts
+++ b/app/entities/transaction-data/model/types.ts
@@ -1,16 +1,10 @@
+import type { TransactionVersion } from '@solana/kit';
 import type {
     CompiledInnerInstruction,
     ParsedTransactionWithMeta,
     TransactionMessage,
     VersionedMessage,
 } from '@solana/web3.js';
-
-/**
- * Transaction message versions Explorer can render.
- *
- * web3.js stops at v0, so its `TransactionVersion` cannot describe a v1 transaction.
- */
-export type TransactionVersion = 'legacy' | 0 | 1;
 
 /**
  * Message-level resource limits carried by a v1 transaction.
@@ -31,10 +25,21 @@ export type TransactionConfig = {
  * A parsed transaction in the shape the transaction detail page consumes.
  *
  * Matches web3.js `ParsedTransactionWithMeta` so existing consumers are unaffected, with the
- * version widened to cover v1 and the v1 resource limits attached.
+ * version widened to cover v1, which web3.js `TransactionVersion` cannot describe.
  */
 export type TransactionWithMeta = Omit<ParsedTransactionWithMeta, 'version'> & {
     version?: TransactionVersion;
+};
+
+type RawTransactionBase = {
+    messageBytes: Uint8Array;
+    meta?: {
+        innerInstructions?: CompiledInnerInstruction[];
+        postBalances: number[];
+        preBalances: number[];
+    };
+    /** Base58-encoded in signer order; a signer slot that has not been signed is `undefined`. */
+    signatures: (string | undefined)[];
     /** Present only on v1 transactions that set at least one resource limit. */
     transactionConfig?: TransactionConfig;
 };
@@ -42,19 +47,12 @@ export type TransactionWithMeta = Omit<ParsedTransactionWithMeta, 'version'> & {
 /**
  * A transaction's wire bytes and the parts of its metadata the inspector needs.
  *
- * `message` and `transaction` are the web3.js views of the bytes and are absent on v1, whose
- * message web3.js cannot represent. `messageBytes` is always present, so anything that only
- * needs the bytes — the download button — works on every version.
+ * `message` and `transaction` are the web3.js views of the bytes, which web3.js can only build for
+ * legacy and v0. `messageBytes` is always present, so anything that only needs the bytes — the
+ * download button — works on every version.
  */
-export type RawTransaction = {
-    message?: VersionedMessage;
-    messageBytes: Uint8Array;
-    meta?: {
-        innerInstructions?: CompiledInnerInstruction[];
-        postBalances: number[];
-        preBalances: number[];
-    };
-    signatures: string[];
-    transaction?: TransactionMessage;
-    version: TransactionVersion;
-};
+export type RawTransaction = RawTransactionBase &
+    (
+        | { version: 'legacy' | 0; message: VersionedMessage; transaction: TransactionMessage }
+        | { version: 1; message?: undefined; transaction?: undefined }
+    );

--- a/app/entities/transaction-data/model/types.ts
+++ b/app/entities/transaction-data/model/types.ts
@@ -40,8 +40,6 @@ type RawTransactionBase = {
     };
     /** Base58-encoded in signer order; a signer slot that has not been signed is `undefined`. */
     signatures: (string | undefined)[];
-    /** Present only on v1 transactions that set at least one resource limit. */
-    transactionConfig?: TransactionConfig;
 };
 
 /**
@@ -49,10 +47,16 @@ type RawTransactionBase = {
  *
  * `message` and `transaction` are the web3.js views of the bytes, which web3.js can only build for
  * legacy and v0. `messageBytes` is always present, so anything that only needs the bytes — the
- * download button — works on every version.
+ * download button — works on every version. Only v1 carries a message-level `transactionConfig`,
+ * and only when it sets at least one limit.
  */
 export type RawTransaction = RawTransactionBase &
     (
-        | { version: 'legacy' | 0; message: VersionedMessage; transaction: TransactionMessage }
-        | { version: 1; message?: undefined; transaction?: undefined }
+        | {
+              version: 'legacy' | 0;
+              message: VersionedMessage;
+              transaction: TransactionMessage;
+              transactionConfig?: undefined;
+          }
+        | { version: 1; message?: undefined; transaction?: undefined; transactionConfig?: TransactionConfig }
     );

--- a/app/entities/transaction-data/model/types.ts
+++ b/app/entities/transaction-data/model/types.ts
@@ -1,0 +1,60 @@
+import type {
+    CompiledInnerInstruction,
+    ParsedTransactionWithMeta,
+    TransactionMessage,
+    VersionedMessage,
+} from '@solana/web3.js';
+
+/**
+ * Transaction message versions Explorer can render.
+ *
+ * web3.js stops at v0, so its `TransactionVersion` cannot describe a v1 transaction.
+ */
+export type TransactionVersion = 'legacy' | 0 | 1;
+
+/**
+ * Message-level resource limits carried by a v1 transaction.
+ *
+ * v1 moves these out of Compute Budget instructions and into the message itself. `priorityFee`
+ * is a total amount in lamports, unlike v0's per-compute-unit price in micro-lamports.
+ *
+ * Structurally mirrors kit's `V1TransactionConfig`, which kit does not re-export as a type.
+ */
+export type TransactionConfig = {
+    computeUnitLimit?: number;
+    heapSize?: number;
+    loadedAccountsDataSizeLimit?: number;
+    priorityFeeLamports?: bigint;
+};
+
+/**
+ * A parsed transaction in the shape the transaction detail page consumes.
+ *
+ * Matches web3.js `ParsedTransactionWithMeta` so existing consumers are unaffected, with the
+ * version widened to cover v1 and the v1 resource limits attached.
+ */
+export type TransactionWithMeta = Omit<ParsedTransactionWithMeta, 'version'> & {
+    version?: TransactionVersion;
+    /** Present only on v1 transactions that set at least one resource limit. */
+    transactionConfig?: TransactionConfig;
+};
+
+/**
+ * A transaction's wire bytes and the parts of its metadata the inspector needs.
+ *
+ * `message` and `transaction` are the web3.js views of the bytes and are absent on v1, whose
+ * message web3.js cannot represent. `messageBytes` is always present, so anything that only
+ * needs the bytes — the download button — works on every version.
+ */
+export type RawTransaction = {
+    message?: VersionedMessage;
+    messageBytes: Uint8Array;
+    meta?: {
+        innerInstructions?: CompiledInnerInstruction[];
+        postBalances: number[];
+        preBalances: number[];
+    };
+    signatures: string[];
+    transaction?: TransactionMessage;
+    version: TransactionVersion;
+};

--- a/app/entities/transfer-instruction/lib.ts
+++ b/app/entities/transfer-instruction/lib.ts
@@ -1,5 +1,5 @@
 import { ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import type { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction } from '@solana/web3.js';
+import type { ParsedInstruction, PartiallyDecodedInstruction } from '@solana/web3.js';
 import { PublicKey, SystemProgram } from '@solana/web3.js';
 
 import { isTokenProgramAddress } from '@/app/shared/model/token-program';
@@ -13,6 +13,17 @@ const RENT_FUNDING_PROGRAMS: PublicKey[] = [ASSOCIATED_TOKEN_PROGRAM_ID];
 export function isRentFundingProgram(programId: PublicKey): boolean {
     return RENT_FUNDING_PROGRAMS.some(p => p.equals(programId));
 }
+
+// The instruction-bearing slice of a parsed transaction. Declared structurally so callers can
+// pass any transaction version — instruction layout does not vary by version.
+type TransactionInstructionSource = {
+    meta?: {
+        innerInstructions?:
+            | { index: number; instructions: (ParsedInstruction | PartiallyDecodedInstruction)[] }[]
+            | null;
+    } | null;
+    transaction: { message: { instructions: (ParsedInstruction | PartiallyDecodedInstruction)[] } };
+};
 
 export type LocatedInstruction<T> = {
     instruction: T;
@@ -28,7 +39,7 @@ export type LocatedInstruction<T> = {
 // Each match carries `topLevelIndex` (and `innerIndex` if the match came from an
 // inner instruction) so downstream loggers can pinpoint the original tx position.
 export function collectTransferInstructions<T extends ParsedInstruction | PartiallyDecodedInstruction>(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionInstructionSource,
     isMatch: (instr: ParsedInstruction | PartiallyDecodedInstruction) => instr is T,
 ): LocatedInstruction<T>[] {
     const innerByIndex = new Map<number, (ParsedInstruction | PartiallyDecodedInstruction)[]>();

--- a/app/features/cu-profiling/ui/CUProfilingSection.tsx
+++ b/app/features/cu-profiling/ui/CUProfilingSection.tsx
@@ -1,14 +1,14 @@
 import { CUProfilingCard, formatInstructionLogs } from '@entities/compute-unit';
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import { useCluster, useClusterInfo } from '@providers/cluster';
 import { useTransactionDetails } from '@providers/transactions';
-import type { ParsedTransactionWithMeta } from '@solana/web3.js';
 import type { Cluster } from '@utils/cluster';
 import { getEpochForSlot } from '@utils/epoch-schedule';
 import type { SignatureProps } from '@utils/index';
 import { type InstructionLogs, parseProgramLogs } from '@utils/program-logs';
 import React from 'react';
 
-// FIXME: missing Storybook story — needs useTransactionDetails provider + ParsedTransactionWithMeta fixture.
+// FIXME: missing Storybook story — needs useTransactionDetails provider + TransactionWithMeta fixture.
 export function CUProfilingSection({ signature }: SignatureProps) {
     const details = useTransactionDetails(signature);
     const { cluster } = useCluster();
@@ -43,7 +43,7 @@ export function CUProfilingSection({ signature }: SignatureProps) {
     return <CUProfilingCard instructions={instructionsForCU} unitsConsumed={unitsConsumed} />;
 }
 
-function formatTransactionLogs(transactionWithMeta: ParsedTransactionWithMeta | null | undefined, cluster: Cluster) {
+function formatTransactionLogs(transactionWithMeta: TransactionWithMeta | null | undefined, cluster: Cluster) {
     const logMessages = transactionWithMeta?.meta?.logMessages || null;
     const err = transactionWithMeta?.meta?.err || undefined;
 

--- a/app/features/receipt/model/create-receipt.ts
+++ b/app/features/receipt/model/create-receipt.ts
@@ -1,5 +1,5 @@
 import { truncateAddress } from '@entities/address';
-import { ParsedTransactionWithMeta } from '@solana/web3.js';
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import { lamportsToSolString } from '@utils/index';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -25,7 +25,7 @@ export async function createReceipt(signature: string, cluster?: QueryCluster): 
     return extractReceiptData(data.transaction, data.cluster);
 }
 
-export async function extractReceiptData(tx: ParsedTransactionWithMeta, cluster: Cluster): Promise<ReceiptResult> {
+export async function extractReceiptData(tx: TransactionWithMeta, cluster: Cluster): Promise<ReceiptResult> {
     const tokenOutcome = await createTokenTransferReceipt(tx, (mint: string | undefined) =>
         getParsedTokenInfo(mint, cluster),
     );

--- a/app/features/receipt/model/memo.ts
+++ b/app/features/receipt/model/memo.ts
@@ -1,14 +1,10 @@
-import {
-    ParsedInstruction,
-    type ParsedTransactionWithMeta,
-    type PartiallyDecodedInstruction,
-    PublicKey,
-} from '@solana/web3.js';
+import type { TransactionWithMeta } from '@entities/transaction-data';
+import { ParsedInstruction, type PartiallyDecodedInstruction, PublicKey } from '@solana/web3.js';
 import { MEMO_PROGRAM_ADDRESS } from '@solana-program/memo';
 
 import { isParsedInstruction } from './types';
 
-export function extractMemoFromTransaction(transaction: ParsedTransactionWithMeta): string | undefined {
+export function extractMemoFromTransaction(transaction: TransactionWithMeta): string | undefined {
     const { transaction: tx } = transaction;
     const memoInstruction = tx.message.instructions.find(isMemoProgram);
     return memoInstruction && extractMemoFromInstruction(memoInstruction);

--- a/app/features/receipt/model/sol-transfer.ts
+++ b/app/features/receipt/model/sol-transfer.ts
@@ -1,3 +1,4 @@
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import {
     collectTransferInstructions,
     isRentFundingProgram,
@@ -5,7 +6,7 @@ import {
     type LocatedInstruction,
     type SolTransferInstruction,
 } from '@entities/transfer-instruction';
-import type { ParsedInstruction, ParsedTransactionWithMeta, PartiallyDecodedInstruction } from '@solana/web3.js';
+import type { ParsedInstruction, PartiallyDecodedInstruction } from '@solana/web3.js';
 import { validate } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -15,7 +16,7 @@ import { extractMemoFromTransaction } from './memo';
 import { SolTransferPayload } from './schemas';
 import { type ReceiptSol, type Transfer } from './types';
 
-export function createSolTransferReceipt(transaction: ParsedTransactionWithMeta): ReceiptSol | undefined {
+export function createSolTransferReceipt(transaction: TransactionWithMeta): ReceiptSol | undefined {
     const located = getSolTransferInstructions(transaction);
     if (located.length === 0) return undefined;
 
@@ -46,9 +47,7 @@ export function createSolTransferReceipt(transaction: ParsedTransactionWithMeta)
     };
 }
 
-function getSolTransferInstructions(
-    transaction: ParsedTransactionWithMeta,
-): LocatedInstruction<SolTransferInstruction>[] {
+function getSolTransferInstructions(transaction: TransactionWithMeta): LocatedInstruction<SolTransferInstruction>[] {
     const collected = collectTransferInstructions(
         transaction,
         (instr: ParsedInstruction | PartiallyDecodedInstruction): instr is SolTransferInstruction =>
@@ -64,7 +63,7 @@ function getSolTransferInstructions(
 }
 
 function buildTransfers(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionWithMeta,
     located: LocatedInstruction<SolTransferInstruction>[],
 ): Transfer[] | undefined {
     const result: Transfer[] = [];
@@ -80,7 +79,7 @@ function buildTransfers(
     return result;
 }
 
-function extractSolTransferPayload(transaction: ParsedTransactionWithMeta, instruction: SolTransferInstruction) {
+function extractSolTransferPayload(transaction: TransactionWithMeta, instruction: SolTransferInstruction) {
     const { info } = instruction.parsed;
     return {
         date: transaction.blockTime ?? undefined,

--- a/app/features/receipt/model/token-transfer.ts
+++ b/app/features/receipt/model/token-transfer.ts
@@ -1,3 +1,4 @@
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import {
     collectTransferInstructions,
     isTokenTransferInstruction,
@@ -5,7 +6,6 @@ import {
     type TokenTransferInstruction,
     type TokenTransferParsed,
 } from '@entities/transfer-instruction';
-import type { ParsedTransactionWithMeta } from '@solana/web3.js';
 import { validate } from 'superstruct';
 
 import { Logger } from '@/app/shared/lib/logger';
@@ -29,7 +29,7 @@ export type TokenReceiptOutcome =
     | { kind: 'not-applicable' };
 
 export async function createTokenTransferReceipt(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionWithMeta,
     getTokenInfo: (mint: string | undefined) => Promise<TokenInfo | undefined>,
 ): Promise<TokenReceiptOutcome> {
     const located = getTokenTransferInstructions(transaction);
@@ -77,7 +77,7 @@ export async function createTokenTransferReceipt(
 }
 
 function getTokenTransferInstructions(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionWithMeta,
 ): LocatedInstruction<TokenTransferInstruction>[] {
     return collectTransferInstructions(transaction, isTokenTransferInstruction);
 }
@@ -99,7 +99,7 @@ type PrimaryToken = {
 // then divides by 10^decimals once. Caller guarantees all instructions share a mint
 // (and therefore the same decimals).
 function buildTokenTransfers(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionWithMeta,
     located: LocatedInstruction<TokenTransferInstruction>[],
     primary: PrimaryToken,
 ): BuildTokenTransfersResult {
@@ -135,10 +135,7 @@ function buildTokenTransfers(
     };
 }
 
-function extractAmountInfo(
-    parsed: TokenTransferParsed,
-    transaction: ParsedTransactionWithMeta,
-): AmountInfo | undefined {
+function extractAmountInfo(parsed: TokenTransferParsed, transaction: TransactionWithMeta): AmountInfo | undefined {
     if (parsed.type === 'transferChecked' || parsed.type === 'transfer2') {
         const tokenAmount = parsed.info.tokenAmount;
         if (!tokenAmount?.amount || tokenAmount.decimals === undefined) return undefined;
@@ -150,7 +147,7 @@ function extractAmountInfo(
     return { decimals, rawAmount: parsed.info.amount };
 }
 
-function extractTokenTransferPayload(transaction: ParsedTransactionWithMeta, instruction: TokenTransferInstruction) {
+function extractTokenTransferPayload(transaction: TransactionWithMeta, instruction: TokenTransferInstruction) {
     const parsed = instruction.parsed;
     return {
         date: transaction.blockTime ?? undefined,
@@ -170,7 +167,7 @@ function extractTokenSender(info: TokenTransferParsed['info']): string | undefin
     return info.authority;
 }
 
-function extractTokenMint(transaction: ParsedTransactionWithMeta, parsed: TokenTransferParsed): string | undefined {
+function extractTokenMint(transaction: TransactionWithMeta, parsed: TokenTransferParsed): string | undefined {
     if ('mint' in parsed.info) {
         return parsed.info.mint?.toString();
     }
@@ -186,7 +183,7 @@ function extractTokenMint(transaction: ParsedTransactionWithMeta, parsed: TokenT
 }
 
 function extractTokenReceiver(
-    transaction: ParsedTransactionWithMeta,
+    transaction: TransactionWithMeta,
     destinationTokenAccount: string | undefined,
 ): string | undefined {
     if (!destinationTokenAccount) {
@@ -202,7 +199,7 @@ function extractTokenReceiver(
     return tokenBalance?.owner;
 }
 
-function extractTotal(parsed: TokenTransferParsed, transaction: ParsedTransactionWithMeta): number {
+function extractTotal(parsed: TokenTransferParsed, transaction: TransactionWithMeta): number {
     if (parsed.type === 'transferChecked' || parsed.type === 'transfer2') {
         return parseFloat(parsed.info.tokenAmount?.uiAmountString || '0');
     }
@@ -219,10 +216,7 @@ function extractTotal(parsed: TokenTransferParsed, transaction: ParsedTransactio
     return rawAmount;
 }
 
-function getTokenDecimals(
-    transaction: ParsedTransactionWithMeta,
-    tokenAccount: string | undefined,
-): number | undefined {
+function getTokenDecimals(transaction: TransactionWithMeta, tokenAccount: string | undefined): number | undefined {
     if (!tokenAccount) {
         return undefined;
     }

--- a/app/features/receipt/ui/ViewReceiptButton.tsx
+++ b/app/features/receipt/ui/ViewReceiptButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import type { TransactionWithMeta } from '@entities/transaction-data';
 import { useCluster } from '@providers/cluster';
-import { ParsedTransactionWithMeta } from '@solana/web3.js';
 import Link from 'next/link';
 import { FileText } from 'react-feather';
 import useSWR from 'swr';
@@ -15,7 +15,7 @@ import { extractReceiptData } from '../model/create-receipt';
 interface ViewReceiptButtonProps {
     signature: string;
     receiptPath: string;
-    transactionWithMeta: ParsedTransactionWithMeta | null | undefined;
+    transactionWithMeta: TransactionWithMeta | null | undefined;
 }
 
 // FIXME: missing Storybook story — gated on NEXT_PUBLIC_RECEIPT_ENABLED + needs a populated transactionWithMeta to render.

--- a/app/features/transaction-history/ui/TransactionRawDataCell.tsx
+++ b/app/features/transaction-history/ui/TransactionRawDataCell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FetchStatus } from '@providers/cache';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useFetchRawTransaction, useRawTransactionDetails } from '@/app/providers/transactions/raw';
 
@@ -12,8 +12,7 @@ import { BaseTransactionRawData } from './BaseTransactionRawData';
 export function TransactionRawDataCell({ signature }: { signature: string }) {
     const fetchRaw = useFetchRawTransaction();
     const rawDetails = useRawTransactionDetails(signature);
-    const serialized = rawDetails?.data?.raw?.message.serialize();
-    const data = useMemo(() => (serialized ? new Uint8Array(serialized) : undefined), [serialized]);
+    const data = rawDetails?.data?.raw?.messageBytes;
     const loading = rawDetails?.status === FetchStatus.Fetching;
 
     const onHover = useCallback(() => {

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -10,6 +10,7 @@ import { Button } from '@components/shared/ui/button';
 import { RefreshButton } from '@components/shared/ui/refresh-button';
 import { cn } from '@components/shared/utils';
 import { estimateRequestedComputeUnitsForParsedTransaction } from '@entities/compute-unit';
+import type { TransactionVersion } from '@entities/transaction-data';
 import { ViewReceiptButton } from '@features/receipt';
 import { FetchStatus } from '@providers/cache';
 import { useCluster, useClusterInfo } from '@providers/cluster';
@@ -27,7 +28,7 @@ import { getTransactionInstructionError } from '@utils/program-err';
 import { intoTransactionInstruction } from '@utils/tx';
 import { useClusterPath } from '@utils/url';
 import Link from 'next/link';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { ZoomIn } from 'react-feather';
 
 import { useFetchRawTransaction, useRawTransactionDetails } from '@/app/providers/transactions/raw';
@@ -112,8 +113,7 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
         pathname: `/tx/${signature}`,
     });
 
-    const rawMessage = rawDetails?.data?.raw?.message;
-    const serializedRawData = useMemo(() => rawMessage?.serialize(), [rawMessage]);
+    const serializedRawData = rawDetails?.data?.raw?.messageBytes;
 
     useEffect(() => {
         if (!rawDetails && clusterStatus === ClusterStatus.Connected) {
@@ -160,13 +160,18 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
     const fee = transactionWithMeta?.meta?.fee;
     const costUnits = transactionWithMeta?.meta?.costUnits;
     const computeUnitsConsumed = transactionWithMeta?.meta?.computeUnitsConsumed;
-    const reservedCUs = transactionWithMeta?.transaction
-        ? estimateRequestedComputeUnitsForParsedTransaction(
-              transactionWithMeta.transaction,
-              clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(info.slot)) : undefined,
-              cluster,
-          )
-        : undefined;
+    const transactionConfig = transactionWithMeta?.transactionConfig;
+    // v1 declares its compute unit limit on the message; every earlier version has to have it
+    // reconstructed from the Compute Budget instructions, which v1 does not carry.
+    const reservedCUs =
+        transactionConfig?.computeUnitLimit ??
+        (transactionWithMeta?.transaction && transactionWithMeta.version !== 1
+            ? estimateRequestedComputeUnitsForParsedTransaction(
+                  transactionWithMeta.transaction,
+                  clusterInfo ? getEpochForSlot(clusterInfo.epochSchedule, BigInt(info.slot)) : undefined,
+                  cluster,
+              )
+            : undefined);
     const transaction = transactionWithMeta?.transaction;
     const blockhash = transaction?.message.recentBlockhash;
     const version = transactionWithMeta?.version;
@@ -340,11 +345,37 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
                     </Row>
                 )}
 
+                {/* v1 message-level resource limits */}
+                {transactionConfig?.priorityFeeLamports !== undefined && (
+                    <Row divider>
+                        <Label className="overflow-visible">
+                            <InfoTooltip text="A total amount paid for prioritization, unlike the per-compute-unit price used before v1">
+                                Priority fee (total)
+                            </InfoTooltip>
+                        </Label>
+                        <Value>
+                            <SolBalance lamports={transactionConfig.priorityFeeLamports} />
+                        </Value>
+                    </Row>
+                )}
+                {transactionConfig?.loadedAccountsDataSizeLimit !== undefined && (
+                    <Row divider>
+                        <Label>Loaded accounts data size limit</Label>
+                        <Value>{transactionConfig.loadedAccountsDataSizeLimit.toLocaleString('en-US')}</Value>
+                    </Row>
+                )}
+                {transactionConfig?.heapSize !== undefined && (
+                    <Row divider>
+                        <Label>Heap size</Label>
+                        <Value>{transactionConfig.heapSize.toLocaleString('en-US')}</Value>
+                    </Row>
+                )}
+
                 {/* Transaction Version */}
                 {version !== undefined && (
                     <Row divider>
                         <Label>Transaction Version</Label>
-                        <Value className="uppercase">{version}</Value>
+                        <Value className="uppercase">{formatTransactionVersion(version)}</Value>
                     </Row>
                 )}
 
@@ -377,4 +408,8 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
             </Card>
         </section>
     );
+}
+
+function formatTransactionVersion(version: TransactionVersion): string {
+    return version === 'legacy' ? version : `v${version}`;
 }

--- a/app/features/transaction/ui/SummaryCard.tsx
+++ b/app/features/transaction/ui/SummaryCard.tsx
@@ -10,7 +10,6 @@ import { Button } from '@components/shared/ui/button';
 import { RefreshButton } from '@components/shared/ui/refresh-button';
 import { cn } from '@components/shared/utils';
 import { estimateRequestedComputeUnitsForParsedTransaction } from '@entities/compute-unit';
-import type { TransactionVersion } from '@entities/transaction-data';
 import { ViewReceiptButton } from '@features/receipt';
 import { FetchStatus } from '@providers/cache';
 import { useCluster, useClusterInfo } from '@providers/cluster';
@@ -20,6 +19,7 @@ import {
     useTransactionDetails,
     useTransactionStatus,
 } from '@providers/transactions';
+import type { TransactionVersion } from '@solana/kit';
 import { ParsedTransaction, SystemInstruction, SystemProgram } from '@solana/web3.js';
 import { Cluster, ClusterStatus } from '@utils/cluster';
 import { displayTimestamp, displayTimestampUtc } from '@utils/date';
@@ -160,7 +160,7 @@ export function SummaryCard({ signature, autoRefresh }: SignatureProps & WithAut
     const fee = transactionWithMeta?.meta?.fee;
     const costUnits = transactionWithMeta?.meta?.costUnits;
     const computeUnitsConsumed = transactionWithMeta?.meta?.computeUnitsConsumed;
-    const transactionConfig = transactionWithMeta?.transactionConfig;
+    const transactionConfig = rawDetails?.data?.raw?.transactionConfig;
     // v1 declares its compute unit limit on the message; every earlier version has to have it
     // reconstructed from the Compute Budget instructions, which v1 does not carry.
     const reservedCUs =

--- a/app/providers/transactions/__tests__/raw.test.tsx
+++ b/app/providers/transactions/__tests__/raw.test.tsx
@@ -17,16 +17,10 @@ vi.mock('@providers/cluster', () => ({
 const loggerError = vi.fn();
 vi.mock('@/app/shared/lib/logger', () => ({ Logger: { error: (...args: unknown[]) => loggerError(...args) } }));
 
-const getTransaction = vi.fn();
-vi.mock('@solana/web3.js', async () => {
-    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js');
-    return {
-        ...actual,
-        Connection: vi.fn().mockImplementation(function () {
-            return { getTransaction: (...args: unknown[]) => getTransaction(...args) };
-        }),
-    };
-});
+const fetchRawTransaction = vi.fn();
+vi.mock('@entities/transaction-data', () => ({
+    fetchRawTransaction: (...args: unknown[]) => fetchRawTransaction(...args),
+}));
 
 const dispatch = vi.fn();
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -39,8 +33,8 @@ beforeEach(() => {
 });
 
 describe('useFetchRawTransaction', () => {
-    it('should dispatch FetchFailed when getTransaction throws', async () => {
-        getTransaction.mockRejectedValue(new Error('rpc boom'));
+    it('should dispatch FetchFailed when the fetch throws', async () => {
+        fetchRawTransaction.mockRejectedValue(new Error('rpc boom'));
         const { result } = renderHook(() => useFetchRawTransaction(), { wrapper });
 
         result.current('sig', 'confirmed');
@@ -61,37 +55,45 @@ describe('useFetchRawTransaction', () => {
         expect(failedAction).not.toHaveProperty('data');
     });
 
-    it('should thread the commitment through to getTransaction', async () => {
-        getTransaction.mockResolvedValue(null);
+    it('should thread the commitment through to the fetch', async () => {
+        fetchRawTransaction.mockResolvedValue(null);
         const { result } = renderHook(() => useFetchRawTransaction(), { wrapper });
 
         result.current('sig', 'confirmed');
 
-        await waitFor(() =>
-            expect(getTransaction).toHaveBeenCalledWith('sig', {
-                commitment: 'confirmed',
-                maxSupportedTransactionVersion: 0,
-            }),
-        );
+        await waitFor(() => expect(fetchRawTransaction).toHaveBeenCalledWith(MOCK_URL, 'sig', 'confirmed'));
     });
 
     it('should pass undefined commitment by default (unchanged behavior for existing callers)', async () => {
-        getTransaction.mockResolvedValue(null);
+        fetchRawTransaction.mockResolvedValue(null);
+        const { result } = renderHook(() => useFetchRawTransaction(), { wrapper });
+
+        result.current('sig');
+
+        await waitFor(() => expect(fetchRawTransaction).toHaveBeenCalledWith(MOCK_URL, 'sig', undefined));
+    });
+
+    it('should dispatch the fetched transaction', async () => {
+        const raw = { messageBytes: new Uint8Array([1, 2, 3]), signatures: ['sig'], version: 1 };
+        fetchRawTransaction.mockResolvedValue(raw);
         const { result } = renderHook(() => useFetchRawTransaction(), { wrapper });
 
         result.current('sig');
 
         await waitFor(() =>
-            expect(getTransaction).toHaveBeenCalledWith('sig', {
-                commitment: undefined,
-                maxSupportedTransactionVersion: 0,
+            expect(dispatch).toHaveBeenCalledWith({
+                data: { raw },
+                key: 'sig',
+                status: FetchStatus.Fetched,
+                type: ActionType.Update,
+                url: MOCK_URL,
             }),
         );
     });
 
     it('should not log to Sentry on a custom cluster, but still dispatch FetchFailed', async () => {
         mockCluster = Cluster.Custom;
-        getTransaction.mockRejectedValue(new Error('rpc boom'));
+        fetchRawTransaction.mockRejectedValue(new Error('rpc boom'));
         const { result } = renderHook(() => useFetchRawTransaction(), { wrapper });
 
         result.current('sig', 'confirmed');

--- a/app/providers/transactions/parsed.tsx
+++ b/app/providers/transactions/parsed.tsx
@@ -1,16 +1,17 @@
 'use client';
 
+import { fetchTransactionDetails, type TransactionWithMeta } from '@entities/transaction-data';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import { Connection, ParsedTransactionWithMeta, TransactionSignature } from '@solana/web3.js';
+import { TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
 export interface Details {
-    transactionWithMeta?: ParsedTransactionWithMeta | null;
+    transactionWithMeta?: TransactionWithMeta | null;
 }
 
 type State = Cache.State<Details>;
@@ -46,10 +47,7 @@ async function fetchDetails(dispatch: Dispatch, signature: TransactionSignature,
     let fetchStatus;
     let transactionWithMeta;
     try {
-        transactionWithMeta = await new Connection(url).getParsedTransaction(signature, {
-            commitment: 'confirmed',
-            maxSupportedTransactionVersion: 0,
-        });
+        transactionWithMeta = await fetchTransactionDetails(url, signature);
         fetchStatus = FetchStatus.Fetched;
     } catch (error) {
         if (cluster !== Cluster.Custom) {

--- a/app/providers/transactions/raw.tsx
+++ b/app/providers/transactions/raw.tsx
@@ -1,33 +1,17 @@
 'use client';
 
+import { fetchRawTransaction, type RawTransaction } from '@entities/transaction-data';
 import * as Cache from '@providers/cache';
 import { ActionType, FetchStatus } from '@providers/cache';
 import { useCluster } from '@providers/cluster';
-import {
-    type CompiledInnerInstruction,
-    Connection,
-    type DecompileArgs,
-    type Finality,
-    TransactionMessage,
-    type TransactionSignature,
-    type VersionedMessage,
-} from '@solana/web3.js';
+import { type Finality, type TransactionSignature } from '@solana/web3.js';
 import { Cluster } from '@utils/cluster';
 import React from 'react';
 
 import { Logger } from '@/app/shared/lib/logger';
 
 export interface Details {
-    raw?: {
-        message: VersionedMessage;
-        meta?: {
-            innerInstructions?: CompiledInnerInstruction[];
-            postBalances: number[];
-            preBalances: number[];
-        };
-        signatures: string[];
-        transaction: TransactionMessage;
-    } | null;
+    raw?: RawTransaction | null;
 }
 
 type State = Cache.State<Details>;
@@ -62,7 +46,7 @@ export function useRawTransactionDetails(signature: TransactionSignature): Cache
     return context.entries[signature];
 }
 
-async function fetchRawTransaction(
+async function loadRawTransaction(
     dispatch: Dispatch,
     signature: TransactionSignature,
     cluster: Cluster,
@@ -78,35 +62,11 @@ async function fetchRawTransaction(
 
     let fetchStatus;
     try {
-        const response = await new Connection(url).getTransaction(signature, {
-            commitment,
-            maxSupportedTransactionVersion: 0,
-        });
+        const raw = await fetchRawTransaction(url, signature, commitment);
         fetchStatus = FetchStatus.Fetched;
 
-        let data: Details = { raw: null };
-        if (response !== null) {
-            const { message, signatures } = response.transaction;
-            const accountKeysFromLookups = response.meta?.loadedAddresses;
-            const decompileArgs: DecompileArgs | undefined = accountKeysFromLookups && { accountKeysFromLookups };
-            data = {
-                raw: {
-                    message,
-                    meta: response.meta
-                        ? {
-                              innerInstructions: response.meta.innerInstructions ?? undefined,
-                              postBalances: response.meta.postBalances,
-                              preBalances: response.meta.preBalances,
-                          }
-                        : undefined,
-                    signatures,
-                    transaction: TransactionMessage.decompile(message, decompileArgs),
-                },
-            };
-        }
-
         dispatch({
-            data,
+            data: { raw },
             key: signature,
             status: fetchStatus,
             type: ActionType.Update,
@@ -134,7 +94,7 @@ export function useFetchRawTransaction() {
     const { cluster, url } = useCluster();
     return React.useCallback(
         (signature: TransactionSignature, commitment?: Finality) => {
-            url && fetchRawTransaction(dispatch, signature, cluster, url, commitment);
+            url && loadRawTransaction(dispatch, signature, cluster, url, commitment);
         },
         [dispatch, cluster, url],
     );

--- a/openspec/changes/read-v1-transactions-with-kit/proposal.md
+++ b/openspec/changes/read-v1-transactions-with-kit/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Read transaction details with kit so v1 renders
+
+## Context
+
+Agave 4.2 accepts version 1 transactions (SIMD-0385), so they land on chain today. v1 differs from v0 in ways the Explorer's rendering path had no answer for:
+
+- Resource limits — compute unit limit, heap size, loaded accounts data size limit, priority fee — move out of Compute Budget instructions and into a message-level config. The priority fee becomes a **total in lamports**, not a per-compute-unit price in micro-lamports.
+- The wire envelope reorders: message bytes first, then a fixed-count signature array with no length prefix.
+- There is no address lookup table support.
+
+Before this change the transaction detail page fetched through web3.js `Connection` with `maxSupportedTransactionVersion: 0`, so a v1 transaction did not render at all.
+
+Raising that ceiling to `1` does not work. web3.js 1.98.4 validates the RPC response with `TransactionVersionStruct = union([literal(0), literal('legacy')])` (`node_modules/@solana/web3.js/lib/index.cjs.js:5596`), and that struct backs `GetTransactionRpcResult`, `GetParsedTransactionRpcResult` and `GetBlockRpcResult` alike. Ask for v1 and superstruct **throws** on the first v1 transaction the RPC returns — a strictly worse failure than the one we started with. web3.js cannot represent a v1 message either: `VersionedMessage.deserialize` asserts `version === 0`.
+
+The `solana` CLI cannot inspect v1 today — `solana confirm -v` sends no `maxSupportedTransactionVersion` and has no flag for it — which makes Explorer the primary inspection tool for v1 until the CLI catches up.
+
+## Why
+
+Reading v1 requires a client that understands it, and `@solana/kit` (already a dependency at 6.5.0) does: it decodes v1 wire bytes, exposes the config mask, and `decompileTransactionMessage` yields the typed limits. AGENTS.md already prefers kit for new functionality.
+
+The open question was not *whether* to use kit but **how far to propagate it**. Roughly twenty components downstream of the transaction providers are written against web3.js types (`ParsedTransactionWithMeta`, `PublicKey`, `VersionedMessage`).
+
+Alternatives considered:
+
+- **Migrate the detail page's consumers to kit types.** Rejected for this change: a large diff across components that have nothing to do with v1, and every one of them a regression risk for legacy and v0 rendering, which is the overwhelming majority of traffic. It remains the right long-term direction.
+- **Adapt kit's response into the web3.js shape at the provider boundary — picked.** One adapter, ~150 lines, fully covered by unit tests. Consumers keep compiling. The only type that had to widen is the transaction version, which web3.js caps at v0.
+- **Keep web3.js and hand-roll a v1 decoder.** Rejected: re-implements what kit already ships and tests.
+- **Upgrade kit to 7.x for `decodeTransactionFromRpcResponse`.** Rejected as unnecessary: 6.5.0's `getCompiledTransactionMessageDecoder` + `decompileTransactionMessage` do the same job, and a major bump is its own risk with its own change.
+
+A second decision: **where the v1 config comes from.** The RPC serves it under `message.transactionConfig`, but kit's RPC types do not model that field (not in 6.5.0, not in 7.0.0), so reading it there would mean a hand-written validator against an untyped field. Decoding the base64 wire bytes instead goes through kit's typed decoder and needs no validator of our own. It costs a second round trip, paid only by v1.
+
+A third: **the Inspect page is gated, not adapted.** Its cards are built on `VersionedMessage`/`MessageV0` throughout. Synthesizing a `MessageV0` from a v1 message would make them render, but `serialize()` would then emit v0 bytes — so the Download button would hand the user a transaction that is not the one on chain. An explicit "not yet supported" card is honest; wrong bytes are not.
+
+## What Changes
+
+- **New entity layer** under `app/entities/transaction-data/`: kit-backed `fetchTransactionDetails` and `fetchRawTransaction`, an `adaptParsedTransaction` boundary, and `decodeWireTransaction` / `decodeTransactionConfig` for the v1 limits. `MAX_SUPPORTED_TRANSACTION_VERSION = 1` is defined once and used by both fetchers.
+- **Providers** `app/providers/transactions/{parsed,raw}.tsx` drop `Connection` for those fetchers. `Details.raw` gains `messageBytes` (the exact wire bytes) and `version`; its `message` and `transaction` become optional, populated for legacy and v0 only.
+- **Download** reads `messageBytes` rather than re-serializing a parsed message, so it is byte-exact on every version.
+- **Summary card** renders the v1 limits, labels the priority fee `Priority fee (total)` to distinguish it from v0's per-compute-unit price, sources the compute unit limit from the config on v1 (the Compute Budget scan it used before finds nothing there), and shows versions as `legacy` / `v0` / `v1`.
+- **Version type widened** to `'legacy' | 0 | 1` in `TransactionWithMeta`. Functions that never read the version — the receipt model, CU profiling, `collectTransferInstructions` — widen to match; web3.js's narrower type stays assignable, so the server-side receipt path is unaffected.
+
+## Impact
+
+- **Behaviour change on existing transactions:** the version row now reads `v0` where it previously read `0`. Deliberate, so `v1` does not sit next to a bare `0`.
+- **Out of scope, still on `maxSupportedTransactionVersion: 0`:** the block page (`app/providers/block.tsx`), address history (`app/features/transaction-history/`), and the server-side receipt fetch (`app/features/receipt/api/get-tx.ts`). They omit v1 entries rather than erroring; each needs the same web3.js→kit move and is worth its own change.
+- **Accepted risk:** v1 costs one extra RPC round trip for the config. Legacy and v0 are unchanged at one call.
+- **Nodes that predate v1** compare the requested ceiling against the versions they actually hold, so sending `1` to them is inert. Submitting v1 wire bytes to an Agave 3.x node is a different path (`app/features/idl/interactive-idl/`) and is untouched here.

--- a/openspec/changes/read-v1-transactions-with-kit/proposal.md
+++ b/openspec/changes/read-v1-transactions-with-kit/proposal.md
@@ -33,7 +33,7 @@ A third: **the Inspect page is gated, not adapted.** Its cards are built on `Ver
 
 ## What Changes
 
-- **New entity layer** under `app/entities/transaction-data/`: kit-backed `fetchTransactionDetails` and `fetchRawTransaction`, an `adaptParsedTransaction` boundary, and `decodeWireTransaction` / `decodeTransactionConfig` for the v1 limits. `MAX_SUPPORTED_TRANSACTION_VERSION = 1` is defined once and used by both fetchers.
+- **New entity layer** under `app/entities/transaction-data/`: kit-backed `fetchTransactionDetails` and `fetchRawTransaction`, an `adaptParsedTransaction` boundary, and `decodeWireTransaction` / `decodeTransactionConfig` for the v1 limits. Both fetchers request kit's own `MAX_SUPPORTED_TRANSACTION_VERSION` ceiling.
 - **Providers** `app/providers/transactions/{parsed,raw}.tsx` drop `Connection` for those fetchers. `Details.raw` gains `messageBytes` (the exact wire bytes), `version` and the decoded v1 `transactionConfig`; it is a union on `version`, so `message` and `transaction` are present for legacy and v0 and absent on v1.
 - **Download** reads `messageBytes` rather than re-serializing a parsed message, so it is byte-exact on every version.
 - **Summary card** renders the v1 limits, labels the priority fee `Priority fee (total)` to distinguish it from v0's per-compute-unit price, sources the compute unit limit from the config on v1 (the Compute Budget scan it used before finds nothing there), and shows versions as `legacy` / `v0` / `v1`.

--- a/openspec/changes/read-v1-transactions-with-kit/proposal.md
+++ b/openspec/changes/read-v1-transactions-with-kit/proposal.md
@@ -27,21 +27,21 @@ Alternatives considered:
 - **Keep web3.js and hand-roll a v1 decoder.** Rejected: re-implements what kit already ships and tests.
 - **Upgrade kit to 7.x for `decodeTransactionFromRpcResponse`.** Rejected as unnecessary: 6.5.0's `getCompiledTransactionMessageDecoder` + `decompileTransactionMessage` do the same job, and a major bump is its own risk with its own change.
 
-A second decision: **where the v1 config comes from.** The RPC serves it under `message.transactionConfig`, but kit's RPC types do not model that field (not in 6.5.0, not in 7.0.0), so reading it there would mean a hand-written validator against an untyped field. Decoding the base64 wire bytes instead goes through kit's typed decoder and needs no validator of our own. It costs a second round trip, paid only by v1.
+A second decision: **where the v1 config comes from.** The RPC serves it under `message.transactionConfig`, but kit's RPC types do not model that field (not in 6.5.0, not in 7.0.0), so reading it there would mean a hand-written validator against an untyped field. Decoding the base64 wire bytes instead goes through kit's typed decoder and needs no validator of our own — and those bytes are already fetched for the download action and the inspector, so the config rides along on that response rather than costing a request of its own.
 
 A third: **the Inspect page is gated, not adapted.** Its cards are built on `VersionedMessage`/`MessageV0` throughout. Synthesizing a `MessageV0` from a v1 message would make them render, but `serialize()` would then emit v0 bytes — so the Download button would hand the user a transaction that is not the one on chain. An explicit "not yet supported" card is honest; wrong bytes are not.
 
 ## What Changes
 
 - **New entity layer** under `app/entities/transaction-data/`: kit-backed `fetchTransactionDetails` and `fetchRawTransaction`, an `adaptParsedTransaction` boundary, and `decodeWireTransaction` / `decodeTransactionConfig` for the v1 limits. `MAX_SUPPORTED_TRANSACTION_VERSION = 1` is defined once and used by both fetchers.
-- **Providers** `app/providers/transactions/{parsed,raw}.tsx` drop `Connection` for those fetchers. `Details.raw` gains `messageBytes` (the exact wire bytes) and `version`; its `message` and `transaction` become optional, populated for legacy and v0 only.
+- **Providers** `app/providers/transactions/{parsed,raw}.tsx` drop `Connection` for those fetchers. `Details.raw` gains `messageBytes` (the exact wire bytes), `version` and the decoded v1 `transactionConfig`; it is a union on `version`, so `message` and `transaction` are present for legacy and v0 and absent on v1.
 - **Download** reads `messageBytes` rather than re-serializing a parsed message, so it is byte-exact on every version.
 - **Summary card** renders the v1 limits, labels the priority fee `Priority fee (total)` to distinguish it from v0's per-compute-unit price, sources the compute unit limit from the config on v1 (the Compute Budget scan it used before finds nothing there), and shows versions as `legacy` / `v0` / `v1`.
-- **Version type widened** to `'legacy' | 0 | 1` in `TransactionWithMeta`. Functions that never read the version — the receipt model, CU profiling, `collectTransferInstructions` — widen to match; web3.js's narrower type stays assignable, so the server-side receipt path is unaffected.
+- **Version type widened** in `TransactionWithMeta` to kit's `TransactionVersion` (`'legacy' | 0 | 1`); web3.js's own version type caps at v0. Functions that never read the version — the receipt model, CU profiling, `collectTransferInstructions` — widen to match; web3.js's narrower type stays assignable, so the server-side receipt path is unaffected.
 
 ## Impact
 
 - **Behaviour change on existing transactions:** the version row now reads `v0` where it previously read `0`. Deliberate, so `v1` does not sit next to a bare `0`.
 - **Out of scope, still on `maxSupportedTransactionVersion: 0`:** the block page (`app/providers/block.tsx`), address history (`app/features/transaction-history/`), and the server-side receipt fetch (`app/features/receipt/api/get-tx.ts`). They omit v1 entries rather than erroring; each needs the same web3.js→kit move and is worth its own change.
-- **Accepted risk:** v1 costs one extra RPC round trip for the config. Legacy and v0 are unchanged at one call.
+- **No extra requests:** the detail page issues the same two calls it did before — one parsed, one raw — on every version.
 - **Nodes that predate v1** compare the requested ceiling against the versions they actually hold, so sending `1` to them is inert. Submitting v1 wire bytes to an Agave 3.x node is a different path (`app/features/idl/interactive-idl/`) and is untouched here.

--- a/openspec/changes/read-v1-transactions-with-kit/specs/transaction-details/spec.md
+++ b/openspec/changes/read-v1-transactions-with-kit/specs/transaction-details/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Transaction details SHALL be fetched with kit at transaction version 1
+
+The transaction detail page SHALL request `getTransaction` through `@solana/kit` with `maxSupportedTransactionVersion: 1`, and SHALL NOT use web3.js `Connection` for that fetch. web3.js validates the response version against a `'legacy' | 0` superstruct union, so it throws on a v1 response rather than rendering it, and its `VersionedMessage` cannot represent a v1 message at all.
+
+The kit response SHALL be adapted into the web3.js-shaped `ParsedTransactionWithMeta` the page's components already consume, with the version widened to `'legacy' | 0 | 1`. Numeric fields the RPC serves as `bigint` — slot, block time, fee, balances, compute units consumed — SHALL be narrowed to `number`, and `costUnits` SHALL be preserved even though kit does not declare it.
+
+#### Scenario: v1 transaction on a cluster that has them
+
+- **WHEN** the detail page loads a transaction whose version is 1
+- **THEN** the page SHALL render it fully rather than erroring or reporting it as not found
+
+#### Scenario: Legacy and v0 transactions
+
+- **WHEN** the detail page loads a legacy or v0 transaction
+- **THEN** it SHALL render exactly as before, including the fee, transaction cost, compute units, and token balance rows
+
+#### Scenario: Cluster that predates v1
+
+- **WHEN** the RPC node holds no v1 transactions
+- **THEN** requesting a ceiling of 1 SHALL be inert, because the node compares that ceiling only against the versions it actually holds
+
+### Requirement: v1 resource limits SHALL be decoded from the wire bytes and rendered distinctly
+
+v1 carries its compute unit limit, heap size, loaded accounts data size limit and total priority fee in a message-level config rather than in Compute Budget instructions. The RPC's `jsonParsed` encoding does not surface that config, so it SHALL be recovered by decoding the `base64` wire bytes with kit's compiled-message decoder. This second request SHALL be issued only for v1.
+
+The priority fee SHALL be labelled as a total amount so it is not read as v0's per-compute-unit price in micro-lamports. The compute unit limit shown for a v1 transaction SHALL come from the config rather than from a scan of Compute Budget instructions, which v1 does not carry.
+
+#### Scenario: v1 transaction that sets resource limits
+
+- **WHEN** a v1 message sets any of the four limits
+- **THEN** the summary card SHALL render each limit that is present
+- **AND** the priority fee SHALL be presented as a total in lamports, distinct from the per-compute-unit price
+
+#### Scenario: v1 transaction that sets no resource limits
+
+- **WHEN** a v1 message sets none of the four limits
+- **THEN** no resource limit rows SHALL be rendered
+
+#### Scenario: Non-v1 transaction
+
+- **WHEN** the transaction is legacy or v0
+- **THEN** no second request SHALL be issued and the compute unit limit SHALL continue to be derived from its Compute Budget instructions
+
+### Requirement: Raw transaction bytes SHALL be retained verbatim, and the inspector SHALL refuse versions it cannot render
+
+The raw transaction provider SHALL retain the message bytes exactly as served by the RPC, and the download action SHALL write those bytes rather than re-serializing a parsed message. This keeps the download byte-identical to the transaction on chain for every version.
+
+The web3.js `VersionedMessage` and decompiled `TransactionMessage` views SHALL be populated for legacy and v0 only. The inspector SHALL report that a version is unsupported rather than render a substitute message shape, because a substitute would serialize to bytes that differ from the transaction on chain.
+
+#### Scenario: Downloading a v1 transaction
+
+- **WHEN** a user downloads a v1 transaction from the summary card
+- **THEN** the written bytes SHALL equal the message bytes the RPC served
+
+#### Scenario: Inspecting a v1 transaction
+
+- **WHEN** a user opens the inspector for a v1 transaction
+- **THEN** the inspector SHALL state that it does not yet support that version, rather than render accounts and instructions from a substituted message

--- a/openspec/changes/read-v1-transactions-with-kit/specs/transaction-details/spec.md
+++ b/openspec/changes/read-v1-transactions-with-kit/specs/transaction-details/spec.md
@@ -23,7 +23,7 @@ The kit response SHALL be adapted into the web3.js-shaped `ParsedTransactionWith
 
 ### Requirement: v1 resource limits SHALL be decoded from the wire bytes and rendered distinctly
 
-v1 carries its compute unit limit, heap size, loaded accounts data size limit and total priority fee in a message-level config rather than in Compute Budget instructions. The RPC's `jsonParsed` encoding does not surface that config, so it SHALL be recovered by decoding the `base64` wire bytes with kit's compiled-message decoder. This second request SHALL be issued only for v1.
+v1 carries its compute unit limit, heap size, loaded accounts data size limit and total priority fee in a message-level config rather than in Compute Budget instructions. The RPC's `jsonParsed` encoding does not surface that config, so it SHALL be recovered by decoding the `base64` wire bytes with kit's compiled-message decoder. Those bytes are the ones the raw transaction fetch already retrieves for the download action and the inspector, so reading the config SHALL NOT cost an additional request.
 
 The priority fee SHALL be labelled as a total amount so it is not read as v0's per-compute-unit price in micro-lamports. The compute unit limit shown for a v1 transaction SHALL come from the config rather than from a scan of Compute Budget instructions, which v1 does not carry.
 
@@ -41,7 +41,7 @@ The priority fee SHALL be labelled as a total amount so it is not read as v0's p
 #### Scenario: Non-v1 transaction
 
 - **WHEN** the transaction is legacy or v0
-- **THEN** no second request SHALL be issued and the compute unit limit SHALL continue to be derived from its Compute Budget instructions
+- **THEN** no config SHALL be reported and the compute unit limit SHALL continue to be derived from its Compute Budget instructions
 
 ### Requirement: Raw transaction bytes SHALL be retained verbatim, and the inspector SHALL refuse versions it cannot render
 


### PR DESCRIPTION
Agave 4.2 Local Validator accepts [v1 transactions (SIMD-0385)](https://solana.com/upgrades/larger-transaction-sizes) so they can be tested today. The detail page fetched through web3.js `Connection` with `maxSupportedTransactionVersion: 0`, so a v1 transaction did not render at all — and raising that ceiling is not an option, because web3.js validates the response against `union([literal(0), literal('legacy')])` and throws on the first v1 the RPC returns.

This moves the transaction detail and raw fetch paths to `@solana/kit` (already a dependency at 6.5.0), which decodes v1 and exposes the message-level config.

## Approach

kit stops at the provider boundary. Roughly twenty components downstream are written against web3.js types, so rather than migrate them all, `adaptParsedTransaction` converts kit's response into the web3.js shape and consumers keep compiling. Migrating those consumers is the right long-term direction, but not as part of a v1 change.

The v1 resource limits come from decoding the base64 wire bytes, not from `message.transactionConfig` — kit's RPC types do not model that field, so reading it there would need a hand-written validator. Decoding goes through kit's typed decoder instead. It costs a second round trip, paid only by v1.

## Changes

- New `app/entities/transaction-data/` entity: `fetchTransactionDetails`, `fetchRawTransaction`, the `adaptParsedTransaction` boundary, and `decodeWireTransaction` / `decodeTransactionConfig`.
- Providers drop `Connection`. `Details.raw` gains `messageBytes` and `version`; `message` and `transaction` become optional, populated for legacy and v0 only.
- Download reads `messageBytes` rather than re-serializing, so it is byte-exact on every version.
- Summary card renders the v1 limits, labels the priority fee `Priority fee (total)` to distinguish it from v0's per-CU price, and shows versions as `legacy` / `v0` / `v1`.
- The Inspect page is gated with an explicit "not supported" card rather than adapted — its cards are built on `MessageV0`, and synthesizing one would make Download emit bytes that are not the transaction on chain.

## Notes for review

- `version` is absent from kit's `getTransaction` integer allow-list, so it arrives as a bigint while `GetTransactionApi` types it as a number. Every `version === 1` check is silently false. Converted in the adapter and tracked upstream in DEV-858.
- The version row now reads `v0` where it previously read `0`, so `v1` does not sit next to a bare `0`.
- Still on `maxSupportedTransactionVersion: 0`: the block page, address history, and the server-side receipt fetch. They omit v1 entries rather than erroring; each needs the same move and is worth its own change.

## Testing

`pnpm lint` and `pnpm typecheck` clean. 19 new unit tests covering the adapter and the config decoder. The 46 failing specs on this branch fail identically on `master` (localStorage and cluster-param suites) and are unrelated.

Here's a script for running v1 txns using Kit: https://gist.github.com/amilz/832fb14baf7dc2bdc5ec2f42d7c3f280

Closes DEV-856