### PR TITLE
refactor(cluster): add central rpc accessor memoized per cluster url

### DIFF
--- a/app/entities/cluster/api/__tests__/get-rpc.spec.ts
+++ b/app/entities/cluster/api/__tests__/get-rpc.spec.ts
@@ -10,4 +10,21 @@ describe('getRpc', () => {
     it('should return distinct clients for distinct URLs', () => {
         expect(getRpc('http://localhost:8899')).not.toBe(getRpc('http://localhost:8900'));
     });
+
+    it('should evict the least recently used client once the cache is full', () => {
+        const first = getRpc('http://first.example');
+        for (let i = 0; i < 30; i++) {
+            getRpc(`http://filler-${i}.example`);
+        }
+        expect(getRpc('http://first.example')).not.toBe(first);
+    });
+
+    it('should keep a recently used client through evictions', () => {
+        const first = getRpc('http://kept.example');
+        for (let i = 0; i < 30; i++) {
+            getRpc(`http://churn-${i}.example`);
+            getRpc('http://kept.example');
+        }
+        expect(getRpc('http://kept.example')).toBe(first);
+    });
 });

--- a/app/entities/cluster/api/__tests__/get-rpc.spec.ts
+++ b/app/entities/cluster/api/__tests__/get-rpc.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRpc } from '../get-rpc';
+
+describe('getRpc', () => {
+    it('should return the same client for repeated calls with the same URL', () => {
+        expect(getRpc('http://localhost:8899')).toBe(getRpc('http://localhost:8899'));
+    });
+
+    it('should return distinct clients for distinct URLs', () => {
+        expect(getRpc('http://localhost:8899')).not.toBe(getRpc('http://localhost:8900'));
+    });
+});

--- a/app/entities/cluster/api/__tests__/get-rpc.spec.ts
+++ b/app/entities/cluster/api/__tests__/get-rpc.spec.ts
@@ -1,30 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getRpc } from '../get-rpc';
+// The client cache is module state, so each test loads a fresh copy of the module.
+async function loadModule() {
+    vi.resetModules();
+    return import('../get-rpc');
+}
 
 describe('getRpc', () => {
-    it('should return the same client for repeated calls with the same URL', () => {
+    it('should return the same client for repeated calls with the same URL', async () => {
+        const { getRpc } = await loadModule();
         expect(getRpc('http://localhost:8899')).toBe(getRpc('http://localhost:8899'));
     });
 
-    it('should return distinct clients for distinct URLs', () => {
+    it('should return distinct clients for distinct URLs', async () => {
+        const { getRpc } = await loadModule();
         expect(getRpc('http://localhost:8899')).not.toBe(getRpc('http://localhost:8900'));
     });
 
-    it('should evict the least recently used client once the cache is full', () => {
+    it('should evict the oldest client once the cache is full', async () => {
+        const { getRpc, MAX_CACHED_RPCS } = await loadModule();
         const first = getRpc('http://first.example');
-        for (let i = 0; i < 30; i++) {
+        for (let i = 0; i < MAX_CACHED_RPCS; i++) {
             getRpc(`http://filler-${i}.example`);
         }
         expect(getRpc('http://first.example')).not.toBe(first);
     });
 
-    it('should keep a recently used client through evictions', () => {
-        const first = getRpc('http://kept.example');
-        for (let i = 0; i < 30; i++) {
+    it('should keep a client cached while newer entries fit within the bound', async () => {
+        const { getRpc, MAX_CACHED_RPCS } = await loadModule();
+        const kept = getRpc('http://kept.example');
+        for (let i = 0; i < MAX_CACHED_RPCS - 1; i++) {
             getRpc(`http://churn-${i}.example`);
-            getRpc('http://kept.example');
         }
-        expect(getRpc('http://kept.example')).toBe(first);
+        expect(getRpc('http://kept.example')).toBe(kept);
     });
 });

--- a/app/entities/cluster/api/get-rpc.ts
+++ b/app/entities/cluster/api/get-rpc.ts
@@ -2,15 +2,26 @@ import { createSolanaRpc } from '@solana/kit';
 
 export type SolanaRpc = ReturnType<typeof createSolanaRpc>;
 
+// Generous bound relative to real usage (a handful of known clusters plus the occasional custom URL);
+// it only exists so free-form custom endpoints can't grow the cache for the life of the tab.
+const MAX_CACHED_RPCS = 25;
+
 const rpcByUrl = new Map<string, SolanaRpc>();
 
 // One rpc client per endpoint. The client is a stateless transport wrapper, so every caller can share
 // it, and the stable identity lets React hooks and effects depend on the rpc without re-firing.
 export function getRpc(url: string): SolanaRpc {
-    let rpc = rpcByUrl.get(url);
-    if (!rpc) {
-        rpc = createSolanaRpc(url);
-        rpcByUrl.set(url, rpc);
+    const cached = rpcByUrl.get(url);
+    if (cached) {
+        // Re-insert so Map iteration order tracks recency and eviction drops the least recently used URL.
+        rpcByUrl.delete(url);
+        rpcByUrl.set(url, cached);
+        return cached;
     }
+    const rpc = createSolanaRpc(url);
+    if (rpcByUrl.size >= MAX_CACHED_RPCS) {
+        rpcByUrl.delete(rpcByUrl.keys().next().value as string);
+    }
+    rpcByUrl.set(url, rpc);
     return rpc;
 }

--- a/app/entities/cluster/api/get-rpc.ts
+++ b/app/entities/cluster/api/get-rpc.ts
@@ -1,0 +1,16 @@
+import { createSolanaRpc } from '@solana/kit';
+
+export type SolanaRpc = ReturnType<typeof createSolanaRpc>;
+
+const rpcByUrl = new Map<string, SolanaRpc>();
+
+// One rpc client per endpoint. The client is a stateless transport wrapper, so every caller can share
+// it, and the stable identity lets React hooks and effects depend on the rpc without re-firing.
+export function getRpc(url: string): SolanaRpc {
+    let rpc = rpcByUrl.get(url);
+    if (!rpc) {
+        rpc = createSolanaRpc(url);
+        rpcByUrl.set(url, rpc);
+    }
+    return rpc;
+}

--- a/app/entities/cluster/api/get-rpc.ts
+++ b/app/entities/cluster/api/get-rpc.ts
@@ -1,25 +1,25 @@
+'use client';
+
 import { createSolanaRpc } from '@solana/kit';
 
 export type SolanaRpc = ReturnType<typeof createSolanaRpc>;
 
 // Generous bound relative to real usage (a handful of known clusters plus the occasional custom URL);
 // it only exists so free-form custom endpoints can't grow the cache for the life of the tab.
-const MAX_CACHED_RPCS = 25;
+export const MAX_CACHED_RPCS = 25;
 
 const rpcByUrl = new Map<string, SolanaRpc>();
 
 // One rpc client per endpoint. The client is a stateless transport wrapper, so every caller can share
 // it, and the stable identity lets React hooks and effects depend on the rpc without re-firing.
+// A cached URL is a pure read, so calling this during render never reorders or evicts anything.
 export function getRpc(url: string): SolanaRpc {
     const cached = rpcByUrl.get(url);
-    if (cached) {
-        // Re-insert so Map iteration order tracks recency and eviction drops the least recently used URL.
-        rpcByUrl.delete(url);
-        rpcByUrl.set(url, cached);
-        return cached;
-    }
+    if (cached) return cached;
+
     const rpc = createSolanaRpc(url);
     if (rpcByUrl.size >= MAX_CACHED_RPCS) {
+        // Map iteration order is insertion order, so this drops the oldest entry.
         rpcByUrl.delete(rpcByUrl.keys().next().value as string);
     }
     rpcByUrl.set(url, rpc);

--- a/app/entities/cluster/index.ts
+++ b/app/entities/cluster/index.ts
@@ -1,3 +1,4 @@
+export { getRpc, type SolanaRpc } from './api/get-rpc';
 export { clusterSelection, type ClusterSelection } from './lib/cluster';
 export type { ClusterInfo } from './lib/types';
 export { type CustomUrlDecision, decideCustomUrl, isCustomUrlCarryable } from './lib/resolve-cluster';
@@ -17,6 +18,7 @@ export {
 } from './model/use-cluster-resource-search';
 export { pickClusterParams, useBuildClusterPath, useClusterPath } from './model/use-cluster-path';
 export { buildExplorerLink, useExplorerLink } from './model/use-explorer-link';
+export { useSolanaRpc } from './model/use-solana-rpc';
 export { AdjacentClusterLink } from './ui/AdjacentClusterLink';
 export { ExplorerLink } from './ui/ExplorerLink';
 export { SearchingClusterIndicator } from './ui/SearchingClusterIndicator';

--- a/app/entities/cluster/model/use-solana-rpc.ts
+++ b/app/entities/cluster/model/use-solana-rpc.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { getRpc, type SolanaRpc } from '../api/get-rpc';
+import { useCluster } from './use-cluster';
+
+// The rpc client for the active cluster. Stable per cluster URL (see getRpc), so it is safe to use
+// directly in hook dependency arrays.
+export function useSolanaRpc(): SolanaRpc {
+    const { url } = useCluster();
+    return getRpc(url);
+}

--- a/app/features/vote/model/vote-accounts.tsx
+++ b/app/features/vote/model/vote-accounts.tsx
@@ -1,5 +1,4 @@
-import { useCluster } from '@providers/cluster';
-import { createSolanaRpc } from '@solana/kit';
+import { getRpc, useCluster } from '@providers/cluster';
 import { Cluster } from '@utils/cluster';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
@@ -34,7 +33,7 @@ async function fetchVoteAccounts({
     url: string;
 }) {
     try {
-        const rpc = createSolanaRpc(url);
+        const rpc = getRpc(url);
 
         const voteAccountsResponse = await rpc.getVoteAccounts({ commitment: 'confirmed' }).send();
         const voteAccounts: VoteAccounts = {

--- a/app/providers/cluster.tsx
+++ b/app/providers/cluster.tsx
@@ -41,8 +41,11 @@ export {
     type ClusterState,
     clusterModalOpenAtom,
     customUrlEnabledAtom,
+    getRpc,
+    type SolanaRpc,
     StateContext,
     useCluster,
     useClusterInfo,
     useClusterModal,
+    useSolanaRpc,
 } from '@entities/cluster';

--- a/app/providers/stats/solanaClusterStats.tsx
+++ b/app/providers/stats/solanaClusterStats.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useCluster } from '@providers/cluster';
-import { createSolanaRpc } from '@solana/kit';
+import { useCluster, useSolanaRpc } from '@providers/cluster';
 import { Cluster } from '@utils/cluster';
 import useTabVisibility from '@utils/use-tab-visibility';
 import React from 'react';
@@ -80,14 +79,13 @@ type Props = { children: React.ReactNode };
 
 export function SolanaClusterStatsProvider({ children }: Props) {
     const { cluster, url } = useCluster();
+    const rpc = useSolanaRpc();
     const [active, setActive] = React.useState(false);
     const [dashboardInfo, dispatchDashboardInfo] = React.useReducer(dashboardInfoReducer, initialDashboardInfo);
     const [performanceInfo, dispatchPerformanceInfo] = React.useReducer(performanceInfoReducer, initialPerformanceInfo);
     const { visible: isTabVisible } = useTabVisibility();
     React.useEffect(() => {
         if (!active || !isTabVisible || !url) return;
-
-        const rpc = createSolanaRpc(url);
 
         let lastSlot: bigint | null = null;
         let stale = false;
@@ -234,7 +232,7 @@ export function SolanaClusterStatsProvider({ children }: Props) {
             clearInterval(blockTimeInterval);
             stale = true;
         };
-    }, [active, cluster, isTabVisible, url]);
+    }, [active, cluster, isTabVisible, rpc, url]);
 
     // Reset when cluster changes
     React.useEffect(() => {

--- a/app/providers/supply.tsx
+++ b/app/providers/supply.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useCluster } from '@providers/cluster';
-import { createSolanaRpc } from '@solana/kit';
+import { getRpc, useCluster } from '@providers/cluster';
 import { Cluster, ClusterStatus } from '@utils/cluster';
 import React from 'react';
 
@@ -53,7 +52,7 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
     dispatch(Status.Connecting);
 
     try {
-        const rpc = createSolanaRpc(url);
+        const rpc = getRpc(url);
 
         const supplyResponse = await rpc
             .getSupply({ commitment: 'finalized', excludeNonCirculatingAccountsList: true })

--- a/openspec/changes/centralize-rpc-access/proposal.md
+++ b/openspec/changes/centralize-rpc-access/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: Centralize RPC access behind the cluster entity
+
+## Context
+
+The Explorer is mid-migration from `@solana/web3.js` v1 to `@solana/kit` 7. Kit already powers transaction decoding, the validators layer, stake/vote/subscriptions, and every `@solana-program/*` client — but each kit call site constructs its own client: ~78 scattered `createSolanaRpc(url)` calls across 36 files, with no shared handle. Every new fetcher re-derives "get me an rpc for the active cluster" from `useCluster().url`, and nothing guarantees two components on the same page share a client.
+
+This change is the first step of the full web3.js removal roadmap, which proceeds in phases: foundations and dependency quick wins (spl-token, buffer-layout, borsh → kit codecs); replacing every remaining `new Connection(...)` in the providers layer with kit rpc; unifying instruction parsing per the `unify-instruction-parsing` change; moving the transaction detail page and the inspector onto kit introspection types; replacing the metaplex/domains/anchor/wallet-adapter dependency corners with kit-native or codama-generated clients; and finally sweeping `PublicKey` for `Address` and deleting the compat shims (`app/utils/kit-wrapper.tsx`, `app/shared/lib/web3js-compat.ts`, `packages/parsers/src/compat/*`). Done means `@solana/web3.js` is out of the dependency tree. Until that endgame, `@/app/shared/lib/web3js-compat` remains the single permitted web3.js bridge.
+
+The provider migrations in that roadmap all need the same primitive first: one blessed way to obtain a kit rpc client for a cluster URL.
+
+### Alternatives considered
+
+- **Keep constructing clients ad-hoc.** Rejected: every `Connection`-removal PR would invent its own client handling, and effect hooks cannot safely depend on a client whose identity changes every render.
+- **A React-context RpcProvider holding the client.** Rejected as needless indirection: the cluster state (and thus the URL) already lives in `ClusterProvider`, and non-React code (route handlers, module-level fetchers) needs a client too. A context would force a second, parallel path for those.
+- **Placement in `app/shared/lib`.** Rejected: the accessor is not generic shared code — it is the cluster entity's concern (an rpc client *for a cluster*), and FSD places it there. Consumers reach it via `@entities/cluster` or the existing `@providers/cluster` façade.
+
+## What Changes
+
+- Add `getRpc(url)` in `app/entities/cluster/api/get-rpc.ts`: returns a `createSolanaRpc` client memoized per URL, so repeated calls share one client and the identity is referentially stable. Exports the `SolanaRpc` type for consumers.
+- Add `useSolanaRpc()` in `app/entities/cluster/model/use-solana-rpc.ts`: the hook form, resolving the active cluster URL via `useCluster()` and delegating to `getRpc`.
+- Export both from the entity's public API and the `@providers/cluster` re-export façade.
+- Adopt the accessor in three existing kit call sites to establish the pattern: `app/providers/supply.tsx`, `app/providers/stats/solanaClusterStats.tsx` (hook form), `app/features/vote/model/vote-accounts.tsx`.
+
+**Out of scope:** migrating the remaining `createSolanaRpc` call sites and the web3.js `Connection` sites — those move onto the accessor in the follow-up provider-migration changes described above.
+
+## Impact
+
+- **No behaviour change.** The adopted call sites issue the same RPC calls against the same URLs; the only difference is client reuse instead of per-call construction.
+- **Every subsequent `Connection`-removal change** consumes this accessor instead of inventing client handling, and effect hooks can list the rpc client in dependency arrays without re-firing on every render.
+- **Tests:** colocated spec covering the per-URL memoization contract.

--- a/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
+++ b/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
@@ -1,0 +1,35 @@
+# rpc-access
+
+## Purpose
+
+One blessed way to obtain a `@solana/kit` rpc client for a cluster URL, owned by the cluster entity, so clients are shared per endpoint and referentially stable.
+
+## ADDED Requirements
+
+### Requirement: The cluster entity owns rpc client construction
+
+App code that needs a kit rpc client SHALL obtain it from the cluster entity's accessor — `useSolanaRpc()` in React components and hooks, `getRpc(url)` elsewhere — rather than calling `createSolanaRpc` directly. Pre-existing direct `createSolanaRpc` call sites migrate onto the accessor as their owning features are migrated off web3.js.
+
+#### Scenario: A React component needs the active cluster's rpc
+
+- **WHEN** a component inside `ClusterProvider` needs an rpc client for the active cluster
+- **THEN** it obtains one from `useSolanaRpc()`
+
+#### Scenario: Non-React code needs an rpc for a known URL
+
+- **WHEN** code outside the React tree holds a cluster URL and needs an rpc client
+- **THEN** it obtains one from `getRpc(url)`
+
+### Requirement: Clients are memoized per URL
+
+`getRpc` MUST return the same client instance for repeated calls with the same URL, and distinct instances for distinct URLs. The returned identity MUST be stable enough to appear in a React hook dependency array without re-firing effects across renders for an unchanged URL.
+
+#### Scenario: Repeated calls with one URL
+
+- **WHEN** `getRpc` is called twice with the same URL
+- **THEN** both calls return the same client instance
+
+#### Scenario: Two different endpoints
+
+- **WHEN** `getRpc` is called with two different URLs
+- **THEN** it returns two distinct client instances

--- a/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
+++ b/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
@@ -22,7 +22,7 @@ App code that needs a kit rpc client SHALL obtain it from the cluster entity's a
 
 ### Requirement: Clients are memoized per URL
 
-`getRpc` MUST return the same client instance for repeated calls with the same URL, and distinct instances for distinct URLs. The returned identity MUST be stable enough to appear in a React hook dependency array without re-firing effects across renders for an unchanged URL.
+`getRpc` MUST return the same client instance for repeated calls with the same URL, and distinct instances for distinct URLs. The returned identity MUST be stable enough to appear in a React hook dependency array without re-firing effects across renders for an unchanged URL. The cache MUST be bounded, evicting the least recently used entry once the bound is exceeded, so free-form custom endpoint URLs cannot grow it for the life of the tab; the bound MUST be generous enough that eviction never touches a URL in active use.
 
 #### Scenario: Repeated calls with one URL
 
@@ -33,3 +33,9 @@ App code that needs a kit rpc client SHALL obtain it from the cluster entity's a
 
 - **WHEN** `getRpc` is called with two different URLs
 - **THEN** it returns two distinct client instances
+
+#### Scenario: A flood of one-off custom URLs
+
+- **WHEN** more distinct URLs than the cache bound are requested
+- **THEN** the least recently used clients are evicted
+- **AND** recently used clients keep their identity

--- a/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
+++ b/openspec/changes/centralize-rpc-access/specs/rpc-access/spec.md
@@ -22,7 +22,7 @@ App code that needs a kit rpc client SHALL obtain it from the cluster entity's a
 
 ### Requirement: Clients are memoized per URL
 
-`getRpc` MUST return the same client instance for repeated calls with the same URL, and distinct instances for distinct URLs. The returned identity MUST be stable enough to appear in a React hook dependency array without re-firing effects across renders for an unchanged URL. The cache MUST be bounded, evicting the least recently used entry once the bound is exceeded, so free-form custom endpoint URLs cannot grow it for the life of the tab; the bound MUST be generous enough that eviction never touches a URL in active use.
+`getRpc` MUST return the same client instance for repeated calls with the same URL, and distinct instances for distinct URLs. The returned identity MUST be stable enough to appear in a React hook dependency array without re-firing effects across renders for an unchanged URL. The cache MUST be bounded, evicting the oldest entry once the bound is exceeded, so free-form custom endpoint URLs cannot grow it for the life of the tab; the bound MUST be generous enough that eviction never touches a URL in active use. Looking up an already-cached URL MUST NOT mutate the cache, so the accessor is safe to call during a React render.
 
 #### Scenario: Repeated calls with one URL
 
@@ -37,5 +37,5 @@ App code that needs a kit rpc client SHALL obtain it from the cluster entity's a
 #### Scenario: A flood of one-off custom URLs
 
 - **WHEN** more distinct URLs than the cache bound are requested
-- **THEN** the least recently used clients are evicted
-- **AND** recently used clients keep their identity
+- **THEN** the oldest clients are evicted
+- **AND** clients cached within the bound keep their identity


### PR DESCRIPTION
## Description

Adds a central RPC accessor to the cluster entity so kit rpc clients are shared per endpoint instead of constructed ad-hoc (~78 scattered `createSolanaRpc(url)` sites today, no shared handle):

- `getRpc(url)` — one memoized `createSolanaRpc` client per cluster URL, referentially stable so effects can depend on it
- `useSolanaRpc()` — hook form resolving the active cluster URL via `useCluster()`
- Adopted in three existing kit call sites to establish the pattern: supply, cluster stats, vote accounts
- Openspec change `centralize-rpc-access` records the accessor contract and the web3.js-removal roadmap it anchors

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Protocol integration
-   [ ] Documentation update
-   [x] Other (please describe): refactor — foundation for the web3.js → kit migration

## Screenshots

N/A — no UI changes.

## Testing

- New colocated spec covers the per-URL memoization contract
- Full local pipeline green (Node 22): `pnpm format:ci && pnpm lint && pnpm openspec:validate && pnpm build && pnpm test:ci`

## Related Issues

Closes DEV-880

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have added tests that prove my fix/feature works
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [ ] I have updated documentation as needed
-   [ ] I have run `build:info` script to update build information
-   [ ] CI/CD checks pass on the PR
-   [ ] Screenshots included — required for protocol screens, recommended for other UI changes
-   [ ] For security-related features, I have included links to related information
