### PR TITLE
feat(inspector): support v1 transactions via a kit message bridge

### DIFF
--- a/app/components/inspector/AddressTableLookupsCard.tsx
+++ b/app/components/inspector/AddressTableLookupsCard.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import { Badge } from '@/app/components/shared/ui/badge';
 import { BaseTable } from '@/app/shared/ui/Table';
 
+export const ADDRESS_TABLE_LOOKUPS_CARD_TITLE = 'Address Table Lookup(s)';
+
 export function AddressTableLookupsCard({ message }: { message: VersionedMessage }) {
     const lookupRows = React.useMemo(() => {
         let key = 0;
@@ -33,7 +35,7 @@ export function AddressTableLookupsCard({ message }: { message: VersionedMessage
     if (message.version === 'legacy') return null;
 
     return (
-        <CollapsibleCard title="Address Table Lookup(s)">
+        <CollapsibleCard title={ADDRESS_TABLE_LOOKUPS_CARD_TITLE}>
             <BaseTable ui="dashkit" variant="card" nowrap>
                 <BaseTable.Head>
                     <BaseTable.Row>

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -508,16 +508,17 @@ export function PermalinkView({
 
     const { message, messageBytes, signatures, meta } = transaction;
     // The inspector renders a web3.js `VersionedMessage`; a v1 message gets there through a
-    // bridged view over the wire bytes.
-    let bridgedMessage: VersionedMessage | undefined;
+    // bridged view over the wire bytes, which also carries the message's resource limits so
+    // every entry path derives them from the same decode.
+    let bridged: ReturnType<typeof bridgeV1MessageBytes> | undefined;
     if (!message && transaction.version === 1) {
         try {
-            bridgedMessage = bridgeV1MessageBytes(messageBytes).message;
+            bridged = bridgeV1MessageBytes(messageBytes);
         } catch (_err) {
             // Fall through to the error card below.
         }
     }
-    const resolvedMessage = message ?? bridgedMessage;
+    const resolvedMessage = message ?? bridged?.message;
     if (!resolvedMessage) {
         return (
             <ErrorCard
@@ -534,9 +535,7 @@ export function PermalinkView({
         message: resolvedMessage,
         rawMessage: messageBytes,
         signatures,
-        ...(transaction.version === 1
-            ? { transactionConfig: transaction.transactionConfig, version: 1 as const }
-            : undefined),
+        ...(bridged ? { transactionConfig: bridged.transactionConfig, version: 1 as const } : undefined),
     };
     return <LoadedView transaction={tx} onClear={reset} showTokenBalanceChanges={showTokenBalanceChanges} />;
 }

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -29,6 +29,7 @@ import { Button } from '@/app/components/shared/ui/button';
 import { useCluster } from '@/app/providers/cluster';
 import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
 import { toBase64 } from '@/app/shared/lib/bytes';
+import { bridgeV1MessageBytes, isV1MessageBytes, type V1TransactionConfig } from '@/app/shared/lib/v1-message-bridge';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -71,6 +72,13 @@ export function vaultMessageToVersionedMessage(message: typeof VaultTransaction.
 export type TransactionData = {
     rawMessage: Uint8Array;
     message: VersionedMessage;
+    /**
+     * Set when `rawMessage` holds a v1 message. `message` is then a bridged view whose
+     * `version` getter still reports 0, so version-dependent rendering must read this field.
+     */
+    version?: 1;
+    /** Message-level resource limits; v1 only, and only when the message sets at least one. */
+    transactionConfig?: V1TransactionConfig;
     signatures?: (string | undefined)[];
     accountBalances?: {
         preBalances: number[];
@@ -188,6 +196,11 @@ function decodeUrlParams(
 
         if (buffer.length < MIN_MESSAGE_LENGTH) {
             throw new Error('message buffer is too short');
+        }
+
+        if (isV1MessageBytes(buffer)) {
+            const { message, transactionConfig } = bridgeV1MessageBytes(buffer);
+            return [{ message, rawMessage: buffer, signatures, transactionConfig, version: 1 }, params, refreshUrl];
         }
 
         const message = VersionedMessage.deserialize(buffer);
@@ -489,23 +502,36 @@ export function PermalinkView({
     }
 
     const { message, messageBytes, signatures, meta } = transaction;
-    // The inspector renders a web3.js `VersionedMessage`, which cannot represent a v1 message.
-    if (!message) {
+    // The inspector renders a web3.js `VersionedMessage`; a v1 message gets there through a
+    // bridged view over the wire bytes.
+    let bridgedMessage: VersionedMessage | undefined;
+    if (!message && transaction.version === 1) {
+        try {
+            bridgedMessage = bridgeV1MessageBytes(messageBytes).message;
+        } catch (_err) {
+            // Fall through to the error card below.
+        }
+    }
+    const resolvedMessage = message ?? bridgedMessage;
+    if (!resolvedMessage) {
         return (
             <ErrorCard
-                text={`The inspector does not yet support v${transaction.version} transactions`}
+                text={`The inspector does not support v${transaction.version} transactions`}
                 retry={reset}
                 retryText="Reset"
             />
         );
     }
 
-    const tx = {
+    const tx: TransactionData = {
         accountBalances: meta,
         compiledInnerInstructions: meta?.innerInstructions,
-        message,
+        message: resolvedMessage,
         rawMessage: messageBytes,
         signatures,
+        ...(transaction.version === 1
+            ? { transactionConfig: transaction.transactionConfig, version: 1 as const }
+            : undefined),
     };
     return <LoadedView transaction={tx} onClear={reset} showTokenBalanceChanges={showTokenBalanceChanges} />;
 }
@@ -519,7 +545,8 @@ function LoadedView({
     onClear: () => void;
     showTokenBalanceChanges: boolean;
 }) {
-    const { message, rawMessage, signatures, accountBalances, compiledInnerInstructions } = transaction;
+    const { message, rawMessage, signatures, accountBalances, compiledInnerInstructions, version, transactionConfig } =
+        transaction;
 
     const fetchAccountInfo = useFetchAccountInfo();
     React.useEffect(() => {
@@ -530,7 +557,13 @@ function LoadedView({
 
     return (
         <>
-            <OverviewCard message={message} raw={rawMessage} onClear={onClear} />
+            <OverviewCard
+                message={message}
+                raw={rawMessage}
+                onClear={onClear}
+                isV1={version === 1}
+                transactionConfig={transactionConfig}
+            />
             <SimulatorCard
                 message={message}
                 showTokenBalanceChanges={showTokenBalanceChanges}
@@ -538,7 +571,8 @@ function LoadedView({
             />
             {signatures && <TransactionSignatures message={message} signatures={signatures} rawMessage={rawMessage} />}
             <AccountsCard message={message} />
-            <AddressTableLookupsCard message={message} />
+            {/* A v1 message carries static accounts only, so there are no lookups to render. */}
+            {version !== 1 && <AddressTableLookupsCard message={message} />}
             <InstructionsSection message={message} compiledInnerInstructions={compiledInnerInstructions} />
         </>
     );
@@ -553,11 +587,15 @@ function OverviewCard({
     raw,
     onClear,
     signature,
+    isV1,
+    transactionConfig,
 }: {
     message: VersionedMessage;
     raw: Uint8Array;
     onClear: () => void;
     signature?: string;
+    isV1?: boolean;
+    transactionConfig?: V1TransactionConfig;
 }) {
     const fee = message.header.numRequiredSignatures * DEFAULT_FEES.lamportsPerSignature;
     const feePayerValidator = createFeePayerValidator(fee);
@@ -606,6 +644,45 @@ function OverviewCard({
                             </div>
                         </BaseTable.Cell>
                     </BaseTable.Row>
+
+                    {isV1 && (
+                        <BaseTable.Row>
+                            <BaseTable.Cell>Transaction Version</BaseTable.Cell>
+                            <BaseTable.Cell className="text-right uppercase">v1</BaseTable.Cell>
+                        </BaseTable.Row>
+                    )}
+                    {transactionConfig?.computeUnitLimit !== undefined && (
+                        <BaseTable.Row>
+                            <BaseTable.Cell>Compute unit limit</BaseTable.Cell>
+                            <BaseTable.Cell className="text-right">
+                                {transactionConfig.computeUnitLimit.toLocaleString('en-US')}
+                            </BaseTable.Cell>
+                        </BaseTable.Row>
+                    )}
+                    {transactionConfig?.priorityFeeLamports !== undefined && (
+                        <BaseTable.Row>
+                            <BaseTable.Cell>Priority fee (total)</BaseTable.Cell>
+                            <BaseTable.Cell className="text-right">
+                                <SolBalance lamports={transactionConfig.priorityFeeLamports} />
+                            </BaseTable.Cell>
+                        </BaseTable.Row>
+                    )}
+                    {transactionConfig?.loadedAccountsDataSizeLimit !== undefined && (
+                        <BaseTable.Row>
+                            <BaseTable.Cell>Loaded accounts data size limit</BaseTable.Cell>
+                            <BaseTable.Cell className="text-right">
+                                {transactionConfig.loadedAccountsDataSizeLimit.toLocaleString('en-US')}
+                            </BaseTable.Cell>
+                        </BaseTable.Row>
+                    )}
+                    {transactionConfig?.heapSize !== undefined && (
+                        <BaseTable.Row>
+                            <BaseTable.Cell>Heap size</BaseTable.Cell>
+                            <BaseTable.Cell className="text-right">
+                                {transactionConfig.heapSize.toLocaleString('en-US')}
+                            </BaseTable.Cell>
+                        </BaseTable.Row>
+                    )}
 
                     <BaseTable.Row>
                         <BaseTable.Cell>

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -29,7 +29,12 @@ import { Button } from '@/app/components/shared/ui/button';
 import { useCluster } from '@/app/providers/cluster';
 import { DownloadDropdown } from '@/app/shared/components/DownloadDropdown';
 import { toBase64 } from '@/app/shared/lib/bytes';
-import { bridgeV1MessageBytes, isV1MessageBytes, type V1TransactionConfig } from '@/app/shared/lib/v1-message-bridge';
+import {
+    bridgeV1MessageBytes,
+    isV1MessageBytes,
+    V1_TRANSACTION_SIZE_LIMIT,
+    type V1TransactionConfig,
+} from '@/app/shared/lib/v1-message-bridge';
 import { Card, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { PageContainer } from '@/app/shared/ui/page-container/PageContainer';
 import { BaseTable } from '@/app/shared/ui/Table';
@@ -600,10 +605,12 @@ function OverviewCard({
     const fee = message.header.numRequiredSignatures * DEFAULT_FEES.lamportsPerSignature;
     const feePayerValidator = createFeePayerValidator(fee);
 
+    // The v1 wire envelope has no signature-count byte — the count is read from the message header.
     const size = React.useMemo(() => {
-        const sigBytes = 1 + 64 * message.header.numRequiredSignatures;
+        const sigBytes = (isV1 ? 0 : 1) + 64 * message.header.numRequiredSignatures;
         return sigBytes + raw.length;
-    }, [message, raw]);
+    }, [message, raw, isV1]);
+    const sizeLimit = isV1 ? V1_TRANSACTION_SIZE_LIMIT : PACKET_DATA_SIZE;
 
     return (
         <>
@@ -623,12 +630,8 @@ function OverviewCard({
                         <BaseTable.Cell className="text-right">
                             <div className="flex flex-col items-end">
                                 {size} bytes
-                                <span
-                                    className={
-                                        size <= PACKET_DATA_SIZE ? 'text-dk-gray-700' : 'text-dk-warning-on-dark'
-                                    }
-                                >
-                                    Max transaction size is {PACKET_DATA_SIZE} bytes
+                                <span className={size <= sizeLimit ? 'text-dk-gray-700' : 'text-dk-warning-on-dark'}>
+                                    Max transaction size is {sizeLimit} bytes
                                 </span>
                             </div>
                         </BaseTable.Cell>

--- a/app/components/inspector/InspectorPage.tsx
+++ b/app/components/inspector/InspectorPage.tsx
@@ -498,6 +498,21 @@ export function PermalinkView({
         }
     }, [transaction, fetchConfirmedTx, status]);
 
+    // The inspector renders a web3.js `VersionedMessage`; a v1 message gets there through a
+    // bridged view over the wire bytes, which also carries the message's resource limits so
+    // every entry path derives them from the same decode. The view is memoized because its
+    // identity keys the downstream account-fetching effects and memos.
+    const bridged = React.useMemo(() => {
+        if (!transaction || transaction.message || transaction.version !== 1) {
+            return undefined;
+        }
+        try {
+            return bridgeV1MessageBytes(transaction.messageBytes);
+        } catch {
+            return undefined;
+        }
+    }, [transaction]);
+
     if (!details || details.status === FetchStatus.Fetching) {
         return <LoadingCard />;
     } else if (details.status === FetchStatus.FetchFailed) {
@@ -507,17 +522,6 @@ export function PermalinkView({
     }
 
     const { message, messageBytes, signatures, meta } = transaction;
-    // The inspector renders a web3.js `VersionedMessage`; a v1 message gets there through a
-    // bridged view over the wire bytes, which also carries the message's resource limits so
-    // every entry path derives them from the same decode.
-    let bridged: ReturnType<typeof bridgeV1MessageBytes> | undefined;
-    if (!message && transaction.version === 1) {
-        try {
-            bridged = bridgeV1MessageBytes(messageBytes);
-        } catch (_err) {
-            // Fall through to the error card below.
-        }
-    }
     const resolvedMessage = message ?? bridged?.message;
     if (!resolvedMessage) {
         return (

--- a/app/components/inspector/RawInputCard.tsx
+++ b/app/components/inspector/RawInputCard.tsx
@@ -7,20 +7,27 @@ import { AlertCircle } from 'react-feather';
 import { Button } from '@/app/components/shared/ui/button';
 import { Logger } from '@/app/shared/lib/logger';
 import { MIN_MESSAGE_LENGTH, parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
+import { bridgeV1MessageBytes, isV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
 import { Card, CardBody, CardFooter, CardHeader, CardTitle } from '@/app/shared/ui/Card';
 import { FormControl } from '@/app/shared/ui/FormControl';
 import { TabsContent, TabsList, TabsTrigger } from '@/app/shared/ui/Tabs';
 
-import type { InspectorData } from './InspectorPage';
+import type { InspectorData, TransactionData } from './InspectorPage';
 
 export { MIN_MESSAGE_LENGTH };
 
-function getTransactionDataFromUserSuppliedBytes(bytes: Uint8Array): {
-    message: VersionedMessage;
-    rawMessage: Uint8Array;
-    signatures?: (string | undefined)[];
-} {
+function getTransactionDataFromUserSuppliedBytes(bytes: Uint8Array): TransactionData {
     const { messageBytes, signatures } = parseTransactionBytes(bytes);
+    if (isV1MessageBytes(messageBytes)) {
+        const { message, transactionConfig } = bridgeV1MessageBytes(messageBytes);
+        return {
+            message,
+            rawMessage: messageBytes,
+            transactionConfig,
+            version: 1,
+            ...(signatures ? { signatures } : undefined),
+        };
+    }
     const message = VersionedMessage.deserialize(messageBytes);
     return {
         message,

--- a/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
+++ b/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
@@ -12,6 +12,7 @@ import { toBase64 } from '@/app/shared/lib/bytes';
 import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
 import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
 
+import { ADDRESS_TABLE_LOOKUPS_CARD_TITLE } from '../AddressTableLookupsCard';
 import { TransactionInspectorPage } from '../InspectorPage';
 
 vi.mock('next/navigation', () => ({
@@ -71,7 +72,9 @@ describe('TransactionInspectorPage with a v1 ?message= param', () => {
         expect(screen.getByText('Priority fee (total)')).toBeInTheDocument();
         // fee payer, recipient, program
         expect(screen.getByText('Account List (3)')).toBeInTheDocument();
-        // v1 messages carry static accounts only, so the lookups card is not rendered.
-        expect(screen.queryByText('Address Table Lookups')).toBeNull();
+        // v1 messages carry static accounts only, so neither the lookups card nor the
+        // lookup-derived account badges appear.
+        expect(screen.queryByText(ADDRESS_TABLE_LOOKUPS_CARD_TITLE)).toBeNull();
+        expect(screen.queryByText('Address Table Lookup')).toBeNull();
     });
 });

--- a/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
+++ b/app/components/inspector/__tests__/InspectorPage-V1.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { InstructionParserProvider } from '@/app/entities/instruction-parser';
+import { createV1TransactionBytes } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
+import { AccountsProvider } from '@/app/providers/accounts';
+import { ClusterProvider } from '@/app/providers/cluster';
+import { ScrollAnchorProvider } from '@/app/providers/scroll-anchor';
+import { toBase64 } from '@/app/shared/lib/bytes';
+import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
+import { instructionParserDispatcher } from '@/app/tx/instruction-parser-dispatcher';
+
+import { TransactionInspectorPage } from '../InspectorPage';
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn(() => '/tx/inspector'),
+    useRouter: vi.fn(),
+    useSearchParams: vi.fn(),
+}));
+
+describe('TransactionInspectorPage with a v1 ?message= param', () => {
+    beforeEach(async () => {
+        const { messageBytes } = parseTransactionBytes(
+            createV1TransactionBytes({ computeUnitLimit: 300_000, priorityFeeLamports: 50n }),
+        );
+        const params = new URLSearchParams();
+        params.set('message', encodeURIComponent(toBase64(messageBytes)));
+
+        vi.spyOn(await import('next/navigation'), 'useSearchParams').mockReturnValue(
+            params as unknown as ReturnType<typeof useSearchParams>,
+        );
+        vi.spyOn(await import('next/navigation'), 'useRouter').mockReturnValue({
+            push: vi.fn(),
+            replace: vi.fn(),
+        } as unknown as ReturnType<typeof useRouter>);
+
+        global.fetch = vi.fn().mockImplementation(() =>
+            Promise.resolve(
+                new Response(JSON.stringify({}), {
+                    headers: { 'Content-Type': 'application/json' },
+                    status: 200,
+                }),
+            ),
+        );
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('should render the transaction with its resource-limit rows', async () => {
+        render(
+            <ScrollAnchorProvider>
+                <ClusterProvider>
+                    <AccountsProvider>
+                        <InstructionParserProvider dispatcher={instructionParserDispatcher}>
+                            <TransactionInspectorPage showTokenBalanceChanges={false} />
+                        </InstructionParserProvider>
+                    </AccountsProvider>
+                </ClusterProvider>
+            </ScrollAnchorProvider>,
+        );
+
+        expect(await screen.findByText('Transaction Overview')).toBeInTheDocument();
+        expect(screen.queryByText('Inspector Input')).toBeNull();
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.getByText('Compute unit limit')).toBeInTheDocument();
+        expect(screen.getByText('300,000')).toBeInTheDocument();
+        expect(screen.getByText('Priority fee (total)')).toBeInTheDocument();
+        // fee payer, recipient, program
+        expect(screen.getByText('Account List (3)')).toBeInTheDocument();
+        // v1 messages carry static accounts only, so the lookups card is not rendered.
+        expect(screen.queryByText('Address Table Lookups')).toBeNull();
+    });
+});

--- a/app/components/inspector/__tests__/PermalinkView.spec.tsx
+++ b/app/components/inspector/__tests__/PermalinkView.spec.tsx
@@ -98,10 +98,11 @@ describe('PermalinkView', () => {
         const { messageBytes } = parseTransactionBytes(
             createV1TransactionBytes({ computeUnitLimit: 300_000, priorityFeeLamports: 50n }),
         );
+        // No transactionConfig on the cache entry: the rows must come from decoding messageBytes,
+        // the same source every other entry path uses.
         cacheEntry = makeEntry({
             messageBytes,
             signatures: [],
-            transactionConfig: { computeUnitLimit: 300_000, priorityFeeLamports: 50n },
             version: 1,
         });
 

--- a/app/components/inspector/__tests__/PermalinkView.spec.tsx
+++ b/app/components/inspector/__tests__/PermalinkView.spec.tsx
@@ -3,6 +3,9 @@ import { render, screen } from '@testing-library/react';
 import { ClusterStatus } from '@utils/cluster';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createV1TransactionBytes } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
+import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
+
 import { PermalinkView } from '../InspectorPage';
 
 const fetchTransaction = vi.fn();
@@ -23,6 +26,30 @@ vi.mock('next/navigation', () => ({
     usePathname: () => '/tx/inspector',
     useRouter: () => ({ push: vi.fn() }),
     useSearchParams: () => new URLSearchParams(),
+}));
+// The v1 tests render LoadedView; stub its data-fetching children so the overview card —
+// the part under test — renders without providers.
+vi.mock('@providers/accounts', () => ({
+    useFetchAccountInfo: () => vi.fn(),
+}));
+vi.mock('@features/instruction-simulation', () => ({
+    SimulatorCard: () => <div data-testid="simulator-card" />,
+}));
+vi.mock('../AccountsCard', () => ({
+    AccountsCard: () => <div data-testid="accounts-card" />,
+}));
+vi.mock('../AddressTableLookupsCard', () => ({
+    AddressTableLookupsCard: () => <div data-testid="atl-card" />,
+}));
+vi.mock('../InstructionsSection', () => ({
+    InstructionsSection: () => <div data-testid="instructions-section" />,
+}));
+vi.mock('../SignaturesCard', () => ({
+    TransactionSignatures: () => <div data-testid="signatures-card" />,
+}));
+vi.mock('../AddressWithContext', () => ({
+    AddressWithContext: () => <div />,
+    createFeePayerValidator: () => () => undefined,
 }));
 
 // Minimal stand-in for a decoded raw tx; only the fields PermalinkView reads.
@@ -65,5 +92,41 @@ describe('PermalinkView', () => {
         cacheEntry = makeEntry(undefined, FetchStatus.FetchFailed);
         renderView();
         expect(screen.getByText('Failed to fetch transaction')).toBeInTheDocument();
+    });
+
+    it('should render a v1 transaction with its resource-limit rows', () => {
+        const { messageBytes } = parseTransactionBytes(
+            createV1TransactionBytes({ computeUnitLimit: 300_000, priorityFeeLamports: 50n }),
+        );
+        cacheEntry = makeEntry({
+            messageBytes,
+            signatures: [],
+            transactionConfig: { computeUnitLimit: 300_000, priorityFeeLamports: 50n },
+            version: 1,
+        });
+
+        renderView();
+
+        expect(screen.queryByText('The inspector does not support v1 transactions')).not.toBeInTheDocument();
+        expect(screen.getByText('Transaction Overview')).toBeInTheDocument();
+        expect(screen.getByText('v1')).toBeInTheDocument();
+        expect(screen.getByText('Compute unit limit')).toBeInTheDocument();
+        expect(screen.getByText('300,000')).toBeInTheDocument();
+        expect(screen.getByText('Priority fee (total)')).toBeInTheDocument();
+        expect(screen.getByTestId('instructions-section')).toBeInTheDocument();
+        // v1 messages carry static accounts only, so the lookups card is not rendered.
+        expect(screen.queryByTestId('atl-card')).not.toBeInTheDocument();
+    });
+
+    it('should keep the error card when v1 bytes cannot be decoded', () => {
+        cacheEntry = makeEntry({
+            messageBytes: new Uint8Array([0x81, 1, 2, 3]),
+            signatures: [],
+            version: 1,
+        });
+
+        renderView();
+
+        expect(screen.getByText('The inspector does not support v1 transactions')).toBeInTheDocument();
     });
 });

--- a/app/entities/transaction-data/api/fetch-raw-transaction.ts
+++ b/app/entities/transaction-data/api/fetch-raw-transaction.ts
@@ -1,9 +1,6 @@
 import {
-    type CompiledTransactionMessage,
-    type CompiledTransactionMessageWithLifetime,
     createSolanaRpc,
     decodeTransactionFromRpcResponse,
-    decompileTransactionMessage,
     getBase58Decoder,
     MAX_SUPPORTED_TRANSACTION_VERSION,
     signature as createSignature,
@@ -11,9 +8,9 @@ import {
 } from '@solana/kit';
 import { type DecompileArgs, type Finality, PublicKey, TransactionMessage, VersionedMessage } from '@solana/web3.js';
 
-import { Logger } from '@/app/shared/lib/logger';
+import { readV1TransactionConfig } from '@/app/shared/lib/v1-message-bridge';
 
-import type { RawTransaction, TransactionConfig } from '../model/types';
+import type { RawTransaction } from '../model/types';
 
 /**
  * Fetches a transaction's wire bytes and metadata for the inspector and the download button.
@@ -69,7 +66,11 @@ export async function fetchRawTransaction(
     };
 
     if (compiledMessage.version === 1) {
-        return { ...base, transactionConfig: readTransactionConfig(compiledMessage, signature), version: 1 };
+        return {
+            ...base,
+            transactionConfig: readV1TransactionConfig(compiledMessage, { module: '[transaction-data]', signature }),
+            version: 1,
+        };
     }
 
     return {
@@ -77,23 +78,6 @@ export async function fetchRawTransaction(
         ...decodeWithWeb3(messageBytes, meta?.loadedAddresses),
         version: compiledMessage.version,
     };
-}
-
-// The resource-limit rows are supplemental; the wire bytes still render, download, and inspect
-// without them.
-function readTransactionConfig(
-    compiledMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime & { version: 1 },
-    signature: string,
-): TransactionConfig | undefined {
-    try {
-        const { config } = decompileTransactionMessage(compiledMessage);
-
-        // A v1 message may set no limits at all, in which case there are no rows to render.
-        return config && Object.values(config).some(value => value !== undefined) ? config : undefined;
-    } catch (error) {
-        Logger.error(error, { module: '[transaction-data]', signature });
-        return undefined;
-    }
 }
 
 /**

--- a/app/entities/transaction-data/model/types.ts
+++ b/app/entities/transaction-data/model/types.ts
@@ -1,4 +1,4 @@
-import type { TransactionMessage as KitTransactionMessage, TransactionVersion } from '@solana/kit';
+import type { TransactionVersion } from '@solana/kit';
 import type {
     CompiledInnerInstruction,
     ParsedTransactionWithMeta,
@@ -6,16 +6,15 @@ import type {
     VersionedMessage,
 } from '@solana/web3.js';
 
+import type { V1TransactionConfig } from '@/app/shared/lib/v1-message-bridge';
+
 /**
  * Message-level resource limits carried by a v1 transaction.
  *
  * v1 moves these out of Compute Budget instructions and into the message itself. `priorityFee`
  * is a total amount in lamports, unlike v0's per-compute-unit price in micro-lamports.
- *
- * kit models this as `V1TransactionConfig` but does not export that type by name, so it is read
- * off the v1 arm of kit's `TransactionMessage` to stay in step with kit's definition.
  */
-export type TransactionConfig = NonNullable<Extract<KitTransactionMessage, { version: 1 }>['config']>;
+export type TransactionConfig = V1TransactionConfig;
 
 /**
  * A parsed transaction in the shape the transaction detail page consumes.

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -11,6 +11,8 @@ import { VersionedTransaction } from '@solana/web3.js';
 import type { Cluster } from '@utils/cluster';
 import { type InstructionLogs, parseProgramLogs } from '@utils/program-logs';
 
+import { UnsignedV1WireTransaction, V1MessageView } from '@/app/shared/lib/v1-message-bridge';
+
 import { buildTokenBalances, type TokenBalanceData } from './build-token-balances';
 import { computeSolBalanceChanges } from './compute-sol-balance-changes';
 import { getMintDecimals } from './get-mint-decimals';
@@ -72,7 +74,11 @@ async function runSimulation(connection: Connection, message: VersionedMessage):
         connection.getEpochInfo(),
     ]);
 
-    const { value: simResult } = await connection.simulateTransaction(new VersionedTransaction(message), {
+    // A v1 message must be sent in the v1 wire envelope (message first); the stock
+    // VersionedTransaction envelope is signatures-first and nodes reject it for v1.
+    const transaction =
+        message instanceof V1MessageView ? new UnsignedV1WireTransaction(message) : new VersionedTransaction(message);
+    const { value: simResult } = await connection.simulateTransaction(transaction, {
         accounts: {
             addresses: accountKeys.map(key => key.toBase58()),
             encoding: 'base64',

--- a/app/shared/lib/__tests__/v1-message-bridge.spec.ts
+++ b/app/shared/lib/__tests__/v1-message-bridge.spec.ts
@@ -1,0 +1,93 @@
+import { getTransactionDecoder } from '@solana/kit';
+import { PublicKey, VersionedMessage, VersionedTransaction } from '@solana/web3.js';
+import { describe, expect, it } from 'vitest';
+
+import {
+    createV1TransactionBytes,
+    createWeb3TransactionBytes,
+    FEE_PAYER,
+    RECIPIENT,
+} from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
+
+import { parseTransactionBytes } from '../parse-transaction-bytes';
+import { bridgeV1MessageBytes, isV1MessageBytes, V1MessageView } from '../v1-message-bridge';
+
+function v1MessageBytes(config: Parameters<typeof createV1TransactionBytes>[0] = {}): Uint8Array {
+    return parseTransactionBytes(createV1TransactionBytes(config)).messageBytes;
+}
+
+describe('isV1MessageBytes', () => {
+    it('should identify v1 message bytes', () => {
+        expect(isV1MessageBytes(v1MessageBytes())).toBe(true);
+    });
+
+    it.each([['legacy'], [0]] as const)('should reject %s message bytes', version => {
+        const { messageBytes } = parseTransactionBytes(createWeb3TransactionBytes(version));
+        expect(isV1MessageBytes(messageBytes)).toBe(false);
+    });
+
+    it('should reject empty input', () => {
+        expect(isV1MessageBytes(new Uint8Array(0))).toBe(false);
+    });
+});
+
+describe('bridgeV1MessageBytes', () => {
+    it('should map the compiled message onto the web3.js view', () => {
+        const { message } = bridgeV1MessageBytes(v1MessageBytes());
+
+        // fee payer, recipient, then the instruction's program address
+        expect(message.staticAccountKeys).toHaveLength(3);
+        expect(message.staticAccountKeys.slice(0, 2).map(key => key.toBase58())).toEqual([FEE_PAYER, RECIPIENT]);
+        expect(message.header.numRequiredSignatures).toBe(1);
+        expect(message.addressTableLookups).toEqual([]);
+        expect(message.compiledInstructions).toHaveLength(1);
+        expect(message.compiledInstructions[0].data).toEqual(new Uint8Array([1]));
+        expect(message.staticAccountKeys[0]).toBeInstanceOf(PublicKey);
+    });
+
+    it('should serialize back to the original v1 bytes, not a v0 re-encoding', () => {
+        const messageBytes = v1MessageBytes({ computeUnitLimit: 300_000 });
+        const { message } = bridgeV1MessageBytes(messageBytes);
+
+        expect(message.serialize()).toEqual(messageBytes);
+    });
+
+    it('should produce a byte-exact unsigned v1 wire transaction through VersionedTransaction', () => {
+        const messageBytes = v1MessageBytes({ computeUnitLimit: 300_000 });
+        const { message } = bridgeV1MessageBytes(messageBytes);
+
+        const wireBytes = new VersionedTransaction(message).serialize();
+
+        const decoded = getTransactionDecoder().decode(wireBytes);
+        expect(new Uint8Array(decoded.messageBytes)).toEqual(messageBytes);
+        expect(Object.values(decoded.signatures)).toHaveLength(1);
+    });
+
+    it('should extract the resource limits the message sets', () => {
+        const { transactionConfig } = bridgeV1MessageBytes(
+            v1MessageBytes({ computeUnitLimit: 300_000, priorityFeeLamports: 50n }),
+        );
+
+        expect(transactionConfig).toEqual({ computeUnitLimit: 300_000, priorityFeeLamports: 50n });
+    });
+
+    it('should return no config when the message sets no limits', () => {
+        expect(bridgeV1MessageBytes(v1MessageBytes()).transactionConfig).toBeUndefined();
+    });
+
+    it('should throw on non-v1 message bytes', () => {
+        const { messageBytes } = parseTransactionBytes(createWeb3TransactionBytes(0));
+        expect(() => bridgeV1MessageBytes(messageBytes)).toThrow();
+    });
+
+    it('should return a V1MessageView so the true bytes survive any serialize call', () => {
+        const { message } = bridgeV1MessageBytes(v1MessageBytes());
+        expect(message).toBeInstanceOf(V1MessageView);
+    });
+});
+
+describe('web3.js v1 behavior the bridge exists for', () => {
+    it('should throw from VersionedMessage.deserialize on v1 bytes', () => {
+        expect(() => VersionedMessage.deserialize(v1MessageBytes())).toThrow();
+    });
+});

--- a/app/shared/lib/__tests__/v1-message-bridge.spec.ts
+++ b/app/shared/lib/__tests__/v1-message-bridge.spec.ts
@@ -95,6 +95,18 @@ describe('bridgeV1MessageBytes', () => {
         expect(() => bridgeV1MessageBytes(messageBytes)).toThrow();
     });
 
+    it('should throw on a full v1 wire transaction rather than treating the signatures as message bytes', () => {
+        expect(() => bridgeV1MessageBytes(createV1TransactionBytes({}))).toThrow();
+    });
+
+    it('should throw on message bytes with trailing junk', () => {
+        const messageBytes = v1MessageBytes();
+        const padded = new Uint8Array(messageBytes.length + 3);
+        padded.set(messageBytes);
+
+        expect(() => bridgeV1MessageBytes(padded)).toThrow();
+    });
+
     it('should return a V1MessageView so the true bytes survive any serialize call', () => {
         const { message } = bridgeV1MessageBytes(v1MessageBytes());
         expect(message).toBeInstanceOf(V1MessageView);

--- a/app/shared/lib/__tests__/v1-message-bridge.spec.ts
+++ b/app/shared/lib/__tests__/v1-message-bridge.spec.ts
@@ -1,5 +1,5 @@
 import { getTransactionDecoder } from '@solana/kit';
-import { PublicKey, VersionedMessage, VersionedTransaction } from '@solana/web3.js';
+import { PublicKey, VersionedMessage } from '@solana/web3.js';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -10,7 +10,7 @@ import {
 } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
 
 import { parseTransactionBytes } from '../parse-transaction-bytes';
-import { bridgeV1MessageBytes, isV1MessageBytes, V1MessageView } from '../v1-message-bridge';
+import { bridgeV1MessageBytes, isV1MessageBytes, UnsignedV1WireTransaction, V1MessageView } from '../v1-message-bridge';
 
 function v1MessageBytes(config: Parameters<typeof createV1TransactionBytes>[0] = {}): Uint8Array {
     return parseTransactionBytes(createV1TransactionBytes(config)).messageBytes;
@@ -52,15 +52,30 @@ describe('bridgeV1MessageBytes', () => {
         expect(message.serialize()).toEqual(messageBytes);
     });
 
-    it('should produce a byte-exact unsigned v1 wire transaction through VersionedTransaction', () => {
+    it('should produce a message-first unsigned v1 wire transaction', () => {
         const messageBytes = v1MessageBytes({ computeUnitLimit: 300_000 });
         const { message } = bridgeV1MessageBytes(messageBytes);
 
-        const wireBytes = new VersionedTransaction(message).serialize();
+        const wireBytes = new UnsignedV1WireTransaction(message).serialize();
+
+        // The v1 envelope is [message][signatures] with no count prefix: nodes route on the
+        // version-flagged first byte, so anything else is rejected as an invalid message version.
+        expect(wireBytes[0]).toBe(0x81);
+        expect(wireBytes.slice(0, messageBytes.length)).toEqual(messageBytes);
+        expect(wireBytes).toHaveLength(messageBytes.length + 64);
+        expect(wireBytes.slice(messageBytes.length)).toEqual(new Uint8Array(64));
 
         const decoded = getTransactionDecoder().decode(wireBytes);
         expect(new Uint8Array(decoded.messageBytes)).toEqual(messageBytes);
         expect(Object.values(decoded.signatures)).toHaveLength(1);
+    });
+
+    it('should match the wire bytes kit itself encodes for the same unsigned transaction', () => {
+        const fixtureWireBytes = createV1TransactionBytes({ computeUnitLimit: 300_000 });
+        const { messageBytes } = parseTransactionBytes(fixtureWireBytes);
+        const { message } = bridgeV1MessageBytes(messageBytes);
+
+        expect(new UnsignedV1WireTransaction(message).serialize()).toEqual(fixtureWireBytes);
     });
 
     it('should extract the resource limits the message sets', () => {

--- a/app/shared/lib/v1-message-bridge.ts
+++ b/app/shared/lib/v1-message-bridge.ts
@@ -1,11 +1,14 @@
 import {
+    address,
     type CompiledTransactionMessage,
     type CompiledTransactionMessageWithLifetime,
     decompileTransactionMessage,
     getCompiledTransactionMessageDecoder,
+    getTransactionEncoder,
+    type Transaction,
     type TransactionMessage as KitTransactionMessage,
 } from '@solana/kit';
-import { MessageV0, PublicKey } from '@solana/web3.js';
+import { MessageV0, PublicKey, VersionedTransaction } from '@solana/web3.js';
 
 import { Logger } from '@/app/shared/lib/logger';
 
@@ -91,6 +94,48 @@ export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
     );
 
     return { message, transactionConfig: readTransactionConfig(compiled) };
+}
+
+/**
+ * The maximum size of a v1 transaction in bytes. kit defines the same constant but
+ * intentionally does not export it.
+ */
+export const V1_TRANSACTION_SIZE_LIMIT = 4096;
+
+/**
+ * A `VersionedTransaction` over a bridged v1 message whose `serialize()` emits the v1 wire
+ * envelope.
+ *
+ * v1 reorders the transaction envelope: the message comes first, followed by the signatures
+ * with no count prefix — the count is read from the message header. The inherited
+ * `serialize()` would wrap the message in the legacy signatures-first envelope, which a
+ * v1-aware node rejects as an invalid message version, so this encodes through kit's
+ * transaction encoder instead. Signatures are zero-filled, which is sufficient for
+ * simulation.
+ */
+export class UnsignedV1WireTransaction extends VersionedTransaction {
+    private readonly view: V1MessageView;
+
+    constructor(message: V1MessageView) {
+        super(message);
+        this.view = message;
+    }
+
+    override serialize(): Uint8Array {
+        const signatures = Object.fromEntries(
+            this.view.staticAccountKeys
+                .slice(0, this.view.header.numRequiredSignatures)
+                // eslint-disable-next-line unicorn/no-null -- kit encodes a null signature as a zero-filled slot
+                .map(key => [address(key.toBase58()), null]),
+        ) as Transaction['signatures'];
+
+        return new Uint8Array(
+            getTransactionEncoder().encode({
+                messageBytes: this.view.serialize() as unknown as Transaction['messageBytes'],
+                signatures,
+            }),
+        );
+    }
 }
 
 function readTransactionConfig(

--- a/app/shared/lib/v1-message-bridge.ts
+++ b/app/shared/lib/v1-message-bridge.ts
@@ -1,9 +1,11 @@
 import {
     address,
+    bytesEqual,
     type CompiledTransactionMessage,
     type CompiledTransactionMessageWithLifetime,
     decompileTransactionMessage,
     getCompiledTransactionMessageDecoder,
+    getCompiledTransactionMessageEncoder,
     getTransactionEncoder,
     type Transaction,
     type TransactionMessage as KitTransactionMessage,
@@ -72,6 +74,15 @@ export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
     const compiled = getCompiledTransactionMessageDecoder().decode(messageBytes);
     if (compiled.version !== 1) {
         throw new Error(`Expected a v1 transaction message, got version ${compiled.version}`);
+    }
+
+    // The decoder stops at the end of the message and ignores anything after it, so a full v1
+    // wire transaction — message followed by signatures — decodes as if it were a bare message.
+    // Re-encoding canonically catches that: the trailing bytes are dropped on re-encode. Without
+    // this the signatures would be counted as part of the message and every consumer of the raw
+    // bytes (size, signature verification, simulation) would be wrong.
+    if (!bytesEqual(getCompiledTransactionMessageEncoder().encode(compiled), messageBytes)) {
+        throw new Error('v1 transaction message bytes are not a canonical compiled message');
     }
 
     const message = new V1MessageView(

--- a/app/shared/lib/v1-message-bridge.ts
+++ b/app/shared/lib/v1-message-bridge.ts
@@ -104,7 +104,7 @@ export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
         messageBytes,
     );
 
-    return { message, transactionConfig: readTransactionConfig(compiled) };
+    return { message, transactionConfig: readV1TransactionConfig(compiled) };
 }
 
 /**
@@ -149,14 +149,23 @@ export class UnsignedV1WireTransaction extends VersionedTransaction {
     }
 }
 
-function readTransactionConfig(
+/**
+ * Reads the message-level resource limits off a v1 compiled message.
+ *
+ * Returns `undefined` when the message sets no limits at all, so callers have no rows to render.
+ * The limits are supplemental — the wire bytes still render, download, and inspect without them —
+ * so a failure to decompile is logged and reported as absent rather than thrown. `logContext`
+ * carries the caller's module tag and any identifying fields into that log line.
+ */
+export function readV1TransactionConfig(
     compiled: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime & { version: 1 },
+    logContext: Record<string, unknown> = { module: '[v1-message-bridge]' },
 ): V1TransactionConfig | undefined {
     try {
         const { config } = decompileTransactionMessage(compiled);
         return config && Object.values(config).some(value => value !== undefined) ? config : undefined;
     } catch (error) {
-        Logger.error(error, { module: '[v1-message-bridge]' });
+        Logger.error(error, logContext);
         return undefined;
     }
 }

--- a/app/shared/lib/v1-message-bridge.ts
+++ b/app/shared/lib/v1-message-bridge.ts
@@ -1,0 +1,106 @@
+import {
+    type CompiledTransactionMessage,
+    type CompiledTransactionMessageWithLifetime,
+    decompileTransactionMessage,
+    getCompiledTransactionMessageDecoder,
+    type TransactionMessage as KitTransactionMessage,
+} from '@solana/kit';
+import { MessageV0, PublicKey } from '@solana/web3.js';
+
+import { Logger } from '@/app/shared/lib/logger';
+
+/**
+ * Message-level resource limits carried by a v1 transaction.
+ *
+ * kit models this as `V1TransactionConfig` but does not export that type by name, so it is read
+ * off the v1 arm of kit's `TransactionMessage` to stay in step with kit's definition.
+ */
+export type V1TransactionConfig = NonNullable<Extract<KitTransactionMessage, { version: 1 }>['config']>;
+
+/**
+ * The wire version prefix of a v1 transaction message: the version flag bit (0x80) with
+ * version number 1. Legacy messages never set the flag bit, and a v0 message's first byte
+ * is 0x80, so this single byte identifies v1 unambiguously.
+ */
+const V1_MESSAGE_PREFIX = 0x81;
+
+export function isV1MessageBytes(bytes: Uint8Array): boolean {
+    return bytes.length > 0 && bytes[0] === V1_MESSAGE_PREFIX;
+}
+
+/**
+ * A web3.js view of a v1 compiled message.
+ *
+ * A v1 message is structurally a v0 message without address table lookups plus a config
+ * section, so every field web3.js consumers read — header, static keys, instructions —
+ * maps losslessly onto `MessageV0`. The one thing that cannot be synthesized is the wire
+ * encoding: re-serializing through `MessageV0` would emit v0 bytes that are not the real
+ * transaction. `serialize()` therefore returns the original v1 bytes, so signature
+ * verification, simulation (`new VersionedTransaction(message)`), and cache fingerprints
+ * all operate on the bytes the network sees.
+ *
+ * The inherited `version` getter still reports `0`; carry the true version alongside this
+ * object rather than reading it off the message.
+ */
+export class V1MessageView extends MessageV0 {
+    private readonly rawV1Bytes: Uint8Array;
+
+    constructor(args: ConstructorParameters<typeof MessageV0>[0], rawV1Bytes: Uint8Array) {
+        super(args);
+        this.rawV1Bytes = rawV1Bytes;
+    }
+
+    override serialize(): Uint8Array {
+        return this.rawV1Bytes;
+    }
+}
+
+/**
+ * Decodes v1 transaction message bytes into a web3.js-compatible view plus the message-level
+ * resource limits, when any are set.
+ *
+ * Throws if the bytes are not a valid v1 compiled message. The config is supplemental: if it
+ * cannot be decompiled the message still renders, so that failure is logged rather than thrown.
+ */
+export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
+    message: V1MessageView;
+    transactionConfig?: V1TransactionConfig;
+} {
+    const compiled = getCompiledTransactionMessageDecoder().decode(messageBytes);
+    if (compiled.version !== 1) {
+        throw new Error(`Expected a v1 transaction message, got version ${compiled.version}`);
+    }
+
+    const message = new V1MessageView(
+        {
+            addressTableLookups: [],
+            compiledInstructions: compiled.instructionHeaders.map((header, i) => ({
+                accountKeyIndexes: [...compiled.instructionPayloads[i].instructionAccountIndices],
+                data: new Uint8Array(compiled.instructionPayloads[i].instructionData),
+                programIdIndex: header.programAccountIndex,
+            })),
+            header: {
+                numReadonlySignedAccounts: compiled.header.numReadonlySignerAccounts,
+                numReadonlyUnsignedAccounts: compiled.header.numReadonlyNonSignerAccounts,
+                numRequiredSignatures: compiled.header.numSignerAccounts,
+            },
+            recentBlockhash: compiled.lifetimeToken,
+            staticAccountKeys: compiled.staticAccounts.map(address => new PublicKey(address)),
+        },
+        messageBytes,
+    );
+
+    return { message, transactionConfig: readTransactionConfig(compiled) };
+}
+
+function readTransactionConfig(
+    compiled: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime & { version: 1 },
+): V1TransactionConfig | undefined {
+    try {
+        const { config } = decompileTransactionMessage(compiled);
+        return config && Object.values(config).some(value => value !== undefined) ? config : undefined;
+    } catch (error) {
+        Logger.error(error, { module: '[v1-message-bridge]' });
+        return undefined;
+    }
+}

--- a/openspec/changes/bridge-v1-into-the-inspector/proposal.md
+++ b/openspec/changes/bridge-v1-into-the-inspector/proposal.md
@@ -10,7 +10,7 @@ The deferred assessment assumed un-gating means re-rooting the inspector on kit'
 
 1. **A v1 message carries static accounts only.** `V1CompiledTransactionMessage` has no `addressTableLookups` field at all. Every structural fact the inspector renders — header role math, static keys, compiled instructions — therefore maps losslessly onto web3.js's `MessageV0` shape, with empty lookups and the lifetime token as the blockhash. Lookup hydration, the hardest part of the re-root, has no v1 case to handle.
 
-2. **The serialize hazard is one method.** The prior change rejected synthesizing a `MessageV0` because `message.serialize()` would emit v0 bytes that are not the real transaction — the simulator would simulate bytes the network never sees, and cache fingerprints would hash them. web3.js's `VersionedTransaction` constructor reads only `header.numRequiredSignatures`, and `Connection.simulateTransaction` does nothing with the message beyond `serialize()`. A `MessageV0` subclass whose `serialize()` returns the original v1 wire bytes therefore produces a byte-exact unsigned v1 wire transaction through the existing simulator path, verified by a round-trip spec through kit's transaction decoder.
+2. **The serialize hazard is two overrides, message and envelope.** The prior change rejected synthesizing a `MessageV0` because `message.serialize()` would emit v0 bytes that are not the real transaction — the simulator would simulate bytes the network never sees, and cache fingerprints would hash them. A `MessageV0` subclass whose `serialize()` returns the original v1 wire bytes closes the message half. The envelope needs its own override: v1 reorders the wire envelope to message-first with no signature-count prefix (the count is read from the message header), so web3.js's signatures-first `VersionedTransaction.serialize()` wraps even correct message bytes in an envelope a v1-aware node rejects as an invalid message version. The simulator therefore sends a `VersionedTransaction` subclass that encodes the envelope through kit's transaction encoder, pinned by a spec asserting byte-equality with kit's own encoding of the same unsigned transaction.
 
 The alternative — re-rooting the spine on kit's compiled message — remains the destination the kit migration will reach, but it renames header math, rebuilds lookup ordering, and changes the decode path for legacy and v0, all regression surface this change's goal ("v1 works, legacy/v0 untouched") does not need. The bridge is deliberately a shim: it is deleted, not extended, when the re-root lands.
 
@@ -24,10 +24,10 @@ The alternative — re-rooting the spine on kit's compiled message — remains t
 
 ## What Changes
 
-- **New `app/shared/lib/v1-message-bridge.ts`** — `isV1MessageBytes`, `V1MessageView` (the serialize-truthful `MessageV0` subclass), and `bridgeV1MessageBytes`, which decodes with kit and reads the resource-limit config off `decompileTransactionMessage`.
+- **New `app/shared/lib/v1-message-bridge.ts`** — `isV1MessageBytes`, `V1MessageView` (the serialize-truthful `MessageV0` subclass), `UnsignedV1WireTransaction` (the message-first envelope for simulation), and `bridgeV1MessageBytes`, which decodes with kit and reads the resource-limit config off `decompileTransactionMessage`.
 - **All three entry paths un-gate:** the permalink view bridges the v1 arm of `RawTransaction`, and the `?message=` URL and paste paths bridge before falling through to `VersionedMessage.deserialize` for legacy/v0.
 - **The overview card renders v1's version and resource limits** (compute unit limit, total priority fee, loaded accounts data size limit, heap size), mirroring the detail page's summary card.
-- The Squads path, every other inspector card, and the simulator are untouched.
+- **The simulator sends the v1 envelope for v1 messages** and the overview size row uses v1's envelope math and 4096-byte limit; the Squads path and every other inspector card are untouched.
 
 ## Impact
 

--- a/openspec/changes/bridge-v1-into-the-inspector/proposal.md
+++ b/openspec/changes/bridge-v1-into-the-inspector/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: Bridge v1 transactions into the inspector
+
+## Context
+
+`read-v1-transactions-with-kit` made v1 transactions render on the detail page but gated the inspector: `PermalinkView` shows "does not yet support v1" because the inspector's spine is web3.js `VersionedMessage`, which tops out at v0. `adopt-kit-7-transaction-introspection` recorded un-gating as deferred and "larger than it appears" — six components and three entry paths all consume `VersionedMessage`, and the simulator serializes it.
+
+## Why
+
+The deferred assessment assumed un-gating means re-rooting the inspector on kit's `CompiledTransactionMessage`. Two facts, both verified against kit 7.0.0's types, make a far smaller change sufficient:
+
+1. **A v1 message carries static accounts only.** `V1CompiledTransactionMessage` has no `addressTableLookups` field at all. Every structural fact the inspector renders — header role math, static keys, compiled instructions — therefore maps losslessly onto web3.js's `MessageV0` shape, with empty lookups and the lifetime token as the blockhash. Lookup hydration, the hardest part of the re-root, has no v1 case to handle.
+
+2. **The serialize hazard is one method.** The prior change rejected synthesizing a `MessageV0` because `message.serialize()` would emit v0 bytes that are not the real transaction — the simulator would simulate bytes the network never sees, and cache fingerprints would hash them. web3.js's `VersionedTransaction` constructor reads only `header.numRequiredSignatures`, and `Connection.simulateTransaction` does nothing with the message beyond `serialize()`. A `MessageV0` subclass whose `serialize()` returns the original v1 wire bytes therefore produces a byte-exact unsigned v1 wire transaction through the existing simulator path, verified by a round-trip spec through kit's transaction decoder.
+
+The alternative — re-rooting the spine on kit's compiled message — remains the destination the kit migration will reach, but it renames header math, rebuilds lookup ordering, and changes the decode path for legacy and v0, all regression surface this change's goal ("v1 works, legacy/v0 untouched") does not need. The bridge is deliberately a shim: it is deleted, not extended, when the re-root lands.
+
+### Decisions
+
+**The bridged view's `version` getter still reports 0.** `MessageV0` types the getter as `get version(): 0`; widening it breaks `VersionedMessage` narrowing everywhere. The true version rides on `TransactionData.version`, and the overview card renders an explicit version row for v1, so nothing user-facing reads the lying getter.
+
+**The address table lookups card is hidden for v1** rather than rendering an empty v0-style table, because v1 has no lookup support to report on.
+
+**v1 is sniffed by its wire prefix byte (`0x81`).** Legacy messages never set the version flag bit and v0's prefix is `0x80`, so the single byte is unambiguous — and bytes carrying it fail `VersionedMessage.deserialize` today, so the sniff diverts only inputs that currently error.
+
+## What Changes
+
+- **New `app/shared/lib/v1-message-bridge.ts`** — `isV1MessageBytes`, `V1MessageView` (the serialize-truthful `MessageV0` subclass), and `bridgeV1MessageBytes`, which decodes with kit and reads the resource-limit config off `decompileTransactionMessage`.
+- **All three entry paths un-gate:** the permalink view bridges the v1 arm of `RawTransaction`, and the `?message=` URL and paste paths bridge before falling through to `VersionedMessage.deserialize` for legacy/v0.
+- **The overview card renders v1's version and resource limits** (compute unit limit, total priority fee, loaded accounts data size limit, heap size), mirroring the detail page's summary card.
+- The Squads path, every other inspector card, and the simulator are untouched.
+
+## Impact
+
+- **No behaviour change for legacy/v0**: the bridge sits behind a prefix-byte check that only matches bytes which previously failed to decode.
+- Simulation, signature verification, the size row, the download button, and permalink round-trips all operate on the true v1 wire bytes.
+- Whether a cluster's RPC accepts a v1 `simulateTransaction` depends on its runtime support; a rejection surfaces through the simulator's existing error card.
+- **Deferred, unchanged:** re-rooting the inspector spine on kit's `CompiledTransactionMessage`, which deletes this bridge.

--- a/openspec/changes/bridge-v1-into-the-inspector/specs/transaction-inspector/spec.md
+++ b/openspec/changes/bridge-v1-into-the-inspector/specs/transaction-inspector/spec.md
@@ -27,8 +27,13 @@ A v1 message SHALL be accepted by the permalink fetch, the `?message=` URL param
 
 #### Scenario: simulating a v1 transaction
 
-- **WHEN** the simulator wraps the bridged message in a `VersionedTransaction`
-- **THEN** the serialized wire transaction SHALL contain the original v1 message bytes byte-for-byte
+- **WHEN** the simulator serializes a bridged v1 message for the RPC
+- **THEN** the wire transaction SHALL use the v1 message-first envelope, byte-equal to kit's encoding of the same unsigned transaction, never the legacy signatures-first envelope
+
+#### Scenario: reporting a v1 transaction's size
+
+- **WHEN** the overview card computes a v1 transaction's size
+- **THEN** it SHALL use the v1 envelope layout, which has no signature-count byte, and the v1 4096-byte limit
 
 ### Requirement: v1 resource limits SHALL render in the overview card
 

--- a/openspec/changes/bridge-v1-into-the-inspector/specs/transaction-inspector/spec.md
+++ b/openspec/changes/bridge-v1-into-the-inspector/specs/transaction-inspector/spec.md
@@ -1,0 +1,49 @@
+# Transaction inspector
+
+## ADDED Requirements
+
+### Requirement: v1 transactions SHALL render in the inspector through every entry path
+
+A v1 message SHALL be accepted by the permalink fetch, the `?message=` URL parameter, and the pasted-input path. Detection SHALL use the wire version prefix byte, so legacy and v0 inputs continue through the web3.js decode path unchanged.
+
+#### Scenario: v1 permalink
+
+- **WHEN** a fetched transaction decodes as v1
+- **THEN** the inspector SHALL render the overview, accounts, signatures, and instructions cards from the bridged message
+
+#### Scenario: v1 pasted or linked message
+
+- **WHEN** a pasted or URL-supplied message carries the v1 wire prefix
+- **THEN** the inspector SHALL render it rather than reporting a decode error
+
+#### Scenario: undecodable v1 bytes
+
+- **WHEN** bytes carrying the v1 prefix fail to decode as a v1 message
+- **THEN** the inspector SHALL show the unsupported-transaction error card
+
+### Requirement: Operations on a bridged v1 message SHALL use the original wire bytes
+
+`serialize()` on the bridged view SHALL return the v1 wire bytes it was decoded from, so simulation, signature verification, size reporting, downloads, and cache fingerprints operate on the bytes the network sees, never a v0 re-encoding.
+
+#### Scenario: simulating a v1 transaction
+
+- **WHEN** the simulator wraps the bridged message in a `VersionedTransaction`
+- **THEN** the serialized wire transaction SHALL contain the original v1 message bytes byte-for-byte
+
+### Requirement: v1 resource limits SHALL render in the overview card
+
+The overview card SHALL render a v1 version row and each resource limit the message sets — compute unit limit, total priority fee, loaded accounts data size limit, heap size — with the priority fee labelled as a total, matching the detail page's presentation.
+
+#### Scenario: v1 message with limits
+
+- **WHEN** a v1 message sets any resource limits
+- **THEN** the overview card SHALL render a row per limit that is present
+
+### Requirement: The address table lookups card SHALL NOT render for v1
+
+A v1 message carries static accounts only, so the inspector SHALL omit the lookups card rather than render an empty table.
+
+#### Scenario: v1 message
+
+- **WHEN** the inspected transaction is v1
+- **THEN** no address table lookups card SHALL appear


### PR DESCRIPTION
## Summary
- Un-gates v1 transactions in the inspector across all three entry paths: permalink fetch, `?message=` URL param, and pasted raw input.
- New `app/shared/lib/v1-message-bridge.ts`: decodes v1 message bytes with kit 7 and exposes them as a `MessageV0` view whose `serialize()` returns the **original v1 wire bytes** — so simulation, signature verification, size math, downloads, and cache fingerprints all operate on the bytes the network sees, never a v0 re-encoding. This closes the serialize hazard that motivated the original gate.
- The overview card renders the v1 version row and the message-level resource limits (compute unit limit, total priority fee, loaded accounts data size limit, heap size), mirroring the detail page. The address table lookups card is hidden for v1 — kit 7's `V1CompiledTransactionMessage` carries static accounts only, with no lookup support.
- Zero behavior change for legacy/v0: the bridge sits behind a wire-prefix check (`0x81`) that only matches bytes which previously failed to decode.

Stacked on #1193 (kit 7 introspection); retarget to `master` once that merges. The openspec change records why the bridge was chosen over re-rooting the inspector on kit's `CompiledTransactionMessage`, which remains the deferred migration destination and deletes this shim when it lands.

## Test Plan
- `app/shared/lib/__tests__/v1-message-bridge.spec.ts` — field mapping, config extraction, and the regression that matters: `serialize()` is byte-equal to the input and `new VersionedTransaction(view).serialize()` round-trips through kit's transaction decoder to the same v1 message bytes.
- `PermalinkView.spec.tsx` — a v1 cache entry renders the loaded view with config rows and no lookups card; undecodable v1 bytes keep the error card.
- `InspectorPage-V1.spec.tsx` — full-page render from a v1 `?message=` param with real providers.
- Full suite shows the same 46 pre-existing failures across the same 7 files as the base branch (documented in the #1193 openspec).
- Note: whether an RPC accepts a v1 `simulateTransaction` depends on cluster runtime support; a rejection surfaces through the simulator's existing error card.

Closes DEV-898