### PR TITLE
fix: highlight color of description in developer settings section

### DIFF
--- a/app/features/cluster-switcher/ui/ClusterModalDeveloperSettings.tsx
+++ b/app/features/cluster-switcher/ui/ClusterModalDeveloperSettings.tsx
@@ -22,7 +22,7 @@ export function ClusterModalDeveloperSettings() {
     };
 
     return (
-        <>
+        <div className="selection:bg-accent selection:text-dark-background">
             <hr />
             <h2 className="mb-6 mt-6 text-center">Developer Settings</h2>
             <div className="flex items-center justify-between">
@@ -44,6 +44,6 @@ export function ClusterModalDeveloperSettings() {
                 }}
                 onCancel={() => setConfirming(false)}
             />
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
## Description
- Fixing the highlight color of the selection in the Developer Settings sections in the cluster sidebar

## Type of change
-   [x] Bug fix

## Screenshots
<img width="396" height="269" alt="Screenshot 2026-08-18 at 11 43 28" src="https://github.com/user-attachments/assets/440993e6-5994-40c4-8467-a89943486fb7" />

## Testing
1. open any page
2. click on cluster btn
3. select any part of the text in developer settings section

## Related Issues
[HOO-941](https://linear.app/solana-fndn/issue/HOO-941/fix-text-highlight-color)

## Checklist
-   [x] My code follows the project's style guidelines
-   [x] All checks pass locally (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
-   [x] CI/CD checks pass on the PR
-   [x] Screenshots included — required for protocol screens, recommended for other UI changes