### PR TITLE
fix(inspector): explain v1 simulation failures

### DIFF
--- a/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
@@ -361,8 +361,8 @@ describe('simulateTransaction', () => {
 });
 
 describe('v1 transactions', () => {
-    function v1Message(): VersionedMessage {
-        return bridgeV1MessageBytes(parseTransactionBytes(createV1TransactionBytes({})).messageBytes).message;
+    function v1Message(config: Parameters<typeof createV1TransactionBytes>[0] = {}): VersionedMessage {
+        return bridgeV1MessageBytes(parseTransactionBytes(createV1TransactionBytes(config)).messageBytes).message;
     }
 
     function connectionWithFeature(activated: boolean, overrides?: Partial<Connection>): Connection {
@@ -387,6 +387,60 @@ describe('v1 transactions', () => {
         await simulate(connection, v1Message());
 
         expect(connection.simulateTransaction).toHaveBeenCalled();
+    });
+
+    describe('MaxLoadedAccountsDataSizeExceeded', () => {
+        // The fee payer is empty, the recipient does not exist, and the program holds 74,800 bytes:
+        // the runtime loads 74,800 + 64 for each of the two accounts that exist.
+        const OWNER = new PublicKey(SYSTEM_PROGRAM_ADDRESS);
+        const PARSED_ACCOUNTS = [
+            { data: Buffer.alloc(0), owner: OWNER },
+            undefined,
+            { data: { parsed: {}, program: 'memo', space: 74_800 }, owner: OWNER },
+        ];
+
+        function connectionRejectingForSize(): Connection {
+            return connectionWithFeature(true, {
+                getMultipleParsedAccounts: vi.fn().mockResolvedValue({ value: PARSED_ACCOUNTS }),
+                simulateTransaction: vi
+                    .fn()
+                    .mockResolvedValue(
+                        createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
+                    ),
+            } as Partial<Connection>);
+        }
+
+        it('should report the size the runtime loaded against the limit the message sets', async () => {
+            const message = v1Message({ loadedAccountsDataSizeLimit: 74_900 });
+
+            const result = await simulate(connectionRejectingForSize(), message);
+
+            expect(result.error).toContain('this transaction loads 74,928 bytes');
+            expect(result.error).toContain('74,800 bytes of account data');
+            expect(result.error).toContain('64 bytes of metadata for each of the 2 accounts that exist on chain');
+            expect(result.error).toContain('above the 74,900 byte limit set in the v1 message config');
+        });
+
+        it('should name the unset limit as zero when the message sets none', async () => {
+            const result = await simulate(connectionRejectingForSize(), v1Message());
+
+            expect(result.error).toContain('this transaction loads 74,928 bytes');
+            expect(result.error).toContain('sets no loaded accounts data size limit');
+        });
+
+        it('should surface the raw error for a non-v1 message', async () => {
+            const connection = createMockConnection({
+                simulateTransaction: vi
+                    .fn()
+                    .mockResolvedValue(
+                        createSimulationResponse({ err: 'MaxLoadedAccountsDataSizeExceeded', logs: [] }),
+                    ),
+            } as Partial<Connection>);
+
+            const result = await simulate(connection);
+
+            expect(result.error).toBe('MaxLoadedAccountsDataSizeExceeded');
+        });
     });
 
     it('should not read the feature gate for a non-v1 message', async () => {

--- a/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
@@ -390,18 +390,27 @@ describe('v1 transactions', () => {
     });
 
     describe('MaxLoadedAccountsDataSizeExceeded', () => {
-        // The fee payer is empty, the recipient does not exist, and the program holds 74,800 bytes:
-        // the runtime loads 74,800 + 64 for each of the two accounts that exist.
         const OWNER = new PublicKey(SYSTEM_PROGRAM_ADDRESS);
+        const UPGRADEABLE_LOADER = new PublicKey('BPFLoaderUpgradeab1e11111111111111111111111');
+        const PROGRAM_DATA_KEY = Keypair.generate().publicKey;
+
+        // The fee payer is empty, the recipient does not exist, and the program holds 74,800 bytes:
+        // the runtime loads 74,800 bytes of data and charges 64 bytes for each of the two accounts.
         const PARSED_ACCOUNTS = [
             { data: Buffer.alloc(0), owner: OWNER },
             undefined,
             { data: { parsed: {}, program: 'memo', space: 74_800 }, owner: OWNER },
         ];
 
-        function connectionRejectingForSize(): Connection {
+        function connectionRejectingForSize(
+            accounts: unknown[] = PARSED_ACCOUNTS,
+            programData: unknown[] = [],
+        ): Connection {
             return connectionWithFeature(true, {
-                getMultipleParsedAccounts: vi.fn().mockResolvedValue({ value: PARSED_ACCOUNTS }),
+                getMultipleParsedAccounts: vi
+                    .fn()
+                    .mockResolvedValueOnce({ value: accounts })
+                    .mockResolvedValue({ value: programData }),
                 simulateTransaction: vi
                     .fn()
                     .mockResolvedValue(
@@ -417,8 +426,27 @@ describe('v1 transactions', () => {
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
             expect(result.error).toContain('74,800 bytes of account data');
-            expect(result.error).toContain('64 bytes of metadata for each of the 2 accounts that exist on chain');
+            expect(result.error).toContain('64 bytes of metadata for each of the 2 accounts it loads');
             expect(result.error).toContain('above the 74,900 byte limit set in the v1 message config');
+        });
+
+        it('should count the program data account of an upgradeable program', async () => {
+            const programAccount = {
+                data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                owner: UPGRADEABLE_LOADER,
+            };
+            // The first lookup returns the message's accounts, the second the program data account
+            // behind the upgradeable program, which the message never lists
+            const connection = connectionRejectingForSize(
+                [{ data: Buffer.alloc(0), owner: OWNER }, programAccount],
+                [{ data: { parsed: {}, program: 'x', space: 500_000 }, owner: UPGRADEABLE_LOADER }],
+            );
+
+            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+
+            // 500,036 bytes of data across three accounts, each charged 64 bytes of metadata
+            expect(result.error).toContain('this transaction loads 500,228 bytes');
+            expect(result.error).toContain('for each of the 3 accounts it loads');
         });
 
         it('should name the unset limit as zero when the message sets none', async () => {
@@ -426,6 +454,20 @@ describe('v1 transactions', () => {
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
             expect(result.error).toContain('sets no loaded accounts data size limit');
+        });
+
+        it('should surface the raw error when the program data lookup fails', async () => {
+            const connection = connectionRejectingForSize([
+                {
+                    data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                    owner: UPGRADEABLE_LOADER,
+                },
+            ]);
+            vi.mocked(connection.getMultipleParsedAccounts).mockRejectedValueOnce(new Error('rpc down'));
+
+            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+
+            expect(result.error).toBe('MaxLoadedAccountsDataSizeExceeded');
         });
 
         it('should surface the raw error for a non-v1 message', async () => {

--- a/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
@@ -6,7 +6,10 @@ import type { InstructionLogs } from '@utils/program-logs';
 import BN from 'bn.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createV1TransactionBytes } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
 import { alloc, toBase64, writeU64LE, writeUint32LE } from '@/app/shared/lib/bytes';
+import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
+import { bridgeV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
 
 // Mock VersionedTransaction so we don't need a real message header
 vi.mock('@solana/web3.js', async () => {
@@ -354,6 +357,44 @@ describe('simulateTransaction', () => {
                 uiTokenAmount: { amount: largeAmount.toString() },
             });
         });
+    });
+});
+
+describe('v1 transactions', () => {
+    function v1Message(): VersionedMessage {
+        return bridgeV1MessageBytes(parseTransactionBytes(createV1TransactionBytes({})).messageBytes).message;
+    }
+
+    function connectionWithFeature(activated: boolean, overrides?: Partial<Connection>): Connection {
+        return createMockConnection({
+            getAccountInfo: vi.fn().mockResolvedValue({
+                data: Buffer.from(activated ? [1, 42, 0, 0, 0, 0, 0, 0, 0] : new Uint8Array(9)),
+            }),
+            ...overrides,
+        } as Partial<Connection>);
+    }
+
+    it('should fail with the feature gate as the cause when the cluster has no v1 support', async () => {
+        const connection = connectionWithFeature(false);
+
+        await expect(simulate(connection, v1Message())).rejects.toThrow('does not support v1 transactions');
+        expect(connection.simulateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should simulate when the cluster has the v1 feature gate active', async () => {
+        const connection = connectionWithFeature(true);
+
+        await simulate(connection, v1Message());
+
+        expect(connection.simulateTransaction).toHaveBeenCalled();
+    });
+
+    it('should not read the feature gate for a non-v1 message', async () => {
+        const connection = connectionWithFeature(false);
+
+        await simulate(connection);
+
+        expect(connection.getAccountInfo).not.toHaveBeenCalled();
     });
 });
 

--- a/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/simulate-transaction.spec.ts
@@ -6,7 +6,7 @@ import type { InstructionLogs } from '@utils/program-logs';
 import BN from 'bn.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createV1TransactionBytes } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
+import { createV1TransactionBytes, RECIPIENT } from '@/app/entities/transaction-data/__fixtures__/wire-transactions';
 import { alloc, toBase64, writeU64LE, writeUint32LE } from '@/app/shared/lib/bytes';
 import { parseTransactionBytes } from '@/app/shared/lib/parse-transaction-bytes';
 import { bridgeV1MessageBytes } from '@/app/shared/lib/v1-message-bridge';
@@ -374,19 +374,73 @@ describe('v1 transactions', () => {
         } as Partial<Connection>);
     }
 
-    it('should fail with the feature gate as the cause when the cluster has no v1 support', async () => {
-        const connection = connectionWithFeature(false);
+    it('should name the feature gate when the node rejects the simulation request outright', async () => {
+        const connection = connectionWithFeature(false, {
+            simulateTransaction: vi.fn().mockRejectedValue(new Error('invalid transaction: UnsupportedVersion')),
+        } as Partial<Connection>);
 
         await expect(simulate(connection, v1Message())).rejects.toThrow('does not support v1 transactions');
-        expect(connection.simulateTransaction).not.toHaveBeenCalled();
     });
 
-    it('should simulate when the cluster has the v1 feature gate active', async () => {
+    it('should name the feature gate when the node returns UnsupportedVersion as a simulation error', async () => {
+        const connection = connectionWithFeature(false, {
+            simulateTransaction: vi
+                .fn()
+                .mockResolvedValue(createSimulationResponse({ err: 'UnsupportedVersion', logs: [] })),
+        } as Partial<Connection>);
+
+        const result = await simulate(connection, v1Message());
+
+        expect(result.error).toContain('does not support v1 transactions');
+    });
+
+    it('should surface the original failure when the cluster does support v1', async () => {
+        const connection = connectionWithFeature(true, {
+            simulateTransaction: vi.fn().mockRejectedValue(new Error('rpc down')),
+        } as Partial<Connection>);
+
+        await expect(simulate(connection, v1Message())).rejects.toThrow('rpc down');
+    });
+
+    it('should surface the original failure when the feature gate cannot be read', async () => {
+        const connection = createMockConnection({
+            getAccountInfo: vi.fn().mockRejectedValue(new Error('gate unreadable')),
+            simulateTransaction: vi.fn().mockRejectedValue(new Error('rpc down')),
+        } as Partial<Connection>);
+
+        await expect(simulate(connection, v1Message())).rejects.toThrow('rpc down');
+    });
+
+    it('should name the feature gate when UnsupportedVersion arrives alongside logs', async () => {
+        const connection = connectionWithFeature(false, {
+            simulateTransaction: vi
+                .fn()
+                .mockResolvedValue(
+                    createSimulationResponse({ err: 'UnsupportedVersion', logs: ['Program log: something'] }),
+                ),
+        } as Partial<Connection>);
+
+        const result = await simulate(connection, v1Message());
+
+        expect(result.error).toContain('does not support v1 transactions');
+    });
+
+    it('should keep the original failure as the cause of the feature gate error', async () => {
+        const cause = new Error('429 Too Many Requests');
+        const connection = connectionWithFeature(false, {
+            simulateTransaction: vi.fn().mockRejectedValue(cause),
+        } as Partial<Connection>);
+
+        await expect(simulate(connection, v1Message())).rejects.toMatchObject({ cause });
+    });
+
+    it('should not read the feature gate when a v1 simulation succeeds', async () => {
         const connection = connectionWithFeature(true);
 
         await simulate(connection, v1Message());
 
         expect(connection.simulateTransaction).toHaveBeenCalled();
+        expect(connection.getAccountInfo).not.toHaveBeenCalled();
     });
 
     describe('MaxLoadedAccountsDataSizeExceeded', () => {
@@ -426,13 +480,14 @@ describe('v1 transactions', () => {
 
             expect(result.error).toContain('this transaction loads 74,928 bytes');
             expect(result.error).toContain('74,800 bytes of account data');
-            expect(result.error).toContain('64 bytes of metadata for each of the 2 accounts it loads');
+            expect(result.error).toContain('64 bytes of metadata for each of the 2 accounts it names');
             expect(result.error).toContain('above the 74,900 byte limit set in the v1 message config');
         });
 
         it('should count the program data account of an upgradeable program', async () => {
             const programAccount = {
                 data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                executable: true,
                 owner: UPGRADEABLE_LOADER,
             };
             // The first lookup returns the message's accounts, the second the program data account
@@ -446,7 +501,70 @@ describe('v1 transactions', () => {
 
             // 500,036 bytes of data across three accounts, each charged 64 bytes of metadata
             expect(result.error).toContain('this transaction loads 500,228 bytes');
-            expect(result.error).toContain('for each of the 3 accounts it loads');
+            expect(result.error).toContain('for each of the 3 accounts it names');
+        });
+
+        it('should count a program data account the message lists only once', async () => {
+            const programAccount = {
+                data: { parsed: { info: { programData: RECIPIENT } }, program: 'x', space: 36 },
+                executable: true,
+                owner: UPGRADEABLE_LOADER,
+            };
+            // RECIPIENT is the message's second account key, so the program's program data account
+            // is already among the accounts the first lookup returned
+            const connection = connectionRejectingForSize([
+                programAccount,
+                { data: { parsed: {}, program: 'x', space: 500_000 }, owner: UPGRADEABLE_LOADER },
+            ]);
+
+            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+
+            // 500,036 bytes of data across two accounts, each charged 64 bytes of metadata
+            expect(result.error).toContain('this transaction loads 500,164 bytes');
+            expect(result.error).toContain('for each of the 2 accounts it names');
+        });
+
+        it('should not look up program data for a non-executable loader-owned account', async () => {
+            const connection = connectionRejectingForSize([
+                { data: Buffer.alloc(0), owner: OWNER },
+                { data: { parsed: {}, program: 'x', space: 500_000 }, executable: false, owner: UPGRADEABLE_LOADER },
+            ]);
+
+            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 1024 }));
+
+            expect(connection.getMultipleParsedAccounts).toHaveBeenCalledTimes(1);
+            expect(result.error).toContain('this transaction loads 500,128 bytes');
+        });
+
+        it('should report the size as a floor when the accounts it can see fit under the limit', async () => {
+            const result = await simulate(
+                connectionRejectingForSize(),
+                v1Message({ loadedAccountsDataSizeLimit: 200_000 }),
+            );
+
+            expect(result.error).toContain('this transaction loads at least 74,928 bytes');
+            expect(result.error).toContain('within the 200,000 byte limit set in the v1 message config');
+            expect(result.error).toContain('accounts the message does not name');
+            expect(result.error).not.toContain('above the');
+        });
+
+        it('should explain the failure even when the RPC returns it alongside logs', async () => {
+            const connection = connectionWithFeature(true, {
+                getMultipleParsedAccounts: vi
+                    .fn()
+                    .mockResolvedValueOnce({ value: PARSED_ACCOUNTS })
+                    .mockResolvedValue({ value: [] }),
+                simulateTransaction: vi.fn().mockResolvedValue(
+                    createSimulationResponse({
+                        err: 'MaxLoadedAccountsDataSizeExceeded',
+                        logs: ['Program failed to load accounts'],
+                    }),
+                ),
+            } as Partial<Connection>);
+
+            const result = await simulate(connection, v1Message({ loadedAccountsDataSizeLimit: 74_900 }));
+
+            expect(result.error).toContain('this transaction loads 74,928 bytes');
         });
 
         it('should name the unset limit as zero when the message sets none', async () => {
@@ -460,6 +578,7 @@ describe('v1 transactions', () => {
             const connection = connectionRejectingForSize([
                 {
                     data: { parsed: { info: { programData: PROGRAM_DATA_KEY.toBase58() } }, program: 'x', space: 36 },
+                    executable: true,
                     owner: UPGRADEABLE_LOADER,
                 },
             ]);

--- a/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
@@ -5,7 +5,6 @@ import { ENABLE_TX_V1_FEATURE, isTxV1Active } from '../tx-v1-feature';
 
 function connectionReturning(data: Uint8Array | null): Connection {
     return {
-         
         getAccountInfo: vi.fn().mockResolvedValue(data === null ? null : { data: Buffer.from(data) }),
     } as unknown as Connection;
 }
@@ -22,7 +21,6 @@ describe('isTxV1Active', () => {
     });
 
     it('should report inactive when the feature account does not exist', async () => {
-         
         await expect(isTxV1Active(connectionReturning(null))).resolves.toBe(false);
     });
 

--- a/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
+++ b/app/features/instruction-simulation/lib/__tests__/tx-v1-feature.spec.ts
@@ -1,0 +1,36 @@
+import type { Connection } from '@solana/web3.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ENABLE_TX_V1_FEATURE, isTxV1Active } from '../tx-v1-feature';
+
+function connectionReturning(data: Uint8Array | null): Connection {
+    return {
+         
+        getAccountInfo: vi.fn().mockResolvedValue(data === null ? null : { data: Buffer.from(data) }),
+    } as unknown as Connection;
+}
+
+describe('isTxV1Active', () => {
+    it('should report active when the gate carries an activation slot', async () => {
+        const activatedAtSlot = new Uint8Array([1, 42, 0, 0, 0, 0, 0, 0, 0]);
+
+        await expect(isTxV1Active(connectionReturning(activatedAtSlot))).resolves.toBe(true);
+    });
+
+    it('should report inactive when the gate is staged but not activated', async () => {
+        await expect(isTxV1Active(connectionReturning(new Uint8Array(9)))).resolves.toBe(false);
+    });
+
+    it('should report inactive when the feature account does not exist', async () => {
+         
+        await expect(isTxV1Active(connectionReturning(null))).resolves.toBe(false);
+    });
+
+    it('should read the transaction v1 feature account', async () => {
+        const connection = connectionReturning(new Uint8Array(9));
+
+        await isTxV1Active(connection);
+
+        expect(connection.getAccountInfo).toHaveBeenCalledWith(ENABLE_TX_V1_FEATURE);
+    });
+});

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -17,6 +17,7 @@ import { buildTokenBalances, type TokenBalanceData } from './build-token-balance
 import { computeSolBalanceChanges } from './compute-sol-balance-changes';
 import { getMintDecimals } from './get-mint-decimals';
 import { resolveAddressLookupTables } from './resolve-address-lookup-tables';
+import { ENABLE_TX_V1_FEATURE, isTxV1Active } from './tx-v1-feature';
 import type { SolBalanceChange } from './types';
 
 export type SimulationResult = {
@@ -66,6 +67,15 @@ type RawSimulation = {
  * state, and run the simulation. Returns raw data for interpretation.
  */
 async function runSimulation(connection: Connection, message: VersionedMessage): Promise<RawSimulation> {
+    // A node whose runtime predates the v1 feature gate rejects the transaction during sanitization
+    // and answers with a bare `UnsupportedVersion` error and no logs, which reads as a failure of
+    // the transaction rather than of the cluster. Check the gate first so the cause is explicit.
+    if (message instanceof V1MessageView && !(await isTxV1Active(connection))) {
+        throw new Error(
+            `this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE.toBase58()} is not active`,
+        );
+    }
+
     const lookupTables = await resolveAddressLookupTables(connection, message);
     const accountKeys = message.getAccountKeys({ addressLookupTableAccounts: lookupTables }).keySegments().flat();
 

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -46,15 +46,75 @@ export async function simulateTransaction({
     cluster,
     accountBalances,
 }: SimulateOptions): Promise<SimulationResult> {
-    const raw = await runSimulation(connection, message);
+    let raw;
+    try {
+        raw = await runSimulation(connection, message);
+    } catch (cause) {
+        throw (await inactiveV1GateError(connection, message, cause)) ?? cause;
+    }
+
     const result = interpretSimulation(raw, cluster, accountBalances);
 
-    if (result.error === MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED && message instanceof V1MessageView) {
-        const explained = await explainLoadedAccountsDataSize(connection, message, raw.parsedAccountsPre);
+    // Match the error the RPC returned rather than the interpreted one, which reports any failure
+    // carrying logs as a bare `TransactionError`.
+    if (raw.simResult.err === UNSUPPORTED_VERSION) {
+        const gate = await inactiveV1GateError(connection, message);
+        if (gate) {
+            return { ...result, error: gate.message };
+        }
+    }
+
+    if (raw.simResult.err === MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED && message instanceof V1MessageView) {
+        const explained = await explainLoadedAccountsDataSize(
+            connection,
+            message,
+            raw.accountKeys,
+            raw.parsedAccountsPre,
+        );
         return explained ? { ...result, error: explained } : result;
     }
 
     return result;
+}
+
+const UNSUPPORTED_VERSION = 'UnsupportedVersion';
+
+/**
+ * The error to report in place of a failed v1 simulation when the cluster has no v1 support, or
+ * `undefined` when the cluster is not the reason the simulation failed.
+ *
+ * A node whose runtime predates the v1 feature gate rejects the transaction during sanitization and
+ * answers with a bare `UnsupportedVersion`, which reads as a failure of the transaction rather than
+ * of the cluster. Which side of the RPC boundary that answer arrives on depends on the node: some
+ * reject the request outright, others return it as a simulation error, so both paths land here.
+ *
+ * The gate is read only once a v1 simulation has already failed, so a cluster that supports v1
+ * costs no extra RPC call, and a cluster whose gate cannot be read reports its original failure.
+ * The failure that prompted the read is carried along as the cause, since a v1 simulation can fail
+ * for reasons of its own on a cluster that happens to lack the gate as well.
+ */
+async function inactiveV1GateError(
+    connection: Connection,
+    message: VersionedMessage,
+    cause?: unknown,
+): Promise<Error | undefined> {
+    if (!(message instanceof V1MessageView)) {
+        return undefined;
+    }
+
+    try {
+        if (await isTxV1Active(connection)) {
+            return undefined;
+        }
+    } catch (cause) {
+        Logger.error(new Error('Failed to read the transaction v1 feature gate', { cause }));
+        return undefined;
+    }
+
+    return new Error(
+        `this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE.toBase58()} is not active`,
+        { cause },
+    );
 }
 
 type RawSimulation = {
@@ -74,15 +134,6 @@ type RawSimulation = {
  * state, and run the simulation. Returns raw data for interpretation.
  */
 async function runSimulation(connection: Connection, message: VersionedMessage): Promise<RawSimulation> {
-    // A node whose runtime predates the v1 feature gate rejects the transaction during sanitization
-    // and answers with a bare `UnsupportedVersion` error and no logs, which reads as a failure of
-    // the transaction rather than of the cluster. Check the gate first so the cause is explicit.
-    if (message instanceof V1MessageView && !(await isTxV1Active(connection))) {
-        throw new Error(
-            `this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE.toBase58()} is not active`,
-        );
-    }
-
     const lookupTables = await resolveAddressLookupTables(connection, message);
     const accountKeys = message.getAccountKeys({ addressLookupTableAccounts: lookupTables }).keySegments().flat();
 
@@ -191,18 +242,26 @@ const UPGRADEABLE_LOADER_ID = new PublicKey('BPFLoaderUpgradeab1e111111111111111
  *
  * The runtime charges each account it loads 64 bytes of metadata plus its data, and charges nothing
  * for an account that does not exist. Calling an upgradeable program loads its program data account
- * as well, which the message never lists, so those are fetched here to be counted.
+ * as well, which the message usually does not list, so those are fetched here to be counted. A
+ * message that does list one is charged for it once, like any other account it names.
+ *
+ * The total is a floor rather than the figure the runtime reached: a program a message reaches by
+ * cross-program invocation is loaded and charged without ever being named, and cannot be found
+ * without executing the transaction. A total that already clears the limit explains the failure on
+ * its own; one that does not is reported as the floor it is, and names what the rest must be.
  */
 async function explainLoadedAccountsDataSize(
     connection: Connection,
     message: V1MessageView,
+    accountKeys: PublicKey[],
     parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | undefined)[],
 ): Promise<string | undefined> {
     const messageAccounts = parsedAccountsPre.filter(account => account !== undefined);
+    const listedAddresses = new Set(accountKeys.map(key => key.toBase58()));
 
     let programDataAccounts;
     try {
-        programDataAccounts = await fetchProgramDataAccounts(connection, messageAccounts);
+        programDataAccounts = await fetchProgramDataAccounts(connection, messageAccounts, listedAddresses);
     } catch (cause) {
         Logger.error(new Error('Failed to load program data accounts', { cause }));
         return undefined;
@@ -214,30 +273,52 @@ async function explainLoadedAccountsDataSize(
     const limit = message.transactionConfig?.loadedAccountsDataSizeLimit;
 
     const accountCount = `${loadedAccounts.length} account${loadedAccounts.length === 1 ? '' : 's'}`;
-    const loads = `this transaction loads ${format(loadedSize)} bytes (${format(dataSize)} bytes of account data, plus ${ACCOUNT_METADATA_SIZE} bytes of metadata for each of the ${accountCount} it loads)`;
-    const cap =
-        limit === undefined
-            ? 'this v1 message sets no loaded accounts data size limit, which v1 reads as a limit of zero bytes'
-            : `above the ${format(limit)} byte limit set in the v1 message config`;
+    const fitsUnderLimit = limit !== undefined && loadedSize <= limit;
+    const measured = fitsUnderLimit ? `at least ${format(loadedSize)}` : format(loadedSize);
+    const loads = `this transaction loads ${measured} bytes (${format(dataSize)} bytes of account data, plus ${ACCOUNT_METADATA_SIZE} bytes of metadata for each of the ${accountCount} it names)`;
+
+    let cap;
+    if (limit === undefined) {
+        cap = 'this v1 message sets no loaded accounts data size limit, which v1 reads as a limit of zero bytes';
+    } else if (fitsUnderLimit) {
+        cap = `within the ${format(limit)} byte limit set in the v1 message config, so the rest of the limit went to accounts the message does not name — a program reached by cross-program invocation, and the program data behind it, are loaded and charged the same way`;
+    } else {
+        cap = `above the ${format(limit)} byte limit set in the v1 message config`;
+    }
 
     return `${MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED} — ${loads}, ${cap}.`;
 }
 
-/** The program data accounts behind whichever of `accounts` are upgradeable programs. */
+/**
+ * The program data accounts behind whichever of `accounts` are upgradeable programs, skipping any
+ * address in `listedAddresses` so that an account the message already names is not counted twice.
+ *
+ * The upgradeable loader owns program data and buffer accounts as well as the programs themselves,
+ * and only a program account holds a program data address, so the executable flag selects them.
+ */
 async function fetchProgramDataAccounts(
     connection: Connection,
     accounts: AccountInfo<ParsedAccountData | Buffer>[],
+    listedAddresses: Set<string>,
 ): Promise<AccountInfo<ParsedAccountData | Buffer>[]> {
-    const addresses = accounts
-        .filter(account => account.owner.equals(UPGRADEABLE_LOADER_ID))
-        .map(programDataAddress)
-        .filter(address => address !== undefined);
+    const addresses = new Map<string, PublicKey>();
 
-    if (addresses.length === 0) {
+    for (const account of accounts) {
+        if (!account.executable || !account.owner.equals(UPGRADEABLE_LOADER_ID)) {
+            continue;
+        }
+
+        const address = programDataAddress(account);
+        if (address !== undefined && !listedAddresses.has(address.toBase58())) {
+            addresses.set(address.toBase58(), address);
+        }
+    }
+
+    if (addresses.size === 0) {
         return [];
     }
 
-    const { value } = await connection.getMultipleParsedAccounts(addresses);
+    const { value } = await connection.getMultipleParsedAccounts([...addresses.values()]);
     return value.filter(account => account !== null);
 }
 

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -47,7 +47,7 @@ export async function simulateTransaction({
     accountBalances,
 }: SimulateOptions): Promise<SimulationResult> {
     const raw = await runSimulation(connection, message);
-    return interpretSimulation(raw, cluster, accountBalances);
+    return interpretSimulation(raw, cluster, message, accountBalances);
 }
 
 type RawSimulation = {
@@ -126,6 +126,7 @@ async function runSimulation(connection: Connection, message: VersionedMessage):
 function interpretSimulation(
     { accountKeys, epochInfo, parsedAccountsPre, simResult }: RawSimulation,
     cluster: Cluster,
+    message: VersionedMessage,
     accountBalances?: { preBalances: number[]; postBalances: number[] },
 ): SimulationResult {
     // Token balance data (raw — UI layer is responsible for generating display rows)
@@ -138,8 +139,8 @@ function interpretSimulation(
     let error: string | undefined;
 
     if (simResult.logs.length === 0 && typeof simResult.err === 'string') {
-        // No logs to parse — surface the raw RPC error string (e.g. "AccountNotFound")
-        error = simResult.err;
+        // No logs to parse — surface the RPC error string (e.g. "AccountNotFound")
+        error = explainSimulationError(simResult.err, message, parsedAccountsPre);
     } else {
         logs = parseProgramLogs(simResult.logs, simResult.err, cluster);
 
@@ -159,4 +160,56 @@ function interpretSimulation(
         tokenBalanceData: tokenData,
         unitsConsumed: simResult.unitsConsumed,
     };
+}
+
+/**
+ * Bytes of account metadata the runtime charges for every account a transaction loads, on top of
+ * that account's data length. An account that does not exist on chain is not charged at all.
+ */
+const ACCOUNT_METADATA_SIZE = 64;
+
+/**
+ * Expands an RPC error string with the cause when the transaction version explains it.
+ *
+ * The runtime reports `MaxLoadedAccountsDataSizeExceeded` whenever a transaction loads more account
+ * data than its limit allows, and reports the size it loaded clamped to that limit — never the size
+ * it needed. v1 moved the resource limits into the message and made every one of them explicit: a
+ * limit the message leaves unset is zero, where legacy and v0 fell back to a generous default. So
+ * on a v1 message the limit is as likely to be missing or too small as the transaction is to be too
+ * large, and nothing in the error says so. Do the arithmetic the runtime did instead, from the
+ * accounts already fetched for the simulation.
+ */
+function explainSimulationError(
+    err: string,
+    message: VersionedMessage,
+    parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | undefined)[],
+): string {
+    if (err !== 'MaxLoadedAccountsDataSizeExceeded' || !(message instanceof V1MessageView)) {
+        return err;
+    }
+
+    const existingAccounts = parsedAccountsPre.filter(account => account !== undefined);
+    const dataSize = existingAccounts.reduce((total, account) => total + accountDataSize(account), 0);
+    const loadedSize = dataSize + existingAccounts.length * ACCOUNT_METADATA_SIZE;
+    const limit = message.transactionConfig?.loadedAccountsDataSizeLimit;
+
+    const size = `this transaction loads ${format(loadedSize)} bytes (${format(dataSize)} bytes of account data, plus ${ACCOUNT_METADATA_SIZE} bytes of metadata for each of the ${existingAccounts.length} accounts that exist on chain)`;
+    const cap =
+        limit === undefined
+            ? 'this v1 message sets no loaded accounts data size limit, which v1 reads as a limit of zero bytes'
+            : `above the ${format(limit)} byte limit set in the v1 message config`;
+
+    return `${err} — ${size}, ${cap}.`;
+}
+
+/**
+ * The on-chain size of an account as the runtime counts it. A parsed account reports its size
+ * directly; one the RPC could not parse arrives as its raw data.
+ */
+function accountDataSize(account: AccountInfo<ParsedAccountData | Buffer>): number {
+    return Buffer.isBuffer(account.data) ? account.data.length : account.data.space;
+}
+
+function format(value: number): string {
+    return value.toLocaleString('en-US');
 }

--- a/app/features/instruction-simulation/lib/simulate-transaction.ts
+++ b/app/features/instruction-simulation/lib/simulate-transaction.ts
@@ -2,15 +2,15 @@ import type {
     AccountInfo,
     Connection,
     ParsedAccountData,
-    PublicKey,
     SimulatedTransactionAccountInfo,
     TransactionError,
     VersionedMessage,
 } from '@solana/web3.js';
-import { VersionedTransaction } from '@solana/web3.js';
+import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import type { Cluster } from '@utils/cluster';
 import { type InstructionLogs, parseProgramLogs } from '@utils/program-logs';
 
+import { Logger } from '@/app/shared/lib/logger';
 import { UnsignedV1WireTransaction, V1MessageView } from '@/app/shared/lib/v1-message-bridge';
 
 import { buildTokenBalances, type TokenBalanceData } from './build-token-balances';
@@ -47,7 +47,14 @@ export async function simulateTransaction({
     accountBalances,
 }: SimulateOptions): Promise<SimulationResult> {
     const raw = await runSimulation(connection, message);
-    return interpretSimulation(raw, cluster, message, accountBalances);
+    const result = interpretSimulation(raw, cluster, accountBalances);
+
+    if (result.error === MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED && message instanceof V1MessageView) {
+        const explained = await explainLoadedAccountsDataSize(connection, message, raw.parsedAccountsPre);
+        return explained ? { ...result, error: explained } : result;
+    }
+
+    return result;
 }
 
 type RawSimulation = {
@@ -126,7 +133,6 @@ async function runSimulation(connection: Connection, message: VersionedMessage):
 function interpretSimulation(
     { accountKeys, epochInfo, parsedAccountsPre, simResult }: RawSimulation,
     cluster: Cluster,
-    message: VersionedMessage,
     accountBalances?: { preBalances: number[]; postBalances: number[] },
 ): SimulationResult {
     // Token balance data (raw — UI layer is responsible for generating display rows)
@@ -139,8 +145,8 @@ function interpretSimulation(
     let error: string | undefined;
 
     if (simResult.logs.length === 0 && typeof simResult.err === 'string') {
-        // No logs to parse — surface the RPC error string (e.g. "AccountNotFound")
-        error = explainSimulationError(simResult.err, message, parsedAccountsPre);
+        // No logs to parse — surface the raw RPC error string (e.g. "AccountNotFound")
+        error = simResult.err;
     } else {
         logs = parseProgramLogs(simResult.logs, simResult.err, cluster);
 
@@ -168,38 +174,86 @@ function interpretSimulation(
  */
 const ACCOUNT_METADATA_SIZE = 64;
 
+const MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED = 'MaxLoadedAccountsDataSizeExceeded';
+
+/** Owner of every upgradeable program account, whose executable code lives in a separate account. */
+const UPGRADEABLE_LOADER_ID = new PublicKey('BPFLoaderUpgradeab1e11111111111111111111111');
+
 /**
- * Expands an RPC error string with the cause when the transaction version explains it.
+ * Restates a loaded accounts data size failure as the arithmetic behind it, or `undefined` when
+ * that cannot be established.
  *
- * The runtime reports `MaxLoadedAccountsDataSizeExceeded` whenever a transaction loads more account
- * data than its limit allows, and reports the size it loaded clamped to that limit — never the size
- * it needed. v1 moved the resource limits into the message and made every one of them explicit: a
- * limit the message leaves unset is zero, where legacy and v0 fell back to a generous default. So
- * on a v1 message the limit is as likely to be missing or too small as the transaction is to be too
- * large, and nothing in the error says so. Do the arithmetic the runtime did instead, from the
- * accounts already fetched for the simulation.
+ * The runtime reports `MaxLoadedAccountsDataSizeExceeded` with the size it loaded clamped to the
+ * transaction's own limit — never the size it needed — so the response cannot say how far over the
+ * transaction was. v1 makes that worse: the limits live in the message and one left unset is zero,
+ * where legacy and v0 fell back to a generous default, so the limit is as likely to be missing or
+ * too small as the transaction is to be too large.
+ *
+ * The runtime charges each account it loads 64 bytes of metadata plus its data, and charges nothing
+ * for an account that does not exist. Calling an upgradeable program loads its program data account
+ * as well, which the message never lists, so those are fetched here to be counted.
  */
-function explainSimulationError(
-    err: string,
-    message: VersionedMessage,
+async function explainLoadedAccountsDataSize(
+    connection: Connection,
+    message: V1MessageView,
     parsedAccountsPre: (AccountInfo<ParsedAccountData | Buffer> | undefined)[],
-): string {
-    if (err !== 'MaxLoadedAccountsDataSizeExceeded' || !(message instanceof V1MessageView)) {
-        return err;
+): Promise<string | undefined> {
+    const messageAccounts = parsedAccountsPre.filter(account => account !== undefined);
+
+    let programDataAccounts;
+    try {
+        programDataAccounts = await fetchProgramDataAccounts(connection, messageAccounts);
+    } catch (cause) {
+        Logger.error(new Error('Failed to load program data accounts', { cause }));
+        return undefined;
     }
 
-    const existingAccounts = parsedAccountsPre.filter(account => account !== undefined);
-    const dataSize = existingAccounts.reduce((total, account) => total + accountDataSize(account), 0);
-    const loadedSize = dataSize + existingAccounts.length * ACCOUNT_METADATA_SIZE;
+    const loadedAccounts = [...messageAccounts, ...programDataAccounts];
+    const dataSize = loadedAccounts.reduce((total, account) => total + accountDataSize(account), 0);
+    const loadedSize = dataSize + loadedAccounts.length * ACCOUNT_METADATA_SIZE;
     const limit = message.transactionConfig?.loadedAccountsDataSizeLimit;
 
-    const size = `this transaction loads ${format(loadedSize)} bytes (${format(dataSize)} bytes of account data, plus ${ACCOUNT_METADATA_SIZE} bytes of metadata for each of the ${existingAccounts.length} accounts that exist on chain)`;
+    const accountCount = `${loadedAccounts.length} account${loadedAccounts.length === 1 ? '' : 's'}`;
+    const loads = `this transaction loads ${format(loadedSize)} bytes (${format(dataSize)} bytes of account data, plus ${ACCOUNT_METADATA_SIZE} bytes of metadata for each of the ${accountCount} it loads)`;
     const cap =
         limit === undefined
             ? 'this v1 message sets no loaded accounts data size limit, which v1 reads as a limit of zero bytes'
             : `above the ${format(limit)} byte limit set in the v1 message config`;
 
-    return `${err} — ${size}, ${cap}.`;
+    return `${MAX_LOADED_ACCOUNTS_DATA_SIZE_EXCEEDED} — ${loads}, ${cap}.`;
+}
+
+/** The program data accounts behind whichever of `accounts` are upgradeable programs. */
+async function fetchProgramDataAccounts(
+    connection: Connection,
+    accounts: AccountInfo<ParsedAccountData | Buffer>[],
+): Promise<AccountInfo<ParsedAccountData | Buffer>[]> {
+    const addresses = accounts
+        .filter(account => account.owner.equals(UPGRADEABLE_LOADER_ID))
+        .map(programDataAddress)
+        .filter(address => address !== undefined);
+
+    if (addresses.length === 0) {
+        return [];
+    }
+
+    const { value } = await connection.getMultipleParsedAccounts(addresses);
+    return value.filter(account => account !== null);
+}
+
+/**
+ * The program data account an upgradeable program account points at.
+ *
+ * The account holds a 4-byte state discriminant followed by that address, which the RPC surfaces
+ * directly when it parses the account and leaves in the raw bytes when it does not.
+ */
+function programDataAddress(account: AccountInfo<ParsedAccountData | Buffer>): PublicKey | undefined {
+    if (Buffer.isBuffer(account.data)) {
+        return account.data.length >= 36 ? new PublicKey(account.data.subarray(4, 36)) : undefined;
+    }
+
+    const programData = (account.data.parsed as { info?: { programData?: string } })?.info?.programData;
+    return programData === undefined ? undefined : new PublicKey(programData);
 }
 
 /**

--- a/app/features/instruction-simulation/lib/tx-v1-feature.ts
+++ b/app/features/instruction-simulation/lib/tx-v1-feature.ts
@@ -1,0 +1,24 @@
+import { getOptionDecoder, getU64Decoder, isSome } from '@solana/kit';
+import { type Connection, PublicKey } from '@solana/web3.js';
+
+/** The feature gate that activates transaction v1 on a cluster. */
+export const ENABLE_TX_V1_FEATURE = new PublicKey('txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL');
+
+/**
+ * A feature account holds a bincode-serialized `solana_feature_gate_interface::Feature`,
+ * which is a single `Option<u64>`: a one-byte tag followed by the activation slot.
+ */
+const featureAccountDecoder = getOptionDecoder(getU64Decoder());
+
+/**
+ * Reports whether transaction v1 is live on the cluster behind `connection`.
+ *
+ * The feature account exists only once the gate has been staged, and its activation slot is
+ * filled in only once the gate goes live. Both an absent account and a staged-but-inactive one
+ * mean the cluster rejects v1 transactions, so both answer `false`. Local validators activate
+ * every feature at genesis, so this is `true` from slot 0 there.
+ */
+export async function isTxV1Active(connection: Connection): Promise<boolean> {
+    const account = await connection.getAccountInfo(ENABLE_TX_V1_FEATURE);
+    return account !== null && isSome(featureAccountDecoder.decode(account.data));
+}

--- a/app/shared/lib/v1-message-bridge.ts
+++ b/app/shared/lib/v1-message-bridge.ts
@@ -46,13 +46,23 @@ export function isV1MessageBytes(bytes: Uint8Array): boolean {
  *
  * The inherited `version` getter still reports `0`; carry the true version alongside this
  * object rather than reading it off the message.
+ *
+ * `transactionConfig` carries the message-level resource limits, which `MessageV0` has nowhere to
+ * put. It is absent when the message sets no limits at all — in v1 that means every limit is zero,
+ * not that a default applies.
  */
 export class V1MessageView extends MessageV0 {
     private readonly rawV1Bytes: Uint8Array;
+    readonly transactionConfig?: V1TransactionConfig;
 
-    constructor(args: ConstructorParameters<typeof MessageV0>[0], rawV1Bytes: Uint8Array) {
+    constructor(
+        args: ConstructorParameters<typeof MessageV0>[0],
+        rawV1Bytes: Uint8Array,
+        transactionConfig?: V1TransactionConfig,
+    ) {
         super(args);
         this.rawV1Bytes = rawV1Bytes;
+        this.transactionConfig = transactionConfig;
     }
 
     override serialize(): Uint8Array {
@@ -85,6 +95,7 @@ export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
         throw new Error('v1 transaction message bytes are not a canonical compiled message');
     }
 
+    const transactionConfig = readV1TransactionConfig(compiled);
     const message = new V1MessageView(
         {
             addressTableLookups: [],
@@ -102,9 +113,10 @@ export function bridgeV1MessageBytes(messageBytes: Uint8Array): {
             staticAccountKeys: compiled.staticAccounts.map(address => new PublicKey(address)),
         },
         messageBytes,
+        transactionConfig,
     );
 
-    return { message, transactionConfig: readV1TransactionConfig(compiled) };
+    return { message, transactionConfig };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Simulating a v1 transaction on a cluster whose runtime predates the feature gate returned a bare `UnsupportedVersion`; it now names the gate, so a cluster limitation no longer reads as a broken transaction. Example Message:

> _...this cluster does not support v1 transactions yet — feature gate ${ENABLE_TX_V1_FEATURE.toBase58()} is not active_


- `MaxLoadedAccountsDataSizeExceeded` now reports the size the runtime actually metered against the limit the message carries, because the RPC clamps the size it reports to that same limit and can never say how far over the transaction was. Example message:

> _Simulation Failure:MaxLoadedAccountsDataSizeExceeded — this transaction loads 75,077 bytes (74,821 bytes of account data, plus 64 bytes of metadata for each of the 4 accounts that exist on chain), above the 75,013 byte limit set in the v1 message config._


- An unset v1 loaded accounts data size limit is reported as the zero it is, rather than as a generous default that no longer exists.
- Follow-up to #1204; no behavior change for legacy or v0 messages, which make no extra RPC call.

## Test Plan
- Verified against a local agave 4.2.1 validator: a memo transaction loads 74,928 bytes (64 bytes of metadata per existing account plus its data, nothing for an account that does not exist), and the same transaction fails at a 75,013 byte limit once the account it created exists.
- The feature gate is not active on any public cluster, so `UnsupportedVersion` reproduces against mainnet today.

Closes DEV-920
