### PR TITLE
fix: outline border for the address component

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -18,7 +18,7 @@ import { useVisibility } from '@/app/shared/lib/visibility';
 import { Copyable } from './Copyable';
 import { useMidTruncation } from './useMidTruncation';
 
-const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-hidden', {
+const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-clip', {
     defaultVariants: {
         alignRight: false,
     },

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -18,7 +18,7 @@ import { useVisibility } from '@/app/shared/lib/visibility';
 import { Copyable } from './Copyable';
 import { useMidTruncation } from './useMidTruncation';
 
-const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-clip', {
+const rowVariants = cva('relative flex w-full min-w-0 items-baseline overflow-x-clip px-px', {
     defaultVariants: {
         alignRight: false,
     },


### PR DESCRIPTION
## Description
- fixing top and bottom border for the address outline

## Type of change
-   [x] Bug fix

## Screenshots
<img width="727" height="371" alt="Screenshot 2026-08-18 at 11 41 08" src="https://github.com/user-attachments/assets/0cc8aa9a-ae20-4c54-ac0e-357e355ec6a9" />

## Testing
1. open [any page](https://explorer-git-fork-hoodieshq-feat-hoo-1-8a11e9-solana-foundation.vercel.app/tx/2eD8zqzqiEmgGeiwRdZBvUfaAsBFHYwqJUVmNdK7FbeUB9iFK57DpC8vq7QMb3K4otsLnunth2QUpGS3ZSpWL6gG) with the address component

## Related Issues
[HOO-1127](https://linear.app/solana-fndn/issue/HOO-1127/fix-outline-border-for-the-address-component)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes