### PR TITLE
feat: domains mobile layout

### DIFF
--- a/.storybook/breakpoint-toolbar.tsx
+++ b/.storybook/breakpoint-toolbar.tsx
@@ -1,22 +1,14 @@
 // Registers a Tailwind breakpoint quick-select toolbar in the Storybook manager.
 // Uses React.createElement (no JSX) so this file is safe to import from both the
 // production Storybook manager and the design-sb manager, which has no JSX transform.
-// Viewport keys must match the `viewport.options` keys in preview.tsx.
+// BREAKPOINTS are generated from tailwind.config in ./breakpoints (keys match viewport.options there).
 import React, { useCallback } from 'react';
 import { addons, types, useGlobals } from 'storybook/manager-api';
 
+import { BREAKPOINTS } from './breakpoints';
+
 const ADDON_ID = 'explorer/breakpoint-toolbar';
 const TOOL_ID = `${ADDON_ID}/tool`;
-
-// Must match the bsXxx keys in preview.tsx viewport.options
-export const BREAKPOINTS = [
-    { key: 'bsXs', label: 'xs·375' },
-    { key: 'bsSm', label: 'sm·576' },
-    { key: 'bsMd', label: 'md·768' },
-    { key: 'bsLg', label: 'lg·992' },
-    { key: 'bsXl', label: 'xl·1200' },
-    { key: 'bsXxl', label: 'xxl·1400' },
-] as const;
 
 function BreakpointTool() {
     const [globals, updateGlobals] = useGlobals();

--- a/.storybook/breakpoints.ts
+++ b/.storybook/breakpoints.ts
@@ -1,0 +1,43 @@
+// Generates the breakpoint viewport badges from the single source of truth — the `breakpoints`
+// Map in tailwind.config.ts. Widths come straight from there; the +1 mirrors getScreenDim (Tailwind
+// screens are min-width = base + 1), so each badge lands on the breakpoint's activation point.
+//
+// tailwind.config's runtime deps (tailwindcss/plugin, tailwindcss-animate) are pure browser-safe
+// functions, so importing it here is safe for the Storybook manager bundle too. height/type are
+// storybook-only preview presentation and stay local — they are not breakpoint values.
+import { breakpoints } from '../tailwind.config';
+
+type ViewportType = 'desktop' | 'mobile' | 'tablet';
+
+const META: Record<string, { height: number; type: ViewportType }> = {
+    lg: { height: 768, type: 'desktop' },
+    md: { height: 1024, type: 'tablet' },
+    sm: { height: 812, type: 'mobile' },
+    xl: { height: 900, type: 'desktop' },
+    xs: { height: 667, type: 'mobile' },
+    xxl: { height: 900, type: 'desktop' },
+    xxs: { height: 568, type: 'mobile' },
+};
+
+const viewportKey = (name: string) => `bs${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+
+// [name, base] ascending so the toolbar and viewport dropdown read smallest → largest.
+const entries = [...breakpoints.entries()].sort(([, a], [, b]) => a - b);
+
+/** Toolbar quick-select chips (manager). `key` matches a BREAKPOINT_VIEWPORTS entry. */
+export const BREAKPOINTS = entries.map(([name, base]) => ({ key: viewportKey(name), label: `${name}·${base + 1}` }));
+
+/** Preview viewport badges. Spread into parameters.viewport.options alongside INITIAL_VIEWPORTS. */
+export const BREAKPOINT_VIEWPORTS: Record<
+    string,
+    { name: string; styles: { height: string; width: string }; type: ViewportType }
+> = Object.fromEntries(
+    entries.map(([name, base]) => {
+        const width = base + 1;
+        const { height, type } = META[name] ?? { height: 900, type: 'desktop' };
+        return [
+            viewportKey(name),
+            { name: `${name}·${width}`, styles: { height: `${height}px`, width: `${width}px` }, type },
+        ];
+    }),
+);

--- a/.storybook/create-preview.tsx
+++ b/.storybook/create-preview.tsx
@@ -4,6 +4,7 @@ import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 
 import { rubikFont } from '@/app/styles';
 
+import { BREAKPOINT_VIEWPORTS } from './breakpoints';
 import type { Preview } from './types';
 
 // Storybook serialises story args with JSON.stringify (for the controls panel and inter-frame
@@ -86,18 +87,12 @@ export function createPreview({ mswEnabled }: { mswEnabled: boolean }): Preview 
                     return 0;
                 },
             },
-            // Bootstrap 5 breakpoint presets — consumed by the breakpoint toolbar.
-            // Keys (bsXs … bsXxl) must match the BREAKPOINTS array in .storybook/breakpoint-toolbar.tsx.
+            // Breakpoint presets generated from tailwind.config `breakpoints` (see ./breakpoints).
             // INITIAL_VIEWPORTS spread included so responsive stories (iphonex, ipad …) resize correctly in story view.
             // NOTE: Storybook 10 reads `options`, not `viewports` — using the wrong key silently falls back to MINIMAL_VIEWPORTS.
             viewport: {
                 options: {
-                    bsLg: { name: 'lg·992', styles: { height: '768px', width: '992px' }, type: 'desktop' },
-                    bsMd: { name: 'md·768', styles: { height: '1024px', width: '768px' }, type: 'tablet' },
-                    bsSm: { name: 'sm·576', styles: { height: '812px', width: '576px' }, type: 'mobile' },
-                    bsXl: { name: 'xl·1200', styles: { height: '900px', width: '1200px' }, type: 'desktop' },
-                    bsXs: { name: 'xs·375', styles: { height: '667px', width: '375px' }, type: 'mobile' },
-                    bsXxl: { name: 'xxl·1400', styles: { height: '900px', width: '1400px' }, type: 'desktop' },
+                    ...BREAKPOINT_VIEWPORTS,
                     ...INITIAL_VIEWPORTS,
                 },
             },

--- a/app/components/shared/ui/collapsible-section.stories.tsx
+++ b/app/components/shared/ui/collapsible-section.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook-config/types';
 import { expect, userEvent, within } from 'storybook/test';
 
-import { CollapsibleSection } from '../CollapsibleSection';
+import { CollapsibleSection } from './collapsible-section';
 
 const meta: Meta<typeof CollapsibleSection> = {
     args: {
@@ -12,7 +12,7 @@ const meta: Meta<typeof CollapsibleSection> = {
     },
     component: CollapsibleSection,
     tags: ['autodocs', 'test'],
-    title: 'Features/Transaction/CollapsibleSection',
+    title: 'Components/Shared/CollapsibleSection',
 };
 
 export default meta;

--- a/app/components/shared/ui/collapsible-section.tsx
+++ b/app/components/shared/ui/collapsible-section.tsx
@@ -1,3 +1,4 @@
+// TODO(fsd): relocate this module to @shared or the appropriate feature/entity layer.
 import { Button } from '@components/shared/ui/button';
 import { cn } from '@components/shared/utils';
 import { ReactNode, useId, useState } from 'react';

--- a/app/entities/domain/ui/BaseDomainsCard.tsx
+++ b/app/entities/domain/ui/BaseDomainsCard.tsx
@@ -2,8 +2,8 @@
 
 import { Address } from '@components/common/Address';
 import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
-import { cn } from '@components/shared/utils';
 import { PublicKey } from '@solana/web3.js';
+import { cva } from 'class-variance-authority';
 import { useMemo } from 'react';
 
 import { Card } from '@/app/shared/ui/Card';
@@ -50,19 +50,37 @@ export function BaseDomainsCard({ domains }: { domains: DomainInfo[] }) {
 // tables: muted uppercase `text-xs` header, `text-sm` body, `outer-space-800` row separators (same tone
 // as the card border), transparent (card-matching) background, 10px/12px padding.
 //
+// `gridCellVariants` owns all cell styling. `role` picks header vs body chrome; `column` picks the
+// per-column body concerns (a `min-width` floor + wrapping on the domain cell, `min-w-0` + no-wrap on
+// the account cell) that used to be threaded in per cell. Header cells leave `column` at its `none`
+// default. `cva` layers the variants over the shared base, so no `cn`/clsx override juggling is needed.
+//
 // Domain column sizing — responsive, no JS. The account column always keeps the rest (`1fr`).
 // - Mobile (xs, sm — below `md`): content-aware within a px band. `fit-content(clamp(200px,50%,400px))`
 //   is the *ceiling* — the column grows with the domain content up to a 50% band (px-clamped 200–400),
-//   then the name wraps (`break-all`). `min-w-[clamp(120px,25%,200px)]` on the body cell is the *floor*,
-//   feeding `fit-content`'s minimum so short names rest at the ~25% band (px-clamped 120–240).
+//   then the name wraps (`break-all`). `min-w-[clamp(120px,25%,240px)]` (the `column: 'domain'` floor)
+//   feeds `fit-content`'s minimum so short names rest at the ~25% band (px-clamped 120–240).
 // - Tablet (md, lg) + desktop (xl, xxl): a fixed 25% band `clamp(120px,25%,240px)` — no content growth;
 //   the name wraps (`break-all`) inside it. Both tiers match, so one `md:` rule covers md→xxl; split it
 //   out (add an `xl:` variant) if desktop ever needs to diverge.
-const GRID_HEADER_CELL = 'flex items-center whitespace-nowrap px-3 py-2.5 text-xs uppercase text-outer-space-300';
-// Shared body-cell styling. `min-width` is set per cell below (a floor on the name, `0` on the account)
-// so it isn't baked in here — `cn` is clsx, so a base `min-w-*` couldn't be overridden per cell.
-const GRID_BODY_CELL = 'flex items-start border-t border-solid border-outer-space-800 px-3 py-2.5';
-const GRID_DOMAIN_FLOOR = 'min-w-[clamp(120px,25%,240px)]';
+const gridCellVariants = cva('flex px-3 py-2.5', {
+    defaultVariants: { column: 'none', role: 'body' },
+    variants: {
+        // Per-column body concerns. `domain` sets the mobile floor (matching the md+ track width) and
+        // wraps the spaceless name via `break-all`; `account` collapses to `min-w-0` and stays on one line.
+        column: {
+            account: 'min-w-0 whitespace-nowrap',
+            domain: 'min-w-[clamp(120px,25%,240px)] break-all',
+            none: '',
+        },
+        // Header vs body chrome. `header`: muted uppercase `text-xs`, centered, no-wrap labels. `body`:
+        // `outer-space-800` top border (same tone as the card border) as the row separator, top-aligned.
+        role: {
+            body: 'items-start border-t border-solid border-outer-space-800',
+            header: 'items-center whitespace-nowrap text-xs uppercase text-outer-space-300',
+        },
+    },
+});
 
 function DomainsGrid({ domains }: { domains: ValidDomain[] }) {
     return (
@@ -78,7 +96,7 @@ function DomainsGrid({ domains }: { domains: ValidDomain[] }) {
             >
                 <div role="row" className="contents">
                     {COLUMNS.map(label => (
-                        <div key={label} role="columnheader" className={GRID_HEADER_CELL}>
+                        <div key={label} role="columnheader" className={gridCellVariants({ role: 'header' })}>
                             {label}
                         </div>
                     ))}
@@ -88,10 +106,10 @@ function DomainsGrid({ domains }: { domains: ValidDomain[] }) {
                         {/* A domain name is a single spaceless token, so `break-all` is what lets it wrap —
                             on mobile once the column hits its `fit-content` ceiling, on md+ inside the fixed
                             25% track. `min-w` sets the mobile floor (and matches the md+ track width). */}
-                        <div role="cell" className={cn(GRID_BODY_CELL, GRID_DOMAIN_FLOOR, 'break-all')}>
+                        <div role="cell" className={gridCellVariants({ column: 'domain' })}>
                             {domain.name}
                         </div>
-                        <div role="cell" className={cn(GRID_BODY_CELL, 'min-w-0 whitespace-nowrap')}>
+                        <div role="cell" className={gridCellVariants({ column: 'account' })}>
                             <Address pubkey={domain.pubkey} link />
                         </div>
                     </div>

--- a/app/entities/domain/ui/BaseDomainsCard.tsx
+++ b/app/entities/domain/ui/BaseDomainsCard.tsx
@@ -1,49 +1,90 @@
 'use client';
 
 import { Address } from '@components/common/Address';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
+import { cn } from '@components/shared/utils';
 import { PublicKey } from '@solana/web3.js';
 import React, { useMemo } from 'react';
 
-import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
-import { BaseTable } from '@/app/shared/ui/Table';
+import { Card } from '@/app/shared/ui/Card';
 
 import { DomainInfo } from '../model/types';
 
+type ValidDomain = DomainInfo & { pubkey: PublicKey };
+
+// Column labels, kept in one place so header copy can't drift from the rows below.
+const COLUMNS = ['Domain', 'Name Service Account'] as const;
+
+// The card is a collapsible section (heading lifted out above the surface + chevron toggle + the
+// `1fr`/`0fr` height animation), provided by the shared `CollapsibleSection`. `className=""` keeps its
+// inner wrapper bare so the surface comes from the `<Card>` below (same pattern the transaction
+// `InstructionsSection` uses).
+//
+// The domain list is a CSS-grid built from `div`s (see `DomainsGrid`), mirroring the transaction
+// page's Accounts/Token Balances tables.
 export function BaseDomainsCard({ domains }: { domains: DomainInfo[] }) {
     const validDomains = useMemo(
         () =>
             domains
                 .map(domain => ({ ...domain, pubkey: tryPublicKey(domain.address) }))
-                .filter((d): d is DomainInfo & { pubkey: PublicKey } => d.pubkey !== null),
+                .filter((d): d is ValidDomain => d.pubkey !== null),
         [domains],
     );
 
     return (
-        <Card ui="dashkit">
-            <CardHeader ui="dashkit">
-                <CardTitle as="h3" ui="dashkit">
-                    Owned Domain Names
-                </CardTitle>
-            </CardHeader>
-            <BaseTable ui="dashkit" variant="card" nowrap>
-                <BaseTable.Head>
-                    <BaseTable.Row>
-                        <BaseTable.HeaderCell className="text-dk-gray-700">Domain Name</BaseTable.HeaderCell>
-                        <BaseTable.HeaderCell className="text-dk-gray-700">Name Service Account</BaseTable.HeaderCell>
-                    </BaseTable.Row>
-                </BaseTable.Head>
-                <BaseTable.Body>
-                    {validDomains.map(domain => (
-                        <BaseTable.Row key={domain.address}>
-                            <BaseTable.Cell>{domain.name}</BaseTable.Cell>
-                            <BaseTable.Cell>
-                                <Address pubkey={domain.pubkey} link />
-                            </BaseTable.Cell>
-                        </BaseTable.Row>
-                    ))}
-                </BaseTable.Body>
-            </BaseTable>
-        </Card>
+        <CollapsibleSection title="Owned Domain Names" className="">
+            {/* Surface matched to the transaction Tokens/Accounts card, in pure Tailwind: bg
+                `outer-space-900` equals `#1e2423` (dashkit `dk-gray-800-dark`); `border-outer-space-800`
+                gives the card the same tone as the row separators; `rounded-lg` is the 8px radius.
+                BaseCard uses `cnPrefixed` (tailwind-merge), so these override the tw variant's defaults. */}
+            <Card variant="tight" className="rounded-lg border-outer-space-800 bg-outer-space-900">
+                <DomainsGrid domains={validDomains} />
+            </Card>
+        </CollapsibleSection>
+    );
+}
+
+// CSS-grid layout — a single 2-column grid so columns stay aligned across header and rows the way a
+// `<table>`'s shared columns do. Pure Tailwind, matching the transaction page's Accounts/Token Balances
+// tables: muted uppercase `text-xs` header, `text-sm` body, `outer-space-800` row separators (same tone
+// as the card border), transparent (card-matching) background, 10px/12px padding.
+//
+// Domain column sizing — responsive, no JS. The account column always keeps the rest (`1fr`).
+// - Mobile (xs, sm — below `md`): content-aware within a px band. `fit-content(clamp(200px,50%,400px))`
+//   is the *ceiling* — the column grows with the domain content up to a 50% band (px-clamped 200–400),
+//   then the name wraps (`break-all`). `min-w-[clamp(120px,25%,200px)]` on the body cell is the *floor*,
+//   feeding `fit-content`'s minimum so short names rest at the ~25% band (px-clamped 120–240).
+// - Tablet (md, lg) + desktop (xl, xxl): a fixed 25% band `clamp(120px,25%,240px)` — no content growth;
+//   the name wraps (`break-all`) inside it. Both tiers match, so one `md:` rule covers md→xxl; split it
+//   out (add an `xl:` variant) if desktop ever needs to diverge.
+const GRID_HEADER_CELL = 'flex items-center whitespace-nowrap px-3 py-2.5 text-xs uppercase text-outer-space-300';
+// Shared body-cell styling. `min-width` is set per cell below (a floor on the name, `0` on the account)
+// so it isn't baked in here — `cn` is clsx, so a base `min-w-*` couldn't be overridden per cell.
+const GRID_BODY_CELL = 'flex items-start border-t border-solid border-outer-space-800 px-3 py-2.5';
+const GRID_DOMAIN_FLOOR = 'min-w-[clamp(120px,25%,240px)]';
+
+function DomainsGrid({ domains }: { domains: ValidDomain[] }) {
+    return (
+        <div className="w-full overflow-x-auto text-sm text-white">
+            <div className="grid min-w-full grid-cols-[fit-content(clamp(200px,50%,400px))_1fr] md:grid-cols-[clamp(120px,25%,240px)_1fr]">
+                {COLUMNS.map(label => (
+                    <div key={label} className={GRID_HEADER_CELL}>
+                        {label}
+                    </div>
+                ))}
+                {domains.map(domain => (
+                    <React.Fragment key={domain.address}>
+                        {/* A domain name is a single spaceless token, so `break-all` is what lets it wrap —
+                            on mobile once the column hits its `fit-content` ceiling, on md+ inside the fixed
+                            25% track. `min-w` sets the mobile floor (and matches the md+ track width). */}
+                        <div className={cn(GRID_BODY_CELL, GRID_DOMAIN_FLOOR, 'break-all')}>{domain.name}</div>
+                        <div className={cn(GRID_BODY_CELL, 'min-w-0 whitespace-nowrap')}>
+                            <Address pubkey={domain.pubkey} link />
+                        </div>
+                    </React.Fragment>
+                ))}
+            </div>
+        </div>
     );
 }
 

--- a/app/entities/domain/ui/BaseDomainsCard.tsx
+++ b/app/entities/domain/ui/BaseDomainsCard.tsx
@@ -4,7 +4,7 @@ import { Address } from '@components/common/Address';
 import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
 import { cn } from '@components/shared/utils';
 import { PublicKey } from '@solana/web3.js';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { Card } from '@/app/shared/ui/Card';
 
@@ -21,7 +21,8 @@ const COLUMNS = ['Domain', 'Name Service Account'] as const;
 // `InstructionsSection` uses).
 //
 // The domain list is a CSS-grid built from `div`s (see `DomainsGrid`), mirroring the transaction
-// page's Accounts/Token Balances tables.
+// page's Accounts/Token Balances tables. ARIA table roles are layered on so it keeps the
+// table/row/columnheader/cell relationships assistive tech got from the old `<table>` markup.
 export function BaseDomainsCard({ domains }: { domains: DomainInfo[] }) {
     const validDomains = useMemo(
         () =>
@@ -66,22 +67,34 @@ const GRID_DOMAIN_FLOOR = 'min-w-[clamp(120px,25%,240px)]';
 function DomainsGrid({ domains }: { domains: ValidDomain[] }) {
     return (
         <div className="w-full overflow-x-auto text-sm text-white">
-            <div className="grid min-w-full grid-cols-[fit-content(clamp(200px,50%,400px))_1fr] md:grid-cols-[clamp(120px,25%,240px)_1fr]">
-                {COLUMNS.map(label => (
-                    <div key={label} className={GRID_HEADER_CELL}>
-                        {label}
-                    </div>
-                ))}
+            {/* `role="table"` + `role="row"` wrappers restore the semantics the old `<table>` gave screen
+                readers. The row wrappers use `contents` (`display: contents`) so they generate no box and
+                their cells stay direct participants in this grid — ARIA structure without disturbing the
+                CSS-grid column alignment. */}
+            <div
+                role="table"
+                aria-label="Owned domain names"
+                className="grid min-w-full grid-cols-[fit-content(clamp(200px,50%,400px))_1fr] md:grid-cols-[clamp(120px,25%,240px)_1fr]"
+            >
+                <div role="row" className="contents">
+                    {COLUMNS.map(label => (
+                        <div key={label} role="columnheader" className={GRID_HEADER_CELL}>
+                            {label}
+                        </div>
+                    ))}
+                </div>
                 {domains.map(domain => (
-                    <React.Fragment key={domain.address}>
+                    <div key={domain.address} role="row" className="contents">
                         {/* A domain name is a single spaceless token, so `break-all` is what lets it wrap —
                             on mobile once the column hits its `fit-content` ceiling, on md+ inside the fixed
                             25% track. `min-w` sets the mobile floor (and matches the md+ track width). */}
-                        <div className={cn(GRID_BODY_CELL, GRID_DOMAIN_FLOOR, 'break-all')}>{domain.name}</div>
-                        <div className={cn(GRID_BODY_CELL, 'min-w-0 whitespace-nowrap')}>
+                        <div role="cell" className={cn(GRID_BODY_CELL, GRID_DOMAIN_FLOOR, 'break-all')}>
+                            {domain.name}
+                        </div>
+                        <div role="cell" className={cn(GRID_BODY_CELL, 'min-w-0 whitespace-nowrap')}>
                             <Address pubkey={domain.pubkey} link />
                         </div>
-                    </React.Fragment>
+                    </div>
                 ))}
             </div>
         </div>

--- a/app/entities/domain/ui/__stories__/BaseDomainsCard.stories.tsx
+++ b/app/entities/domain/ui/__stories__/BaseDomainsCard.stories.tsx
@@ -7,13 +7,48 @@ import { BaseDomainsCard } from '../BaseDomainsCard';
 const meta = {
     component: BaseDomainsCard,
     decorators: [withClusterAndAccounts, withTokenInfoBatch],
-    parameters: nextjsParameters,
+    parameters: {
+        ...nextjsParameters,
+        docs: {
+            description: {
+                component: [
+                    "Presentational card rendering an account's domains as a collapsible section — the heading",
+                    'is lifted out above the card and a toggle collapses the list. This component only supplies',
+                    'the copy and the per-row data; everything else is composed from the shared primitives below.',
+                    '',
+                    '## References',
+                    '',
+                    '- [CollapsibleSection](?path=/docs/components-shared-collapsiblesection--docs) — the shared collapsible wrapper: a `<section aria-labelledby>` with the heading (`<h2 className="m-0 text-lg font-normal text-white">`) lifted out above the surface, a `Collapse`/`Expand` toggle, and the height animation. Passed `className=""` so the surface comes from the `<Card>` below (the same pattern the transaction `InstructionsSection` uses).',
+                    '- [Button](?path=/docs/components-shared-button--docs) (`variant="outline" size="sm"`) — the collapse/expand toggle inside `CollapsibleSection`: a rotating `ChevronDown` plus a `Collapse`/`Expand` label on `md+`, with `aria-expanded` reflecting state.',
+                    '- Collapse animation — a `grid` wrapper toggling `grid-rows-[1fr]` ↔ `grid-rows-[0fr]` around an `overflow-hidden` child, so the list animates open/closed without fixed heights.',
+                    '- [Card](?path=/docs/components-shared-card-basecard--docs) — the surface holding the list: a Tailwind `variant="tight"` card.',
+                    '- Domain list — a pure-Tailwind CSS grid (`clamp(120px,25%,200px) 1fr`) built from `div`s, mirroring the transaction Accounts/Token Balances tables. Columns: "Domain" and "Name Service Account".',
+                    '- [Address](?path=/docs/components-common-address--docs) (`link`) — fills the "Name Service Account" cell, rendering each domain\'s pubkey as a linked, copyable address with a tooltip.',
+                    '- [LoadingCard](?path=/docs/components-common-loadingcard--docs) / [ErrorCard](?path=/docs/components-common-errorcard--docs) — not part of this card; rendered by the wrapping `DomainsCard` for the loading and error states.',
+                ].join('\n'),
+            },
+        },
+    },
     tags: ['autodocs', 'test'],
     title: 'Entities/Domain/BaseDomainsCard',
 } satisfies Meta<typeof BaseDomainsCard>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// Real long domain owned by Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v — its on-chain name-account
+// key derived the same way as the app's fetch path. Hoisted so args and the `play` assertion share one
+// source of truth for the (verbose) name.
+const LONG_DOMAIN = {
+    address: 'EXNHvjcrDi4hM634GxZsEGC5i9xhcuFqcPSTAY9XSXvb',
+    name: 'thisisaverylongdomainnamemainlyusedforfunctionaltesting.sol',
+};
+// Synthetic name ~4× longer (the real label repeated four times) — no such domain is registered, so
+// the address is a placeholder; it exists purely to see how an extreme value wraps/contains.
+const EXTRA_LONG_DOMAIN = {
+    address: 'So11111111111111111111111111111111111111112',
+    name: 'thisisaverylongdomainnamemainlyusedforfunctionaltestingthisisaverylongdomainnamemainlyusedforfunctionaltestingthisisaverylongdomainnamemainlyusedforfunctionaltestingthisisaverylongdomainnamemainlyusedforfunctionaltesting.sol',
+};
 
 export const SingleDomain: Story = {
     args: {
@@ -31,6 +66,8 @@ export const MultipleDomains: Story = {
             { address: '5ASxtmcPKDeD8NoE5QpskizPokqDdX1qHFiqZb1spLdo', name: 'example.sol' },
             { address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', name: 'bob.sol' },
             { address: 'Sysvar1111111111111111111111111111111111111', name: 'charlie.ans' },
+            LONG_DOMAIN,
+            EXTRA_LONG_DOMAIN,
         ],
     },
     play: async ({ canvasElement }) => {
@@ -38,5 +75,7 @@ export const MultipleDomains: Story = {
         expect(canvas.getByText('example.sol')).toBeInTheDocument();
         expect(canvas.getByText('bob.sol')).toBeInTheDocument();
         expect(canvas.getByText('charlie.ans')).toBeInTheDocument();
+        expect(canvas.getByText(LONG_DOMAIN.name)).toBeInTheDocument();
+        expect(canvas.getByText(EXTRA_LONG_DOMAIN.name)).toBeInTheDocument();
     },
 };

--- a/app/features/transaction/ui/AccountsCard.tsx
+++ b/app/features/transaction/ui/AccountsCard.tsx
@@ -5,6 +5,7 @@ import { BalanceDelta } from '@components/common/BalanceDelta';
 import { ErrorCard } from '@components/common/ErrorCard';
 import { SolBalance } from '@components/common/SolBalance';
 import { Button } from '@components/shared/ui/button';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
 import { cn } from '@components/shared/utils';
 import { AccountInfo, useAccountsInfo } from '@entities/account';
 import { useCluster } from '@providers/cluster';
@@ -20,7 +21,6 @@ import { useBreakpoint } from '@/app/shared/lib/use-breakpoint';
 import { AccountBadges } from './AccountBadges';
 import { AccountDetailSlideover } from './AccountDetailSlideover';
 import { AccountExpandedContent } from './AccountExpandedContent';
-import { CollapsibleSection } from './CollapsibleSection';
 
 type TransactionAccountRowProps = {
     account: ParsedMessageAccount;

--- a/app/features/transaction/ui/InstructionsSection.tsx
+++ b/app/features/transaction/ui/InstructionsSection.tsx
@@ -24,6 +24,7 @@ import { UnknownDetailsCard } from '@components/instruction/UnknownDetailsCard';
 import { isWormholeInstruction } from '@components/instruction/wormhole/types';
 import { WormholeDetailsCard } from '@components/instruction/WormholeDetailsCard';
 import { ZkElGamalProofDetailsCard } from '@components/instruction/ZkElGamalProofDetailsCard';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
 import { isParsedInstruction, useInstructionParser } from '@entities/instruction-parser';
 import { isZkElGamalProofInstruction } from '@entities/zk-elgamal-proof';
 import { getMangoInstructionLabel, isMangoInstruction } from '@explorer/decoder-mango/detection';
@@ -63,7 +64,6 @@ import dynamic from 'next/dynamic';
 import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import { CollapsibleSection } from './CollapsibleSection';
 import { CommonInstructionDetailsCard } from './CommonInstructionDetailsCard';
 
 const SerumDetailsCard = dynamic(

--- a/app/features/transaction/ui/ProgramLogSection.tsx
+++ b/app/features/transaction/ui/ProgramLogSection.tsx
@@ -1,5 +1,6 @@
 import { TableCardBody } from '@components/common/TableCardBody';
 import { ProgramLogsCardBody } from '@components/ProgramLogsCardBody';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
 import { cn } from '@components/shared/utils';
 import { useCluster } from '@providers/cluster';
 import { useTransactionDetails } from '@providers/transactions';
@@ -10,8 +11,6 @@ import React from 'react';
 import { Button } from '@/app/components/shared/ui/button';
 import { BaseCardBody } from '@/app/shared/ui/Card';
 import { BaseTable } from '@/app/shared/ui/Table';
-
-import { CollapsibleSection } from './CollapsibleSection';
 
 type ChipProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean };
 export function Chip({ children, className, active, ...props }: ChipProps) {

--- a/app/features/transaction/ui/TokenBalancesCard.tsx
+++ b/app/features/transaction/ui/TokenBalancesCard.tsx
@@ -3,6 +3,7 @@
 import ScaledUiAmountMultiplierTooltip from '@components/account/token-extensions/ScaledUiAmountMultiplierTooltip';
 import { Address } from '@components/common/Address';
 import { BalanceDelta } from '@components/common/BalanceDelta';
+import { CollapsibleSection } from '@components/shared/ui/collapsible-section';
 import { cn } from '@components/shared/utils';
 import { useTransactionDetails } from '@providers/transactions';
 import { ParsedMessageAccount, PublicKey, TokenBalance } from '@solana/web3.js';
@@ -14,8 +15,6 @@ import useAsyncEffect from 'use-async-effect';
 import { useScaledUiAmountForMint } from '@/app/providers/accounts/tokens';
 import { useCluster } from '@/app/providers/cluster';
 import { getTokenInfos } from '@/app/utils/token-info';
-
-import { CollapsibleSection } from './CollapsibleSection';
 
 type TokenBalanceRow = {
     account: PublicKey;

--- a/app/shared/ui/Card/BaseCard.tsx
+++ b/app/shared/ui/Card/BaseCard.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
-import { cn } from '@/app/components/shared/utils';
+import { cnPrefixed } from '@/app/components/shared/utils';
 
 // `ui` picks the visual lineage. Default is "tw" since most consumers already use Tailwind — pass ui="dashkit" explicitly when migrating Bootstrap `.card*` callsites; the "dashkit" branch + dk-* tokens get deleted once migration completes.
 type UI = 'dashkit' | 'tw';
@@ -42,7 +42,11 @@ export interface BaseCardProps extends React.HTMLAttributes<HTMLDivElement>, Var
 
 const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>(
     ({ className, flex, marginBottom, ui, variant, ...props }, ref) => (
-        <div ref={ref} className={cn(cardVariants({ flex, marginBottom, ui, variant }), className)} {...props} />
+        <div
+            ref={ref}
+            className={cnPrefixed(cardVariants({ flex, marginBottom, ui, variant }), className)}
+            {...props}
+        />
     ),
 );
 BaseCard.displayName = 'BaseCard';
@@ -64,7 +68,7 @@ interface UIPropOverride {
 
 const BaseCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cn(headerVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(headerVariants({ ui: ui }), className)} {...props} />
     ),
 );
 BaseCardHeader.displayName = 'BaseCardHeader';
@@ -81,7 +85,7 @@ const bodyVariants = cva([], {
 
 const BaseCardBody = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cn(bodyVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(bodyVariants({ ui: ui }), className)} {...props} />
     ),
 );
 BaseCardBody.displayName = 'BaseCardBody';
@@ -98,7 +102,7 @@ const footerVariants = cva([], {
 
 const BaseCardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cn(footerVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(footerVariants({ ui: ui }), className)} {...props} />
     ),
 );
 BaseCardFooter.displayName = 'BaseCardFooter';
@@ -142,7 +146,7 @@ const BaseCardTitle = React.forwardRef<HTMLElement, BaseCardTitleProps>(
     ({ as = 'div', className, ui, ...props }, ref) => {
         const Element = as as React.ElementType;
         const sizeClass = ui === 'dashkit' ? dashkitTitleSizeByAs[as] : '';
-        return <Element ref={ref} className={cn(titleVariants({ ui: ui }), sizeClass, className)} {...props} />;
+        return <Element ref={ref} className={cnPrefixed(titleVariants({ ui: ui }), sizeClass, className)} {...props} />;
     },
 );
 BaseCardTitle.displayName = 'BaseCardTitle';
@@ -150,7 +154,7 @@ BaseCardTitle.displayName = 'BaseCardTitle';
 // OKLCH-only sub-component; no dashkit equivalent so it renders the same in both UIs.
 const BaseCardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
     ({ className, ...props }, ref) => (
-        <div ref={ref} className={cn('text-sm text-neutral-500', className)} {...props} />
+        <div ref={ref} className={cnPrefixed('text-sm text-neutral-500', className)} {...props} />
     ),
 );
 BaseCardDescription.displayName = 'BaseCardDescription';

--- a/app/shared/ui/Card/BaseCard.tsx
+++ b/app/shared/ui/Card/BaseCard.tsx
@@ -68,7 +68,7 @@ interface UIPropOverride {
 
 const BaseCardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cnPrefixed(headerVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(headerVariants({ ui }), className)} {...props} />
     ),
 );
 BaseCardHeader.displayName = 'BaseCardHeader';
@@ -85,7 +85,7 @@ const bodyVariants = cva([], {
 
 const BaseCardBody = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cnPrefixed(bodyVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(bodyVariants({ ui }), className)} {...props} />
     ),
 );
 BaseCardBody.displayName = 'BaseCardBody';
@@ -102,7 +102,7 @@ const footerVariants = cva([], {
 
 const BaseCardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & UIPropOverride>(
     ({ className, ui, ...props }, ref) => (
-        <div ref={ref} className={cnPrefixed(footerVariants({ ui: ui }), className)} {...props} />
+        <div ref={ref} className={cnPrefixed(footerVariants({ ui }), className)} {...props} />
     ),
 );
 BaseCardFooter.displayName = 'BaseCardFooter';
@@ -145,8 +145,11 @@ interface BaseCardTitleProps extends React.HTMLAttributes<HTMLElement>, UIPropOv
 const BaseCardTitle = React.forwardRef<HTMLElement, BaseCardTitleProps>(
     ({ as = 'div', className, ui, ...props }, ref) => {
         const Element = as as React.ElementType;
+        // TODO: fold `sizeClass` into `titleVariants` as an `as` variant (a compound variant keyed on
+        // `ui: 'dashkit'` + `as`) so the dashkit size token is part of the CVA config instead of a
+        // separate class passed alongside it.
         const sizeClass = ui === 'dashkit' ? dashkitTitleSizeByAs[as] : '';
-        return <Element ref={ref} className={cnPrefixed(titleVariants({ ui: ui }), sizeClass, className)} {...props} />;
+        return <Element ref={ref} className={cnPrefixed(titleVariants({ ui }), sizeClass, className)} {...props} />;
     },
 );
 BaseCardTitle.displayName = 'BaseCardTitle';

--- a/app/shared/ui/Table/BaseTable.tsx
+++ b/app/shared/ui/Table/BaseTable.tsx
@@ -33,8 +33,33 @@ const tableVariants = cva([], {
             variant: 'card',
         },
     ],
-    defaultVariants: { nowrap: false, ui: 'tw', variant: 'plain' },
+    defaultVariants: { body: 'default', head: 'default', nowrap: false, ui: 'tw', variant: 'plain' },
     variants: {
+        // `body` mirrors `head` for the data rows: `subtle` sets 8px vertical / 12px horizontal padding.
+        // Same specificity story as `head` — `tbody tr td` (0,1,3) beats base `td` (0,1,1); the edge
+        // overrides add `:first-child`/`:last-child` (0,2,3) to beat the card variant's `pl-6`/`pr-6`.
+        // Row text colour is left untouched so the data stays readable.
+        body: {
+            default: '',
+            subtle: [
+                '[&_tbody_tr_td]:px-3 [&_tbody_tr_td]:py-2',
+                '[&_tbody_tr_td:first-child]:pl-3 [&_tbody_tr_td:last-child]:pr-3',
+            ].join(' '),
+        },
+        // `head` restyles just the header row while keeping the `<table>` structure. `subtle` takes
+        // the transaction Token Balances table header's muted colour (`outer-space-300`), drops the
+        // header's own `bg-dark-background` so it shares the transparent tbody/card surface, and sets
+        // 8px vertical / 12px horizontal padding — colours and spacing only. Base overrides use
+        // `thead tr th` (specificity 0,1,3 > base 0,1,2); the edge padding overrides add `:first-child`/
+        // `:last-child` (0,2,3) to beat the card variant's `thead th:first-child` (0,2,2) `pl-6`/`pr-6`.
+        head: {
+            default: '',
+            subtle: [
+                '[&_thead_tr_th]:bg-transparent [&_thead_tr_th]:text-outer-space-300',
+                '[&_thead_tr_th]:px-3 [&_thead_tr_th]:py-2',
+                '[&_thead_tr_th:first-child]:pl-3 [&_thead_tr_th:last-child]:pr-3',
+            ].join(' '),
+        },
         nowrap: { false: '', true: '' },
         ui: {
             // Tailwind translation of compiled `.table.table-sm`; keeps the Dashkit `1.5rem` table margin and the `#1e2423` tbody border that the SCSS late-override pins.
@@ -82,8 +107,10 @@ export interface BaseTableProps
         VariantProps<typeof tableVariants> {}
 
 const BaseTableRoot = React.forwardRef<HTMLTableElement, BaseTableProps>(
-    ({ className, nowrap, ui, variant, ...props }, ref) => {
-        const table = <table ref={ref} className={cn(tableVariants({ nowrap, ui, variant }), className)} {...props} />;
+    ({ body, className, head, nowrap, ui, variant, ...props }, ref) => {
+        const table = (
+            <table ref={ref} className={cn(tableVariants({ body, head, nowrap, ui, variant }), className)} {...props} />
+        );
         if (variant === 'card') {
             return <div className={cn(wrapperVariants({ ui }))}>{table}</div>;
         }

--- a/app/shared/ui/Table/__stories__/BaseTable.stories.tsx
+++ b/app/shared/ui/Table/__stories__/BaseTable.stories.tsx
@@ -4,6 +4,22 @@ import { BaseCard, BaseCardBody, BaseCardHeader, BaseCardTitle } from '../../Car
 import { BaseTable } from '../BaseTable';
 
 const meta: Meta<typeof BaseTable> = {
+    argTypes: {
+        body: {
+            control: 'inline-radio',
+            description: 'Data row styling. `subtle` sets 8px vertical / 12px horizontal cell padding.',
+            options: ['default', 'subtle'],
+        },
+        head: {
+            control: 'inline-radio',
+            description:
+                'Header row styling. `subtle` uses the Token Balances header colour, a transparent (row-matching) background, and 8px/12px padding.',
+            options: ['default', 'subtle'],
+        },
+        nowrap: { control: 'boolean' },
+        ui: { control: 'inline-radio', options: ['dashkit', 'tw'] },
+        variant: { control: 'inline-radio', options: ['plain', 'card'] },
+    },
     component: BaseTable,
     tags: ['autodocs', 'test'],
     title: 'Components/Shared/Table/BaseTable',
@@ -126,6 +142,31 @@ export const DashkitCardInsideCard: Story = {
                 </BaseTable>
             </BaseCardBody>
         </BaseCard>
+    ),
+};
+
+// `head="subtle"` restyles just the header row (muted `outer-space-300` colour, transparent row-matching
+// background, 8px/12px padding), matching the transaction Token Balances header. Flip the `head` control
+// to compare with `default`.
+export const DashkitCardSubtleHead: Story = {
+    args: { head: 'subtle', nowrap: true, ui: 'dashkit', variant: 'card' },
+    name: 'Dashkit / Card variant + subtle head',
+    render: args => (
+        <BaseTable {...args}>
+            <CardSampleRows />
+        </BaseTable>
+    ),
+};
+
+// The domain-list combination: `subtle` header + `subtle` rows (row-matching header background, muted
+// header colour, uniform 8px/12px padding across header and body). Flip `head`/`body` to compare.
+export const DashkitCardSubtleHeadAndBody: Story = {
+    args: { body: 'subtle', head: 'subtle', nowrap: true, ui: 'dashkit', variant: 'card' },
+    name: 'Dashkit / Card variant + subtle head & body',
+    render: args => (
+        <BaseTable {...args}>
+            <CardSampleRows />
+        </BaseTable>
     ),
 };
 


### PR DESCRIPTION
## Description

Update the domains card layout to match the design code:
- [x] Move the heading outside the card and add collapse / expand behavior.
- [x] Update the spacing.
- [x] Add specific layouts for breakpoints where the content doesn’t fit by default.
- [x] Use a grid instead of tables, so we have more flexibility to rearrange data based on screen size.

## Type of change
-   [x] Design update

## Screenshots
<!-- For UI changes, especially protocol screens, include screenshots showing the changes -->
<!-- This is REQUIRED for protocol integration PRs -->
<img width="4596" height="1195" alt="domains_comparison" src="https://github.com/user-attachments/assets/2907b10e-bfb8-4ee2-8948-c10923e02ac8" />

## Testing
Open [account with domains](https://explorer-git-fork-hoodieshq-feat-domai-7b8799-solana-foundation.vercel.app/address/Fw1ETanDZafof7xEULsnq9UY6o71Tpds89tNwPkWLb1v/domains).

## Related Issues
[HOO-914](https://linear.app/solana-fndn/issue/HOO-914/domains-mobile-layout)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes