### PR TITLE
Add YeetAMM program name

### DIFF
--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -142,7 +142,7 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.RAYDIUM_AMM,
     },
-    'yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp': {
+    yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp: {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.YEET_AMM,
     },

--- a/app/utils/programs.ts
+++ b/app/utils/programs.ts
@@ -71,6 +71,7 @@ export enum PROGRAM_NAMES {
     WORMHOLE_CORE = 'Wormhole Core Bridge',
     WORMHOLE_TOKEN = 'Wormhole Token Bridge',
     WORMHOLE_NFT = 'Wormhole NFT Bridge',
+    YEET_AMM = 'YeetAMM Program',
 
     // ZK Compression
     ZK_LIGHT_SYSTEM_PROGRAM = 'Light System Program',
@@ -140,6 +141,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
     '675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8': {
         deployments: [Cluster.MainnetBeta],
         name: PROGRAM_NAMES.RAYDIUM_AMM,
+    },
+    'yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp': {
+        deployments: [Cluster.MainnetBeta],
+        name: PROGRAM_NAMES.YEET_AMM,
     },
     '8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz': {
         deployments: [Cluster.Testnet],


### PR DESCRIPTION
## Description

Adds the program name for **YeetAMM**, the AMM behind the [YeetLaunch](https://yeetlaunch.io) launchpad, live on Solana mainnet-beta:

```
yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp
```

Every pool, swap and graduation on YeetLaunch runs through this one program, so it currently renders as a bare program ID on transaction and account pages for anyone trading or launching there.

One detail that may be useful context when reading its transactions: the bonding curve and the AMM are the same program and the same pool account. A token converts from curve mode to AMM mode in place, inside the transaction that crosses its graduation threshold, rather than migrating liquidity to a separate protocol. So a single swap instruction can also be the moment the pool changes mode — there is no separate migration transaction to look for.

The program address is published by the project at [yeetlaunch.io/dev](https://yeetlaunch.io/dev), alongside its config and authority accounts, and in Appendix D of the [whitepaper](https://yeetlaunch.io/YeetLaunch_Whitepaper_v1.5.pdf). A security contact is published at [/.well-known/security.txt](https://yeetlaunch.io/.well-known/security.txt) per RFC 9116 and as an on-chain `security.txt` record inside the program itself. The program upgrade authority is a 2-of-3 Squads multisig (`BUQUKDJjsraVRsvE48cZaZabj1cexxegWeD4qnQ4Kb6K`), readable on-chain.

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): **Program name registry entry.** Data only — two additions to `app/utils/programs.ts`. No decoder, no new screens, no protocol-specific UI.

## Screenshots

Not applicable — this PR adds no UI. The only visible effect is that the existing program label renders `YeetAMM Program` instead of the raw base58 address, using the same component every other entry in `PROGRAM_NAMES` uses.

Happy to add a before/after screenshot if you would like one for the record.

## Testing

The change is two static entries in an existing registry, matching the surrounding style: a `PROGRAM_NAMES` enum member placed with the other third-party programs, and a mapping entry with `deployments: [Cluster.MainnetBeta]` in the same shape as its neighbours.

The address itself was verified against mainnet-beta rather than copied from documentation: the program account is executable and live, its config account resolves, and its upgrade authority reads as the multisig vault quoted above.

**Formatting was verified** against the repo's own Prettier config (`prettier@3.5.3` with `@solana/prettier-config-solana`): the unmodified upstream file passes, and this branch now passes too. That check caught one real issue — `quoteProps: "as-needed"` strips quotes from object keys that are valid identifiers, and unlike every neighbouring address this one begins with a letter, so the quotes I had copied from adjacent entries were wrong. Fixed in the second commit.

**The full test suite and ESLint were not run locally** — see the checklist note below. I have deliberately not ticked that box.

## Related Issues

None.

## Checklist

-   [x] My code follows the project's style guidelines — 4-space indentation, enum entry placed alphabetically within the existing third-party block, mapping entry identical in shape to adjacent entries
-   [ ] I have added tests that prove my fix/feature works — no tests added; registry entries in this file do not appear to carry per-entry tests. Happy to add one if that is the expectation for new program names.
-   [ ] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`) — **partial.** Prettier was run against the repo's config and this branch passes; `pnpm test`, `eslint` and `typecheck` were not run, as this was authored without a full local checkout. Not ticking a box I can only half satisfy. Relying on CI for the rest and happy to fix anything it flags.
-   [ ] I have updated documentation as needed — not applicable
-   [ ] I have run `build:info` script to update build information — not applicable to a data-only change; say the word if you would like it run
-   [ ] CI/CD checks pass on the PR — will confirm once CI has run
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes — none included, as this PR adds no UI. The only visible effect is the existing program-label component rendering a name instead of a raw address. Glad to add a before/after if you would like one.
-   [x] For security-related features, I have included links to related information — `security.txt` (RFC 9116 and on-chain), published address list, and the multisig upgrade authority are all linked above
